### PR TITLE
allow subsampling vertex edges

### DIFF
--- a/python/healpix-geo/docs/api-hidden.rst
+++ b/python/healpix-geo/docs/api-hidden.rst
@@ -45,3 +45,7 @@
 
    healpix_geo.slices.MultiConcreteSlice.size
    healpix_geo.slices.MultiConcreteSlice.slices
+
+   healpix_geo.auto.Grid.level
+   healpix_geo.auto.Grid.indexing_scheme
+   healpix_geo.auto.Grid.ellipsoid

--- a/python/healpix-geo/python/healpix_geo/auto.py
+++ b/python/healpix-geo/python/healpix_geo/auto.py
@@ -160,16 +160,19 @@ def vertices(
     Examples
     --------
     Imports
+
     >>> import healpix_geo.auto as hg
     >>> import numpy as np
 
     Set up the grid and cell ids
+
     >>> ipix = np.array([42, 6, 10])
     >>> grid = hg.Grid(level=12, indexing_scheme="nested", ellipsoid="sphere")
     >>> grid
     Grid(level=12, indexing_scheme='nested', ellipsoid='sphere')
 
     Compute just the vertices:
+
     >>> lon, lat = hg.vertices(ipix, grid)
     >>> np.stack([lon, lat], axis=-1)
     array([[[4.49230957e+01, 6.52784088e-02],
@@ -188,6 +191,7 @@ def vertices(
             [4.49560547e+01, 3.73019424e-02]]])
 
     Subsample the edges to have 3 additional points per edge:
+
     >>> lon, lat = hg.vertices(ipix, grid, step=4)
     >>> np.stack([lon, lat], axis=-1)
     array([[[4.49230957e+01, 6.52784088e-02],

--- a/python/healpix-geo/python/healpix_geo/auto.py
+++ b/python/healpix-geo/python/healpix_geo/auto.py
@@ -129,7 +129,7 @@ def lonlat_to_healpix(
 
 
 def vertices(
-    ipix: npt.NDArray[np.uint64], grid: Grid, *, num_threads: int = 0
+    ipix: npt.NDArray[np.uint64], grid: Grid, *, step: int = 1, num_threads: int = 0
 ) -> (npt.NDArray[np.float64], npt.NDArray[np.float64]):
     """Get the longitudes and latitudes of the vertices of some HEALPix cells.
 
@@ -141,6 +141,11 @@ def vertices(
         The HEALPix cell indexes given as a `np.uint64` numpy array.
     grid : Grid
         The definition of the HEALPix grid.
+    step : int, default: 1
+        The number of vertices returned per HEALPix side. By default it is set to 1 meaning that
+        it will only return the vertices of the cell. 2 means that it will return the vertices of
+        the cell plus one more vertex per edge (the center of the edge). More generally, the number
+        of vertices returned is ``4 * step``.
     num_threads : int, optional
         Specifies the number of threads to use for the computation. Default to 0 means
         it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
@@ -154,12 +159,17 @@ def vertices(
 
     Examples
     --------
+    Imports
     >>> import healpix_geo.auto as hg
     >>> import numpy as np
+
+    Set up the grid and cell ids
     >>> ipix = np.array([42, 6, 10])
     >>> grid = hg.Grid(level=12, indexing_scheme="nested", ellipsoid="sphere")
     >>> grid
     Grid(level=12, indexing_scheme='nested', ellipsoid='sphere')
+
+    Compute just the vertices:
     >>> lon, lat = hg.vertices(ipix, grid)
     >>> np.stack([lon, lat], axis=-1)
     array([[[4.49230957e+01, 6.52784088e-02],
@@ -176,11 +186,65 @@ def vertices(
             [4.49780273e+01, 3.73019424e-02],
             [4.49670410e+01, 4.66274299e-02],
             [4.49560547e+01, 3.73019424e-02]]])
+
+    Subsample the edges to have 3 additional points per edge:
+    >>> lon, lat = hg.vertices(ipix, grid, step=4)
+    >>> np.stack([lon, lat], axis=-1)
+    array([[[4.49230957e+01, 6.52784088e-02],
+            [4.49258423e+01, 6.76097816e-02],
+            [4.49285889e+01, 6.99411545e-02],
+            [4.49313354e+01, 7.22725275e-02],
+            [4.49340820e+01, 7.46039007e-02],
+            [4.49313354e+01, 7.69352739e-02],
+            [4.49285889e+01, 7.92666473e-02],
+            [4.49258423e+01, 8.15980209e-02],
+            [4.49230957e+01, 8.39293945e-02],
+            [4.49203491e+01, 8.15980209e-02],
+            [4.49176025e+01, 7.92666473e-02],
+            [4.49148560e+01, 7.69352739e-02],
+            [4.49121094e+01, 7.46039007e-02],
+            [4.49148560e+01, 7.22725275e-02],
+            [4.49176025e+01, 6.99411545e-02],
+            [4.49203491e+01, 6.76097816e-02]],
+    <BLANKLINE>
+           [[4.50109863e+01, 2.79764560e-02],
+            [4.50137329e+01, 3.03078275e-02],
+            [4.50164795e+01, 3.26391991e-02],
+            [4.50192261e+01, 3.49705707e-02],
+            [4.50219727e+01, 3.73019424e-02],
+            [4.50192261e+01, 3.96333142e-02],
+            [4.50164795e+01, 4.19646860e-02],
+            [4.50137329e+01, 4.42960579e-02],
+            [4.50109863e+01, 4.66274299e-02],
+            [4.50082397e+01, 4.42960579e-02],
+            [4.50054932e+01, 4.19646860e-02],
+            [4.50027466e+01, 3.96333142e-02],
+            [4.50000000e+01, 3.73019424e-02],
+            [4.50027466e+01, 3.49705707e-02],
+            [4.50054932e+01, 3.26391991e-02],
+            [4.50082397e+01, 3.03078275e-02]],
+    <BLANKLINE>
+           [[4.49670410e+01, 2.79764560e-02],
+            [4.49697876e+01, 3.03078275e-02],
+            [4.49725342e+01, 3.26391991e-02],
+            [4.49752808e+01, 3.49705707e-02],
+            [4.49780273e+01, 3.73019424e-02],
+            [4.49752808e+01, 3.96333142e-02],
+            [4.49725342e+01, 4.19646860e-02],
+            [4.49697876e+01, 4.42960579e-02],
+            [4.49670410e+01, 4.66274299e-02],
+            [4.49642944e+01, 4.42960579e-02],
+            [4.49615479e+01, 4.19646860e-02],
+            [4.49588013e+01, 3.96333142e-02],
+            [4.49560547e+01, 3.73019424e-02],
+            [4.49588013e+01, 3.49705707e-02],
+            [4.49615479e+01, 3.26391991e-02],
+            [4.49642944e+01, 3.03078275e-02]]])
     """
     module = _dispatch_module(grid.indexing_scheme)
     params = grid._as_params()
 
-    return module.vertices(ipix, num_threads=num_threads, **params)
+    return module.vertices(ipix, num_threads=num_threads, step=step, **params)
 
 
 def kth_neighbourhood(

--- a/python/healpix-geo/python/healpix_geo/nested.py
+++ b/python/healpix-geo/python/healpix_geo/nested.py
@@ -121,7 +121,7 @@ def lonlat_to_healpix(longitude, latitude, depth, ellipsoid="sphere", num_thread
     )
 
 
-def vertices(ipix, depth, ellipsoid, num_threads=0):
+def vertices(ipix, depth, ellipsoid, step=1, num_threads=0):
     """Get the longitudes and latitudes of the vertices of some HEALPix cells at a given depth.
 
     This method returns the 4 vertices of each cell in `ipix`.
@@ -136,6 +136,11 @@ def vertices(ipix, depth, ellipsoid, num_threads=0):
         Reference ellipsoid to evaluate healpix on. If the reference ellipsoid
         is spherical, this will return the same result as
         :py:func:`cdshealpix.nested.vertices`.
+    step : int, default: 1
+        The number of vertices returned per HEALPix side. By default it is set to 1 meaning that
+        it will only return the vertices of the cell. 2 means that it will return the vertices of
+        the cell plus one more vertex per edge (the center of the edge). More generally, the number
+        of vertices returned is ``4 * step``.
     num_threads : int, optional
         Specifies the number of threads to use for the computation. Default to 0 means
         it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
@@ -182,7 +187,7 @@ def vertices(ipix, depth, ellipsoid, num_threads=0):
 
     num_threads = np.uint16(num_threads)
 
-    return healpix_geo.nested.vertices(depth, ipix, ellipsoid, num_threads)
+    return healpix_geo.nested.vertices(depth, ipix, ellipsoid, step, num_threads)
 
 
 def kth_neighbourhood(ipix, depth, ring, num_threads=0):

--- a/python/healpix-geo/python/healpix_geo/ring.py
+++ b/python/healpix-geo/python/healpix_geo/ring.py
@@ -108,7 +108,7 @@ def lonlat_to_healpix(longitude, latitude, depth, ellipsoid="sphere", num_thread
     )
 
 
-def vertices(ipix, depth, ellipsoid, num_threads=0):
+def vertices(ipix, depth, ellipsoid, step=1, num_threads=0):
     """Get the longitudes and latitudes of the vertices of some HEALPix cells at a given depth.
 
     This method returns the 4 vertices of each cell in `ipix`.
@@ -122,6 +122,11 @@ def vertices(ipix, depth, ellipsoid, num_threads=0):
     ellipsoid : str, default: "sphere"
         Reference ellipsoid to evaluate healpix on. If ``"sphere"``, this will return
         the same result as :py:func:`cdshealpix.ring.vertices`.
+    step : int, default: 1
+        The number of vertices returned per HEALPix side. By default it is set to 1 meaning that
+        it will only return the vertices of the cell. 2 means that it will return the vertices of
+        the cell plus one more vertex per edge (the center of the edge). More generally, the number
+        of vertices returned is ``4 * step``.
     num_threads : int, optional
         Specifies the number of threads to use for the computation. Default to 0 means
         it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
@@ -168,7 +173,7 @@ def vertices(ipix, depth, ellipsoid, num_threads=0):
 
     num_threads = np.uint16(num_threads)
 
-    return healpix_geo.ring.vertices(depth, ipix, ellipsoid, num_threads)
+    return healpix_geo.ring.vertices(depth, ipix, ellipsoid, step, num_threads)
 
 
 def kth_neighbourhood(ipix, depth, ring, num_threads=0):

--- a/python/healpix-geo/python/healpix_geo/tests/test_auto.py
+++ b/python/healpix-geo/python/healpix_geo/tests/test_auto.py
@@ -91,11 +91,12 @@ def test_healpix_to_lonlat(grid, cell_ids, expected_lon, expected_lat):
 
 
 @pytest.mark.parametrize(
-    ["grid", "cell_ids", "expected_lon", "expected_lat"],
+    ["grid", "cell_ids", "step", "expected_lon", "expected_lat"],
     (
         (
             auto.Grid(level=2, indexing_scheme="nested", ellipsoid="WGS84"),
             np.array([3, 54], dtype="uint64"),
+            1,
             np.array([[45.0, 56.25, 45.0, 33.75], [326.25, 337.5, 330.0, 315.0]]),
             np.array(
                 [
@@ -107,19 +108,74 @@ def test_healpix_to_lonlat(grid, cell_ids, expected_lon, expected_lat):
         (
             auto.Grid(level=3, indexing_scheme="ring", ellipsoid="WGS84"),
             np.array([19, 67, 94], dtype="uint64"),
+            2,
             np.array(
                 [
-                    [225.0, 240.0, 225.0, 210.0],
-                    [115.71428571, 120.0, 108.0, 105.0],
-                    [135.0, 141.42857143, 135.0, 128.57142857],
+                    [
+                        225.0,
+                        231.42857143,
+                        240.0,
+                        234.0,
+                        225.0,
+                        216.0,
+                        210.0,
+                        218.57142857,
+                    ],
+                    [
+                        115.71428571,
+                        117.69230769,
+                        120.0,
+                        114.54545455,
+                        108.0,
+                        106.36363636,
+                        105.0,
+                        110.76923077,
+                    ],
+                    [
+                        135.0,
+                        138.0,
+                        141.42857143,
+                        138.46153846,
+                        135.0,
+                        131.53846154,
+                        128.57142857,
+                        132.0,
+                    ],
                 ],
                 dtype="float64",
             ),
             np.array(
                 [
-                    [66.53737405, 72.46140572, 78.33504545, 72.46140572],
-                    [48.26869833, 54.46234938, 60.54441647, 54.46234938],
-                    [41.93785391, 48.26869833, 54.46234938, 48.26869833],
+                    [
+                        66.53737405,
+                        69.50681506,
+                        72.46140572,
+                        75.40341607,
+                        78.33504545,
+                        75.40341607,
+                        72.46140572,
+                        69.50681506,
+                    ],
+                    [
+                        48.26869833,
+                        51.38098728,
+                        54.46234938,
+                        57.51586389,
+                        60.54441647,
+                        57.51586389,
+                        54.46234938,
+                        51.38098728,
+                    ],
+                    [
+                        41.93785391,
+                        45.12217715,
+                        48.26869833,
+                        51.38098728,
+                        54.46234938,
+                        51.38098728,
+                        48.26869833,
+                        45.12217715,
+                    ],
                 ],
                 dtype="float64",
             ),
@@ -130,6 +186,7 @@ def test_healpix_to_lonlat(grid, cell_ids, expected_lon, expected_lat):
                 [1963569437533536256, 824158731808800768, 5116089176692883456],
                 dtype="uint64",
             ),
+            1,
             np.array(
                 [
                     [326.25, 337.5, 330.0, 315.0],
@@ -150,8 +207,8 @@ def test_healpix_to_lonlat(grid, cell_ids, expected_lon, expected_lat):
     ),
     ids=["nested", "ring", "zuniq"],
 )
-def test_vertices(grid, cell_ids, expected_lon, expected_lat):
-    actual_lon, actual_lat = auto.vertices(cell_ids, grid)
+def test_vertices(grid, cell_ids, step, expected_lon, expected_lat):
+    actual_lon, actual_lat = auto.vertices(cell_ids, grid, step=step)
 
     np.testing.assert_allclose(actual_lon, expected_lon)
     np.testing.assert_allclose(actual_lat, expected_lat)

--- a/python/healpix-geo/python/healpix_geo/tests/test_inference.py
+++ b/python/healpix-geo/python/healpix_geo/tests/test_inference.py
@@ -437,6 +437,7 @@ class TestGeographicToHealpix:
 
 
 class TestVertices:
+    @pytest.mark.parametrize("step", [1, 3])
     @pytest.mark.parametrize(
         ["cell_ids", "depth", "indexing_scheme"],
         (
@@ -480,20 +481,22 @@ class TestVertices:
             ),
         ),
     )
-    def test_spherical(self, cell_ids, depth, indexing_scheme):
+    def test_spherical(self, cell_ids, depth, indexing_scheme, step):
         if indexing_scheme == "ring":
             param_cds = 2**depth
             hg_vertices = healpix_geo.ring.vertices
             cds_vertices = cdshealpix.ring.vertices
         elif indexing_scheme == "zuniq":
 
-            def cds_vertices(cell_ids, depth):
+            def cds_vertices(cell_ids, depth, step):
                 cell_ids, depths = healpix_geo.zuniq.to_nested(cell_ids)
 
-                return cdshealpix.nested.vertices(cell_ids, depths)
+                return cdshealpix.nested.vertices(cell_ids, depths, step=step)
 
-            def hg_vertices(cell_ids, depth, ellipsoid):
-                return healpix_geo.zuniq.vertices(cell_ids, ellipsoid=ellipsoid)
+            def hg_vertices(cell_ids, depth, ellipsoid, step):
+                return healpix_geo.zuniq.vertices(
+                    cell_ids, ellipsoid=ellipsoid, step=step
+                )
 
             param_cds = depth
         else:
@@ -501,8 +504,10 @@ class TestVertices:
             hg_vertices = healpix_geo.nested.vertices
             cds_vertices = cdshealpix.nested.vertices
 
-        actual_lon, actual_lat = hg_vertices(cell_ids, depth, ellipsoid="sphere")
-        expected_lon_, expected_lat_ = cds_vertices(cell_ids, param_cds)
+        actual_lon, actual_lat = hg_vertices(
+            cell_ids, depth, ellipsoid="sphere", step=step
+        )
+        expected_lon_, expected_lat_ = cds_vertices(cell_ids, param_cds, step=step)
         expected_lon = np.asarray(expected_lon_.to("degree"))
         expected_lat = np.asarray(expected_lat_.to("degree"))
 

--- a/python/healpix-geo/python/healpix_geo/zuniq.py
+++ b/python/healpix-geo/python/healpix_geo/zuniq.py
@@ -192,7 +192,7 @@ def lonlat_to_healpix(longitude, latitude, depth, ellipsoid="sphere", num_thread
     )
 
 
-def vertices(ipix, ellipsoid, num_threads=0):
+def vertices(ipix, ellipsoid, step=1, num_threads=0):
     """Get the longitudes and latitudes of the vertices of some HEALPix cells in zuniq encoding.
 
     This method returns the 4 vertices of each cell in `ipix`.
@@ -205,6 +205,11 @@ def vertices(ipix, ellipsoid, num_threads=0):
         Reference ellipsoid to evaluate healpix on. If the reference ellipsoid
         is spherical, this will return the same result as
         :py:func:`cdshealpix.nested.vertices`.
+    step : int, default: 1
+        The number of vertices returned per HEALPix side. By default it is set to 1 meaning that
+        it will only return the vertices of the cell. 2 means that it will return the vertices of
+        the cell plus one more vertex per edge (the center of the edge). More generally, the number
+        of vertices returned is ``4 * step``.
     num_threads : int, optional
         Specifies the number of threads to use for the computation. Default to 0 means
         it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
@@ -248,7 +253,7 @@ def vertices(ipix, ellipsoid, num_threads=0):
 
     num_threads = np.uint16(num_threads)
 
-    return healpix_geo.zuniq.vertices(ipix, ellipsoid, num_threads)
+    return healpix_geo.zuniq.vertices(ipix, ellipsoid, step, num_threads)
 
 
 def kth_neighbourhood(ipix, ring, num_threads=0):

--- a/python/healpix-geo/src/index.rs
+++ b/python/healpix-geo/src/index.rs
@@ -662,7 +662,7 @@ impl RangeMOCIndex {
     ///
     /// Parameters
     /// ----------
-    /// geometry : healpix_geo.Bbox or shapely.Geometry
+    /// geometry : healpix_geo.geometry.Bbox or shapely.Geometry
     ///     The geometry to query by. Supported are:
     ///     - Bbox for true bounding box queries (planar geometry)
     ///     - shapely objects for spherical geometry queries

--- a/python/healpix-geo/src/index.rs
+++ b/python/healpix-geo/src/index.rs
@@ -549,15 +549,15 @@ impl RangeMOCIndex {
     ///
     /// Parameters
     /// ----------
-    /// indexer : slice of int or array-like of numpy.uint64
-    ///     The cell ids or ranges of cell ids to find.
+    /// indexer : slice of int or array-like
+    ///     The cell ids or ranges of cell ids to find. If an array, must be of dtype uint64.
     ///
     /// Returns
     /// -------
     /// subset : RangeMOCIndex
     ///     The resulting subset.
-    /// indexer : slice of int or array-like of numpy.uint64
-    ///     The integer positions of the selected cells.
+    /// indexer : slice of int or array-like
+    ///     The integer positions of the selected cells as a uint64 array.
     fn sel<'a>(&self, py: Python<'a>, indexer: IndexKind<'a>) -> PyResult<(IndexKind<'a>, Self)> {
         let depth = self.moc.depth_max();
         let range_sizes = self.moc.range_sizes();

--- a/python/healpix-geo/src/indexing_schemes/nested/coordinates.rs
+++ b/python/healpix-geo/src/indexing_schemes/nested/coordinates.rs
@@ -63,11 +63,13 @@ pub(crate) fn lonlat_to_healpix<'py>(
 
 #[allow(clippy::type_complexity)]
 #[pyfunction]
+#[pyo3(signature = (depth, ipix, ellipsoid_like, step=1, nthreads=0))]
 pub(crate) fn vertices<'py>(
     py: Python<'py>,
     depth: u8,
     ipix: &Bound<'py, PyArrayDyn<u64>>,
     ellipsoid_like: EllipsoidLike,
+    step: usize,
     nthreads: u16,
 ) -> PyResult<(Bound<'py, PyArrayDyn<f64>>, Bound<'py, PyArrayDyn<f64>>)> {
     let ellipsoid = ellipsoid_like.into_ellipsoid()?;
@@ -77,8 +79,13 @@ pub(crate) fn vertices<'py>(
 
     let layer = healpix::nested::get(depth);
 
-    let vertices: Vec<Vec<(f64, f64)>> =
-        vectorized::vertices(ipix_.as_slice()?, layer, &ellipsoid, nthreads as usize);
+    let vertices: Vec<Vec<(f64, f64)>> = vectorized::vertices(
+        ipix_.as_slice()?,
+        layer,
+        &ellipsoid,
+        step,
+        nthreads as usize,
+    );
 
     let (lon, lat): (Vec<Vec<f64>>, Vec<Vec<f64>>) = vertices
         .into_iter()

--- a/python/healpix-geo/src/indexing_schemes/ring/coordinates.rs
+++ b/python/healpix-geo/src/indexing_schemes/ring/coordinates.rs
@@ -62,11 +62,13 @@ pub(crate) fn lonlat_to_healpix<'py>(
 
 #[allow(clippy::type_complexity)]
 #[pyfunction]
+#[pyo3(signature = (depth, ipix, ellipsoid_like, step=1, nthreads=0))]
 pub(crate) fn vertices<'py>(
     py: Python<'py>,
     depth: u8,
     ipix: &Bound<'py, PyArrayDyn<u64>>,
     ellipsoid_like: EllipsoidLike,
+    step: usize,
     nthreads: u16,
 ) -> PyResult<(Bound<'py, PyArrayDyn<f64>>, Bound<'py, PyArrayDyn<f64>>)> {
     let ellipsoid = ellipsoid_like.into_ellipsoid()?;
@@ -75,8 +77,13 @@ pub(crate) fn vertices<'py>(
 
     let nside = healpix::nside(depth);
 
-    let vertices: Vec<Vec<(f64, f64)>> =
-        vectorized::vertices(ipix_.as_slice()?, &nside, &ellipsoid, nthreads as usize);
+    let vertices: Vec<Vec<(f64, f64)>> = vectorized::vertices(
+        ipix_.as_slice()?,
+        &nside,
+        &ellipsoid,
+        step,
+        nthreads as usize,
+    );
 
     let (lon, lat): (Vec<Vec<f64>>, Vec<Vec<f64>>) = vertices
         .into_iter()

--- a/python/healpix-geo/src/indexing_schemes/zuniq/coordinates.rs
+++ b/python/healpix-geo/src/indexing_schemes/zuniq/coordinates.rs
@@ -94,10 +94,12 @@ pub(crate) fn lonlat_to_healpix<'py>(
 
 #[allow(clippy::type_complexity)]
 #[pyfunction]
+#[pyo3(signature = (ipix, ellipsoid_like, step=1, nthreads=0))]
 pub(crate) fn vertices<'py>(
     py: Python<'py>,
     ipix: &Bound<'py, PyArrayDyn<u64>>,
     ellipsoid_like: EllipsoidLike,
+    step: usize,
     nthreads: u16,
 ) -> PyResult<(Bound<'py, PyArrayDyn<f64>>, Bound<'py, PyArrayDyn<f64>>)> {
     let ellipsoid = ellipsoid_like.into_ellipsoid()?;
@@ -106,7 +108,7 @@ pub(crate) fn vertices<'py>(
     let ipix_ = ipix.readonly();
 
     let vertices: Vec<Vec<(f64, f64)>> =
-        vectorized::vertices(ipix_.as_slice()?, &ellipsoid, nthreads as usize);
+        vectorized::vertices(ipix_.as_slice()?, &ellipsoid, step, nthreads as usize);
 
     let (lon, lat): (Vec<Vec<f64>>, Vec<Vec<f64>>) = vertices
         .into_iter()

--- a/rust/healpix-geo-core/src/scalar/nested/coordinates.rs
+++ b/rust/healpix-geo-core/src/scalar/nested/coordinates.rs
@@ -20,8 +20,12 @@ pub fn lonlat_to_healpix(lon: &f64, lat: &f64, layer: &Layer, ellipsoid: &Ellips
     layer.hash(lon_, lat_)
 }
 
-pub fn vertices(hash: &u64, layer: &Layer, ellipsoid: &Ellipsoid) -> Vec<(f64, f64)> {
-    let vertices = layer.vertices(*hash);
+pub fn vertices(hash: &u64, layer: &Layer, ellipsoid: &Ellipsoid, step: &usize) -> Vec<(f64, f64)> {
+    let vertices = if step == 1 {
+        layer.vertices(*hash)
+    } else {
+        layer.path_along_cell_edge(*hash, Cardinal::S, false, *step as u32)
+    };
 
     vertices
         .into_iter()

--- a/rust/healpix-geo-core/src/scalar/nested/coordinates.rs
+++ b/rust/healpix-geo-core/src/scalar/nested/coordinates.rs
@@ -1,5 +1,6 @@
 use crate::ellipsoid::{Ellipsoid, ReferenceBody};
 
+use cdshealpix::compass_point::Cardinal;
 use cdshealpix::nested::Layer;
 
 pub fn healpix_to_lonlat(hash: &u64, layer: &Layer, ellipsoid: &Ellipsoid) -> (f64, f64) {
@@ -21,15 +22,17 @@ pub fn lonlat_to_healpix(lon: &f64, lat: &f64, layer: &Layer, ellipsoid: &Ellips
 }
 
 pub fn vertices(hash: &u64, layer: &Layer, ellipsoid: &Ellipsoid, step: &usize) -> Vec<(f64, f64)> {
-    let vertices = if step == 1 {
-        layer.vertices(*hash)
+    let vertices: Vec<(f64, f64)> = if *step == 1 {
+        layer.vertices(*hash).into()
     } else {
-        layer.path_along_cell_edge(*hash, Cardinal::S, false, *step as u32)
+        layer
+            .path_along_cell_edge(*hash, &Cardinal::S, false, *step as u32)
+            .into()
     };
 
     vertices
         .into_iter()
-        .map(|(lon, lat)| {
+        .map(|(lon, lat): (f64, f64)| {
             (
                 lon.to_degrees().rem_euclid(360.0),
                 ellipsoid.latitude_authalic_to_geographic(lat).to_degrees(),

--- a/rust/healpix-geo-core/src/scalar/ring/coordinates.rs
+++ b/rust/healpix-geo-core/src/scalar/ring/coordinates.rs
@@ -20,8 +20,14 @@ pub fn lonlat_to_healpix(lon: &f64, lat: &f64, nside: &u32, ellipsoid: &Ellipsoi
     healpix::ring::hash(*nside, lon_, lat_)
 }
 
-pub fn vertices(hash: &u64, nside: &u32, ellipsoid: &Ellipsoid) -> Vec<(f64, f64)> {
-    let vertices = healpix::ring::vertices(*nside, *hash);
+pub fn vertices(hash: &u64, nside: &u32, ellipsoid: &Ellipsoid, step: &usize) -> Vec<(f64, f64)> {
+    let vertices = if step == 1 {
+        healpix::ring::vertices(*hash)
+    } else {
+        let layer = healpix::nested::get(healpix::depth(*nside));
+
+        layer.path_along_cell_edge(layer.from_ring(*hash), Cardinal::S, false, *step as u32)
+    };
 
     vertices
         .into_iter()

--- a/rust/healpix-geo-core/src/scalar/ring/coordinates.rs
+++ b/rust/healpix-geo-core/src/scalar/ring/coordinates.rs
@@ -1,6 +1,7 @@
 use crate::ellipsoid::{Ellipsoid, ReferenceBody};
 
 use cdshealpix as healpix;
+use cdshealpix::compass_point::Cardinal;
 
 pub fn healpix_to_lonlat(hash: &u64, nside: &u32, ellipsoid: &Ellipsoid) -> (f64, f64) {
     let center = healpix::ring::center(*nside, *hash);
@@ -21,17 +22,19 @@ pub fn lonlat_to_healpix(lon: &f64, lat: &f64, nside: &u32, ellipsoid: &Ellipsoi
 }
 
 pub fn vertices(hash: &u64, nside: &u32, ellipsoid: &Ellipsoid, step: &usize) -> Vec<(f64, f64)> {
-    let vertices = if step == 1 {
-        healpix::ring::vertices(*hash)
+    let vertices: Vec<(f64, f64)> = if *step == 1 {
+        healpix::ring::vertices(*nside, *hash).into()
     } else {
         let layer = healpix::nested::get(healpix::depth(*nside));
 
-        layer.path_along_cell_edge(layer.from_ring(*hash), Cardinal::S, false, *step as u32)
+        layer
+            .path_along_cell_edge(layer.from_ring(*hash), &Cardinal::S, false, *step as u32)
+            .into()
     };
 
     vertices
         .into_iter()
-        .map(|(lon, lat)| {
+        .map(|(lon, lat): (f64, f64)| {
             (
                 lon.to_degrees().rem_euclid(360.0),
                 ellipsoid.latitude_authalic_to_geographic(lat).to_degrees(),

--- a/rust/healpix-geo-core/src/scalar/zuniq/coordinates.rs
+++ b/rust/healpix-geo-core/src/scalar/zuniq/coordinates.rs
@@ -17,9 +17,9 @@ pub fn lonlat_to_healpix(lon: &f64, lat: &f64, layer: &Layer, ellipsoid: &Ellips
     healpix::nested::to_zuniq(layer.depth(), hash_nested)
 }
 
-pub fn vertices(hash: &u64, ellipsoid: &Ellipsoid) -> Vec<(f64, f64)> {
+pub fn vertices(hash: &u64, ellipsoid: &Ellipsoid, step: usize) -> Vec<(f64, f64)> {
     let (depth, hash_nested) = healpix::nested::from_zuniq(*hash);
     let layer = healpix::nested::get(depth);
 
-    crate::scalar::nested::coordinates::vertices(&hash_nested, layer, ellipsoid)
+    crate::scalar::nested::coordinates::vertices(&hash_nested, layer, ellipsoid, step)
 }

--- a/rust/healpix-geo-core/src/scalar/zuniq/coordinates.rs
+++ b/rust/healpix-geo-core/src/scalar/zuniq/coordinates.rs
@@ -17,7 +17,7 @@ pub fn lonlat_to_healpix(lon: &f64, lat: &f64, layer: &Layer, ellipsoid: &Ellips
     healpix::nested::to_zuniq(layer.depth(), hash_nested)
 }
 
-pub fn vertices(hash: &u64, ellipsoid: &Ellipsoid, step: usize) -> Vec<(f64, f64)> {
+pub fn vertices(hash: &u64, ellipsoid: &Ellipsoid, step: &usize) -> Vec<(f64, f64)> {
     let (depth, hash_nested) = healpix::nested::from_zuniq(*hash);
     let layer = healpix::nested::get(depth);
 

--- a/rust/healpix-geo-core/src/vectorized/nested/coordinates.rs
+++ b/rust/healpix-geo-core/src/vectorized/nested/coordinates.rs
@@ -41,12 +41,13 @@ pub fn vertices(
     ipix: &[u64],
     layer: &Layer,
     ellipsoid: &Ellipsoid,
+    step: usize,
     nthreads: usize,
 ) -> Vec<Vec<(f64, f64)>> {
     let mut result = Vec::<Vec<(f64, f64)>>::with_capacity(ipix.len());
 
     maybe_parallelize!(nthreads, ipix, result, |hash| scalar::vertices(
-        hash, layer, ellipsoid
+        hash, layer, ellipsoid, &step
     ));
 
     result

--- a/rust/healpix-geo-core/src/vectorized/ring/coordinates.rs
+++ b/rust/healpix-geo-core/src/vectorized/ring/coordinates.rs
@@ -39,12 +39,13 @@ pub fn vertices(
     ipix: &[u64],
     nside: &u32,
     ellipsoid: &Ellipsoid,
+    step: usize,
     nthreads: usize,
 ) -> Vec<Vec<(f64, f64)>> {
     let mut result = Vec::<Vec<(f64, f64)>>::with_capacity(ipix.len());
 
     maybe_parallelize!(nthreads, ipix, result, |hash| scalar::vertices(
-        hash, nside, ellipsoid
+        hash, nside, ellipsoid, &step
     ));
 
     result

--- a/rust/healpix-geo-core/src/vectorized/zuniq/coordinates.rs
+++ b/rust/healpix-geo-core/src/vectorized/zuniq/coordinates.rs
@@ -32,11 +32,16 @@ pub fn lonlat_to_healpix(
     result
 }
 
-pub fn vertices(ipix: &[u64], ellipsoid: &Ellipsoid, nthreads: usize) -> Vec<Vec<(f64, f64)>> {
+pub fn vertices(
+    ipix: &[u64],
+    ellipsoid: &Ellipsoid,
+    step: usize,
+    nthreads: usize,
+) -> Vec<Vec<(f64, f64)>> {
     let mut result = Vec::<Vec<(f64, f64)>>::with_capacity(ipix.len());
 
     maybe_parallelize!(nthreads, ipix, result, |hash| scalar::vertices(
-        hash, ellipsoid
+        hash, ellipsoid, &step
     ));
 
     result


### PR DESCRIPTION
- [x] closes #140

Similarly to `healpy` / `cdshealpix`, this adds a `step` parameter to the `vertices` functions.

Remaining tasks:
- [x] expose `step` in the `auto` namespace