### PR TITLE
bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Justus Magin <keewis@posteo.de>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
I forgot to do this after the previous release, which caused the current release to fail.