### PR TITLE
pickling the index

### DIFF
--- a/python/healpix_geo/tests/test_index.py
+++ b/python/healpix_geo/tests/test_index.py
@@ -113,10 +113,15 @@ class TestRangeMOCIndex:
 
         np.testing.assert_equal(actual.cell_ids(), expected)
 
-    def test_pickle_roundtrip(self):
-        level = 2
-        cell_ids = np.arange(12 * 4**level, dtype="uint64")
-        index = healpix_geo.nested.RangeMOCIndex.from_cell_ids(level, cell_ids)
+    @pytest.mark.parametrize(
+        ["depth", "cell_ids"],
+        (
+            (2, np.arange(1 * 4**2, 3 * 4**2, dtype="uint64")),
+            (5, np.arange(12 * 4**5, dtype="uint64")),
+        ),
+    )
+    def test_pickle_roundtrip(self, depth, cell_ids):
+        index = healpix_geo.nested.RangeMOCIndex.from_cell_ids(depth, cell_ids)
 
         pickled = pickle.dumps(index)
         assert isinstance(pickled, bytes)

--- a/python/healpix_geo/tests/test_index.py
+++ b/python/healpix_geo/tests/test_index.py
@@ -1,3 +1,5 @@
+import pickle
+
 import numpy as np
 import pytest
 
@@ -80,7 +82,7 @@ class TestRangeMOCIndex:
 
         actual = index1.intersection(index2)
 
-        isinstance(actual, healpix_geo.nested.RangeMOCIndex)
+        assert isinstance(actual, healpix_geo.nested.RangeMOCIndex)
         np.testing.assert_equal(actual.cell_ids(), expected)
 
     @pytest.mark.parametrize(
@@ -110,3 +112,14 @@ class TestRangeMOCIndex:
         actual = index.isel(indexer)
 
         np.testing.assert_equal(actual.cell_ids(), expected)
+
+    def test_pickle_roundtrip(self):
+        level = 2
+        cell_ids = np.arange(12 * 4**level, dtype="uint64")
+        index = healpix_geo.nested.RangeMOCIndex.from_cell_ids(level, cell_ids)
+
+        pickled = pickle.dumps(index)
+        unpickled = pickle.loads(pickled)
+
+        assert isinstance(unpickled, healpix_geo.nested.RangeMOCIndex)
+        np.testing.assert_equal(unpickled.cell_ids(), index.cell_ids())

--- a/python/healpix_geo/tests/test_index.py
+++ b/python/healpix_geo/tests/test_index.py
@@ -119,7 +119,9 @@ class TestRangeMOCIndex:
         index = healpix_geo.nested.RangeMOCIndex.from_cell_ids(level, cell_ids)
 
         pickled = pickle.dumps(index)
+        assert isinstance(pickled, bytes)
         unpickled = pickle.loads(pickled)
 
         assert isinstance(unpickled, healpix_geo.nested.RangeMOCIndex)
+        assert index.depth == unpickled.depth
         np.testing.assert_equal(unpickled.cell_ids(), index.cell_ids())

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,11 +1,16 @@
 use ndarray::Array1;
 use numpy::{PyArray1, PyArrayDyn, PyArrayMethods};
-use pyo3::exceptions::{PyNotImplementedError, PyValueError};
+use pyo3::exceptions::{PyNotImplementedError, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
-use pyo3::types::{PySlice, PyTuple, PyType};
+use pyo3::types::{PyBytes, PySlice, PyTuple, PyType};
 
+use moc::deser::json::from_json_aladin;
 use moc::elemset::range::MocRanges;
+use moc::moc::cell::CellMOC;
 use moc::moc::range::RangeMOC;
+use moc::moc::{
+    CellMOCIntoIterator, CellMOCIterator, HasMaxDepth, RangeMOCIntoIterator, RangeMOCIterator,
+};
 use moc::qty::Hpx;
 use std::cmp::PartialEq;
 use std::ops::Range;
@@ -166,6 +171,15 @@ impl RangeMOCIndex {
     }
 
     #[classmethod]
+    fn create_empty(_cls: &Bound<'_, PyType>, depth: u8) -> PyResult<Self> {
+        let index = RangeMOCIndex {
+            moc: RangeMOC::new_empty(depth),
+        };
+
+        Ok(index)
+    }
+
+    #[classmethod]
     fn from_cell_ids<'a>(
         _cls: &Bound<'a, PyType>,
         _py: Python,
@@ -205,6 +219,58 @@ impl RangeMOCIndex {
     #[getter]
     fn depth(&self) -> u8 {
         self.moc.depth_max()
+    }
+
+    pub fn __setstate__(&mut self, state: &[u8]) -> PyResult<()> {
+        // Deserialize the data contained in the PyBytes object
+        // and update the struct with the deserialized values.
+        // serde+bincode version:
+        // *self = deserialize(state).map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
+
+        let cell_moc: CellMOC<u64, Hpx<u64>> = from_json_aladin(
+            std::str::from_utf8(state).map_err(|err| PyRuntimeError::new_err(err.to_string()))?,
+        )
+        .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
+        let reconstructed = RangeMOC::from_cells(
+            cell_moc.depth_max(),
+            cell_moc
+                .into_cell_moc_iter()
+                .map(|c| -> (u8, u64) { (c.depth, c.idx) }),
+            None,
+        );
+        *self = RangeMOCIndex { moc: reconstructed };
+
+        Ok(())
+    }
+
+    pub fn __getstate__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
+        // Serialize the struct and return a PyBytes object
+        // containing the serialized data.
+        let mut serialized: Vec<u8> = Default::default();
+        self.moc
+            .clone()
+            .into_range_moc_iter()
+            .cells()
+            .to_json_aladin(None, &mut serialized)
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        // let serialized = serialize(&self).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        let bytes = PyBytes::new(py, &serialized);
+        Ok(bytes)
+    }
+
+    pub fn __reduce__(&self, py: Python) -> PyResult<(PyObject, PyObject, PyObject)> {
+        let create = py
+            .import("healpix_geo")?
+            .getattr("RangeMOCIndex")?
+            .getattr("create_empty")?;
+        let args = ();
+        let state = self.__getstate__(py)?;
+
+        Ok((
+            create.into_pyobject(py)?.unbind().into_any(),
+            args.into_pyobject(py)?.unbind().into_any(),
+            state.into_pyobject(py)?.unbind().into_any(),
+        ))
     }
 
     fn cell_ids<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyArray1<u64>>> {

--- a/src/index.rs
+++ b/src/index.rs
@@ -265,7 +265,7 @@ impl RangeMOCIndex {
             .getattr("nested")?
             .getattr("RangeMOCIndex")?
             .getattr("create_empty")?;
-        let args = ();
+        let args = (self.moc.depth_max(),);
         let state = self.__getstate__(py)?;
 
         Ok((

--- a/src/index.rs
+++ b/src/index.rs
@@ -155,6 +155,7 @@ impl Subset for RangeMOC<u64, Hpx<u64>> {
 /// Only works with cell ids following the "nested" scheme.
 #[derive(PartialEq, Debug, Clone)]
 #[pyclass]
+#[pyo3(module = "healpix_geo.nested")]
 pub struct RangeMOCIndex {
     moc: RangeMOC<u64, Hpx<u64>>,
 }
@@ -261,6 +262,7 @@ impl RangeMOCIndex {
     pub fn __reduce__(&self, py: Python) -> PyResult<(PyObject, PyObject, PyObject)> {
         let create = py
             .import("healpix_geo")?
+            .getattr("nested")?
             .getattr("RangeMOCIndex")?
             .getattr("create_empty")?;
         let args = ();


### PR DESCRIPTION
To transfer index objects between workers we need to be able to pickle them. This implements the pickling protocols (`__getstate__`, `__setstate__`, and `__reduce__`) based on the Aladin JSON format supported by the `moc` crate.

Should the serialization to JSON become a problem, we can revisit cds-astro/cds-moc-rust#12.