### PR TITLE
use ABI3 to avoid building wheels for all supported python versions

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -91,12 +91,7 @@ jobs:
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: |
-            3.10
-            3.11
-            3.12
-            3.13
-            3.14
+          python-version: 3.10
 
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # 1.51.0
@@ -140,12 +135,7 @@ jobs:
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: |
-            3.10
-            3.11
-            3.12
-            3.13
-            3.14
+          python-version: 3.10
 
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # 1.51.0
@@ -186,12 +176,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           architecture: ${{ matrix.platform.target }}
-          python-version: |
-            3.10
-            3.11
-            3.12
-            3.13
-            3.14
+          python-version: 3.10
 
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # 1.51.0
@@ -230,12 +215,7 @@ jobs:
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: |
-            3.10
-            3.11
-            3.12
-            3.13
-            3.14
+          python-version: 3.10
 
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # 1.51.0

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -91,7 +91,7 @@ jobs:
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # 1.51.0
@@ -135,7 +135,7 @@ jobs:
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # 1.51.0
@@ -176,7 +176,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           architecture: ${{ matrix.platform.target }}
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # 1.51.0
@@ -215,7 +215,7 @@ jobs:
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # 1.51.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,6 @@ categories = ["science::geo"]
 [workspace.dependencies]
 cdshealpix = { git = "https://github.com/cds-astro/cds-healpix-rust.git", rev = "0c76809be71e248ed137b9d68f10746d0418d413" }
 moc = "0.19.1"
-numpy = "0.27.1"
-pyo3 = "0.27.2"
 rayon = "1.11.0"
 geodesy = "0.14.0"
 itertools = "0.14.0"

--- a/python/healpix-geo/Cargo.toml
+++ b/python/healpix-geo/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib"]
 [dependencies]
 healpix-geo-core = { workspace = true }
 moc = { workspace = true }
-numpy = { workspace = true }
-pyo3 = { workspace = true }
+numpy = "0.27.1"
+pyo3 = { version = "0.27.2", features = ["abi3-py310"] }
 rayon = { workspace = true }
 geodesy = { workspace = true }
 cdshealpix = { workspace = true }


### PR DESCRIPTION
This will drastically reduce the number of wheels we need to build, to one per platform / architecture.