### PR TITLE
generation of meshes from healpix 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assertables"
+version = "10.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3c16d80246a076246d8b525d9f404543e90fe0818636cd89c249c2a4bee3bb1"
+dependencies = [
+ "regex",
+ "walkdir",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,10 +446,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -448,6 +475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -500,6 +528,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,12 +565,14 @@ dependencies = [
 name = "healpix-geo-core"
 version = "0.2.1"
 dependencies = [
+ "assertables",
  "cdshealpix 0.9.1 (git+https://github.com/cds-astro/cds-healpix-rust.git?rev=d9d017cda85a097b65d200e3c4cccefc54665915)",
  "geodesy",
  "itertools 0.15.0",
  "moc",
  "num-traits",
  "rayon",
+ "rstest",
  "serde",
  "serde_json",
 ]
@@ -981,6 +1017,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.13+spec-1.1.0",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,10 +1179,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustversion"
@@ -1323,8 +1412,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -1337,6 +1426,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1345,9 +1443,30 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -1705,6 +1824,15 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]

--- a/pixi.toml
+++ b/pixi.toml
@@ -26,9 +26,6 @@ depends-on = [
 ipython = "*"
 jupyterlab = ">=4.5.5,<5"
 
-[feature.dev.tasks]
-ipython = "ipython"
-
 [feature.dev.pypi-dependencies]
 pytest-accept = ">=0.2.3, <0.3"
 

--- a/python/healpix-geo/python/healpix_geo/__init__.py
+++ b/python/healpix-geo/python/healpix_geo/__init__.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from healpix_geo import geometry, healpix_geo, nested, ring, zuniq
 from healpix_geo.geometry import Bbox
+from healpix_geo.mesh import vertex_to_geographic
 
 
 def cartesian_to_lonlat(x, y, z, ellipsoid="sphere", num_threads=0):
@@ -98,6 +99,7 @@ __all__ = [
     "slices",
     "geometry",
     "Bbox",
+    "vertex_to_geographic",
     "lonlat_to_cartesian",
     "cartesian_to_lonlat",
 ]

--- a/python/healpix-geo/python/healpix_geo/__init__.py
+++ b/python/healpix-geo/python/healpix_geo/__init__.py
@@ -98,4 +98,6 @@ __all__ = [
     "slices",
     "geometry",
     "Bbox",
+    "lonlat_to_cartesian",
+    "cartesian_to_lonlat",
 ]

--- a/python/healpix-geo/python/healpix_geo/mesh.py
+++ b/python/healpix-geo/python/healpix_geo/mesh.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from healpix_geo import healpix_geo
+from healpix_geo.utils import _check_depth
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+    from healpix_geo.typing import EllipsoidLike
+
+
+def vertex_to_geographic(
+    vertex_ids: npt.NDArray[np.uint64],
+    depth: int,
+    *,
+    ellipsoid: EllipsoidLike = "sphere",
+    num_threads: int = 0,
+) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    """geographic coordinates for the given vertex ids
+
+    Parameters
+    ----------
+    vertex_ids : array-like of uint64
+        The given vertex ids.
+    depth : int
+        The depth of the cells the vertices are computed for.
+    ellipsoid : ellipsoid-like, default: "sphere"
+        Reference ellipsoid to evaluate the healpix vertex ids on.
+    nthreads : int, optional
+        Specifies the number of threads to use for the computation. Default to 0 means
+        it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
+        or the number of logical CPUs (otherwise)
+
+    Returns
+    -------
+    longitude, latitude : array-like of numpy.float64
+        The coordinates of the given vertices. Both arrays have the same shape as the array of vertex ids.
+
+    Examples
+    --------
+    >>> from healpix_geo import vertex_to_geographic
+    >>> import numpy as np
+    >>> depth = 0
+    >>> vertex_ids = np.arange(12 * 4**depth + 2, dtype="uint64")
+    >>> lon, lat = vertex_to_geographic(vertex_ids, depth, ellipsoid="sphere")
+    >>> np.stack([lon, lat], axis=-1)
+    array([[  0.       ,  90.       ],
+           [  0.       ,  41.8103149],
+           [ 90.       ,  41.8103149],
+           [180.       ,  41.8103149],
+           [270.       ,  41.8103149],
+           [ 45.       ,   0.       ],
+           [135.       ,   0.       ],
+           [225.       ,   0.       ],
+           [315.       ,   0.       ],
+           [  0.       , -41.8103149],
+           [ 90.       , -41.8103149],
+           [180.       , -41.8103149],
+           [270.       , -41.8103149],
+           [  0.       , -90.       ]])
+    """
+    _check_depth(depth)
+    depth = int(depth)
+    vertex_ids = np.astype(np.atleast_1d(vertex_ids), np.uint64)
+
+    assert np.all(
+        vertex_ids < 12 * 4**depth + 2
+    ), f"Some vertex ids exceed the valid range for depth {depth}"
+
+    num_threads = np.uint16(num_threads)
+
+    return healpix_geo.vertex_to_geographic(depth, vertex_ids, ellipsoid, num_threads)

--- a/python/healpix-geo/python/healpix_geo/nested.py
+++ b/python/healpix-geo/python/healpix_geo/nested.py
@@ -1,8 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import marray
 import numpy as np
 
 from healpix_geo import healpix_geo
 from healpix_geo.utils import _check_depth, _check_ipixels, _check_ring
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
 
 RangeMOCIndex = healpix_geo.nested.RangeMOCIndex
 internal_boundary = healpix_geo.nested.internal_boundary
@@ -305,6 +312,62 @@ def vertices(ipix, depth, ellipsoid="sphere", step=1, num_threads=0):
     num_threads = np.uint16(num_threads)
 
     return healpix_geo.nested.vertices(depth, ipix, ellipsoid, step, num_threads)
+
+
+def vertex_indices(
+    ipix: npt.NDArray[np.uint64],
+    depth: int,
+    *,
+    num_threads: int = 0,
+) -> npt.NDArray[np.uint64]:
+    """Get the indices of the 4 vertices of the given cells.
+
+    Parameters
+    ----------
+    ipix : array-like of numpy.uint64
+        The HEALPix cell indexes.
+    depth : int
+        The depth of the HEALPix cells.
+    num_threads : int, optional
+        Specifies the number of threads to use for the computation. Default to 0 means
+        it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
+        or the number of logical CPUs (otherwise)
+
+    Returns
+    -------
+    vertex_ids : array-like of numpy.uint64
+        The identifiers of vertices of the given cells.
+
+    Raises
+    ------
+    ValueError
+        When the HEALPix cell indexes given have values out of :math:`[0, 4^{29 - depth})`.
+
+    See Also
+    --------
+    healpix_geo.vertex_to_geographic
+
+    Examples
+    --------
+    >>> from healpix_geo.nested import vertex_indices
+    >>> import numpy as np
+
+    >>> ipix = np.array([42, 6, 10])
+    >>> depth = 12
+
+    >>> vertex_ids = vertex_indices(ipix, depth)
+    >>> vertex_ids
+    array([[100542461, 100526078, 100509693, 100526077],
+           [100608001, 100591618, 100575233, 100591617],
+           [100607999, 100591616, 100575231, 100591615]], dtype=uint64)
+    """
+    _check_depth(depth)
+    depth = int(depth)
+    ipix = np.atleast_1d(ipix)
+    _check_ipixels(data=ipix, depth=depth)
+    ipix = np.astype(ipix, np.uint64)
+
+    return healpix_geo.nested.vertex_indices(depth, ipix, num_threads)
 
 
 def bilinear_interpolation(

--- a/python/healpix-geo/python/healpix_geo/ring.py
+++ b/python/healpix-geo/python/healpix_geo/ring.py
@@ -1,8 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import marray
 import numpy as np
 
 from healpix_geo import healpix_geo
 from healpix_geo.utils import _check_depth, _check_ipixels, _check_ring
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
 
 
 def healpix_to_lonlat(ipix, depth, ellipsoid="sphere", num_threads=0):
@@ -289,6 +296,62 @@ def vertices(ipix, depth, ellipsoid, step=1, num_threads=0):
     num_threads = np.uint16(num_threads)
 
     return healpix_geo.ring.vertices(depth, ipix, ellipsoid, step, num_threads)
+
+
+def vertex_indices(
+    ipix: npt.NDArray[np.uint64],
+    depth: int,
+    *,
+    num_threads: int = 0,
+) -> npt.NDArray[np.uint64]:
+    """Get the indices of the 4 vertices of the given cells.
+
+    Parameters
+    ----------
+    ipix : array-like of numpy.uint64
+        The HEALPix cell indexes.
+    depth : int
+        The depth of the HEALPix cells.
+    num_threads : int, optional
+        Specifies the number of threads to use for the computation. Default to 0 means
+        it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
+        or the number of logical CPUs (otherwise)
+
+    Returns
+    -------
+    vertex_ids : array-like of numpy.uint64
+        The identifiers of vertices of the given cells.
+
+    Raises
+    ------
+    ValueError
+        When the HEALPix cell indexes given have values out of :math:`[0, 4^{29 - depth})`.
+
+    See Also
+    --------
+    healpix_geo.vertex_to_geographic
+
+    Examples
+    --------
+    >>> from healpix_geo.nested import vertex_indices
+    >>> import numpy as np
+
+    >>> ipix = np.array([42, 6, 10])
+    >>> depth = 12
+
+    >>> vertex_ids = vertex_indices(ipix, depth)
+    >>> vertex_ids
+    array([[100542461, 100526078, 100509693, 100526077],
+           [100608001, 100591618, 100575233, 100591617],
+           [100607999, 100591616, 100575231, 100591615]], dtype=uint64)
+    """
+    _check_depth(depth)
+    depth = int(depth)
+    ipix = np.atleast_1d(ipix)
+    _check_ipixels(data=ipix, depth=depth)
+    ipix = np.astype(ipix, np.uint64)
+
+    return healpix_geo.ring.vertex_indices(depth, ipix, num_threads)
 
 
 def bilinear_interpolation(

--- a/python/healpix-geo/python/healpix_geo/zuniq.py
+++ b/python/healpix-geo/python/healpix_geo/zuniq.py
@@ -1,8 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import marray
 import numpy as np
 
 from healpix_geo import healpix_geo
 from healpix_geo.utils import _check_depth, _check_ipixels
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
 
 
 def from_nested(ipix, depth, num_threads=0):
@@ -367,6 +374,57 @@ def vertices(ipix, ellipsoid, step=1, num_threads=0):
     num_threads = np.uint16(num_threads)
 
     return healpix_geo.zuniq.vertices(ipix, ellipsoid, step, num_threads)
+
+
+def vertex_indices(
+    ipix: npt.NDArray[np.uint64],
+    *,
+    num_threads: int = 0,
+) -> npt.NDArray[np.uint64]:
+    """Get the indices of the 4 vertices of the given cells.
+
+    Parameters
+    ----------
+    ipix : array-like of numpy.uint64
+        The HEALPix cell indexes.
+    num_threads : int, optional
+        Specifies the number of threads to use for the computation. Default to 0 means
+        it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
+        or the number of logical CPUs (otherwise)
+
+    Returns
+    -------
+    vertex_ids : array-like of numpy.uint64
+        The identifiers of vertices of the given cells.
+
+    Raises
+    ------
+    ValueError
+        When the HEALPix cell indexes given have values out of :math:`[0, 4^{29 - depth})`.
+
+    See Also
+    --------
+    healpix_geo.vertex_to_geographic
+
+    Examples
+    --------
+    >>> from healpix_geo.zuniq import vertex_indices
+    >>> import numpy as np
+
+    >>> ipix = np.array([42, 6, 10])
+
+    >>> vertex_ids = vertex_indices(ipix)
+    >>> vertex_ids
+    array([[1729382249662513151, 1729382247515029504, 1729382245367545855,
+            1729382247515029503],
+           [1729382253957480449, 1729382251809996802, 1729382249662513153,
+            1729382251809996801],
+           [1729382253957480448, 1729382251809996801, 1729382249662513152,
+            1729382251809996800]], dtype=uint64)
+    """
+    ipix = np.astype(np.atleast_1d(ipix), np.uint64)
+
+    return healpix_geo.zuniq.vertex_indices(ipix, num_threads)
 
 
 def bilinear_interpolation(

--- a/python/healpix-geo/src/indexing_schemes/nested/mesh.rs
+++ b/python/healpix-geo/src/indexing_schemes/nested/mesh.rs
@@ -1,0 +1,23 @@
+use healpix_geo_core::vectorized::nested::mesh as vectorized;
+use numpy::{PyArray2, PyArrayDyn, PyArrayMethods, PyUntypedArrayMethods};
+use pyo3::prelude::*;
+
+#[pyfunction]
+pub(crate) fn vertex_indices<'py>(
+    py: Python<'py>,
+    depth: u8,
+    ipix: &Bound<'py, PyArrayDyn<u64>>,
+    nthreads: u16,
+) -> PyResult<Bound<'py, PyArrayDyn<u64>>> {
+    let input_shape = ipix.shape();
+    let output_shape: Vec<usize> = input_shape.iter().copied().chain([4]).collect();
+
+    let ipix_ = ipix.readonly();
+
+    let vertex_ids = vectorized::vertex_indices(depth, ipix_.as_slice()?, nthreads as usize)
+        .into_iter()
+        .map(|(a, b, c, d)| vec![a, b, c, d])
+        .collect::<Vec<Vec<u64>>>();
+
+    PyArray2::from_vec2(py, &vertex_ids)?.reshape(output_shape)
+}

--- a/python/healpix-geo/src/indexing_schemes/nested/mod.rs
+++ b/python/healpix-geo/src/indexing_schemes/nested/mod.rs
@@ -1,6 +1,7 @@
 mod coordinates;
 mod coverage;
 mod hierarchy;
+mod mesh;
 mod sets;
 
 pub(crate) use self::coordinates::{
@@ -11,4 +12,5 @@ pub(crate) use self::coverage::{
     box_coverage, cone_coverage, elliptical_cone_coverage, polygon_coverage, zone_coverage,
 };
 pub(crate) use self::hierarchy::{kth_neighbourhood, kth_neighbours, siblings, zoom_to};
+pub(crate) use self::mesh::vertex_indices;
 pub(crate) use self::sets::internal_boundary;

--- a/python/healpix-geo/src/indexing_schemes/ring/mesh.rs
+++ b/python/healpix-geo/src/indexing_schemes/ring/mesh.rs
@@ -1,0 +1,23 @@
+use healpix_geo_core::vectorized::ring::mesh as vectorized;
+use numpy::{PyArray2, PyArrayDyn, PyArrayMethods, PyUntypedArrayMethods};
+use pyo3::prelude::*;
+
+#[pyfunction]
+pub(crate) fn vertex_indices<'py>(
+    py: Python<'py>,
+    depth: u8,
+    ipix: &Bound<'py, PyArrayDyn<u64>>,
+    nthreads: u16,
+) -> PyResult<Bound<'py, PyArrayDyn<u64>>> {
+    let input_shape = ipix.shape();
+    let output_shape: Vec<usize> = input_shape.iter().copied().chain([4]).collect();
+
+    let ipix_ = ipix.readonly();
+
+    let vertex_ids = vectorized::vertex_indices(depth, ipix_.as_slice()?, nthreads as usize)
+        .into_iter()
+        .map(|(a, b, c, d)| vec![a, b, c, d])
+        .collect::<Vec<Vec<u64>>>();
+
+    PyArray2::from_vec2(py, &vertex_ids)?.reshape(output_shape)
+}

--- a/python/healpix-geo/src/indexing_schemes/ring/mod.rs
+++ b/python/healpix-geo/src/indexing_schemes/ring/mod.rs
@@ -1,6 +1,7 @@
 mod coordinates;
 mod coverage;
 mod hierarchy;
+mod mesh;
 
 pub(crate) use self::coordinates::{
     angular_distances, bilinear_interpolation, cartesian_to_healpix, healpix_to_cartesian,
@@ -10,3 +11,4 @@ pub(crate) use self::coverage::{
     box_coverage, cone_coverage, elliptical_cone_coverage, polygon_coverage, zone_coverage,
 };
 pub(crate) use self::hierarchy::{kth_neighbourhood, kth_neighbours};
+pub(crate) use self::mesh::vertex_indices;

--- a/python/healpix-geo/src/indexing_schemes/zuniq/mesh.rs
+++ b/python/healpix-geo/src/indexing_schemes/zuniq/mesh.rs
@@ -1,0 +1,22 @@
+use healpix_geo_core::vectorized::zuniq::mesh as vectorized;
+use numpy::{PyArray2, PyArrayDyn, PyArrayMethods, PyUntypedArrayMethods};
+use pyo3::prelude::*;
+
+#[pyfunction]
+pub(crate) fn vertex_indices<'py>(
+    py: Python<'py>,
+    ipix: &Bound<'py, PyArrayDyn<u64>>,
+    nthreads: u16,
+) -> PyResult<Bound<'py, PyArrayDyn<u64>>> {
+    let input_shape = ipix.shape();
+    let output_shape: Vec<usize> = input_shape.iter().copied().chain([4]).collect();
+
+    let ipix_ = ipix.readonly();
+
+    let vertex_ids = vectorized::vertex_indices(ipix_.as_slice()?, nthreads as usize)
+        .into_iter()
+        .map(|(a, b, c, d)| vec![a, b, c, d])
+        .collect::<Vec<Vec<u64>>>();
+
+    PyArray2::from_vec2(py, &vertex_ids)?.reshape(output_shape)
+}

--- a/python/healpix-geo/src/indexing_schemes/zuniq/mod.rs
+++ b/python/healpix-geo/src/indexing_schemes/zuniq/mod.rs
@@ -2,6 +2,7 @@ mod conversion;
 mod coordinates;
 mod coverage;
 mod hierarchy;
+mod mesh;
 
 pub(crate) use self::conversion::{from_nested, to_nested};
 pub(crate) use self::coordinates::{
@@ -12,3 +13,4 @@ pub(crate) use self::coverage::{
     box_coverage, cone_coverage, elliptical_cone_coverage, polygon_coverage, zone_coverage,
 };
 pub(crate) use self::hierarchy::{kth_neighbourhood, kth_neighbours};
+pub(crate) use self::mesh::vertex_indices;

--- a/python/healpix-geo/src/lib.rs
+++ b/python/healpix-geo/src/lib.rs
@@ -68,5 +68,5 @@ mod healpix_geo {
     #[pymodule_export]
     use crate::geometry::{cartesian_to_lonlat, lonlat_to_cartesian};
     #[pymodule_export]
-    use crate::mesh::vertex_coordinates;
+    use crate::mesh::vertex_to_geographic;
 }

--- a/python/healpix-geo/src/lib.rs
+++ b/python/healpix-geo/src/lib.rs
@@ -5,6 +5,7 @@ mod execution;
 mod geometry;
 mod index;
 mod indexing_schemes;
+mod mesh;
 mod traits;
 
 #[pymodule]
@@ -17,7 +18,7 @@ mod nested {
         angular_distances, bilinear_interpolation, box_coverage, cartesian_to_healpix,
         cone_coverage, elliptical_cone_coverage, healpix_to_cartesian, healpix_to_lonlat,
         internal_boundary, kth_neighbourhood, kth_neighbours, lonlat_to_healpix, polygon_coverage,
-        siblings, vertices, zone_coverage, zoom_to,
+        siblings, vertex_indices, vertices, zone_coverage, zoom_to,
     };
 }
 
@@ -27,8 +28,8 @@ mod ring {
     use crate::indexing_schemes::ring::{
         angular_distances, bilinear_interpolation, box_coverage, cartesian_to_healpix,
         cone_coverage, elliptical_cone_coverage, healpix_to_cartesian, healpix_to_lonlat,
-        kth_neighbourhood, kth_neighbours, lonlat_to_healpix, polygon_coverage, vertices,
-        zone_coverage,
+        kth_neighbourhood, kth_neighbours, lonlat_to_healpix, polygon_coverage, vertex_indices,
+        vertices, zone_coverage,
     };
 }
 
@@ -39,7 +40,7 @@ mod zuniq {
         bilinear_interpolation, box_coverage, cartesian_to_healpix, cone_coverage,
         elliptical_cone_coverage, from_nested, healpix_to_cartesian, healpix_to_lonlat,
         kth_neighbourhood, kth_neighbours, lonlat_to_healpix, polygon_coverage, to_nested,
-        vertices, zone_coverage,
+        vertex_indices, vertices, zone_coverage,
     };
 }
 
@@ -66,4 +67,6 @@ mod healpix_geo {
 
     #[pymodule_export]
     use crate::geometry::{cartesian_to_lonlat, lonlat_to_cartesian};
+    #[pymodule_export]
+    use crate::mesh::vertex_coordinates;
 }

--- a/python/healpix-geo/src/mesh.rs
+++ b/python/healpix-geo/src/mesh.rs
@@ -1,0 +1,30 @@
+use numpy::{PyArray1, PyArrayDyn, PyArrayMethods, PyUntypedArrayMethods};
+use pyo3::prelude::*;
+
+use crate::ellipsoid::EllipsoidLike;
+use healpix_geo_core::vectorized::mesh as vectorized;
+
+#[allow(clippy::type_complexity)]
+#[pyfunction]
+pub(crate) fn vertex_coordinates<'py>(
+    py: Python<'py>,
+    depth: u8,
+    ipix: &Bound<'py, PyArrayDyn<u64>>,
+    ellipsoid_like: EllipsoidLike,
+    nthreads: u16,
+) -> PyResult<(Bound<'py, PyArrayDyn<f64>>, Bound<'py, PyArrayDyn<f64>>)> {
+    let ellipsoid = ellipsoid_like.into_ellipsoid()?;
+    let input_shape = ipix.shape();
+
+    let ipix_ = ipix.readonly();
+
+    let (lon, lat): (Vec<f64>, Vec<f64>) =
+        vectorized::vertex_coordinates(depth, ipix_.as_slice()?, &ellipsoid, nthreads as usize)
+            .into_iter()
+            .unzip();
+
+    Ok((
+        PyArray1::from_vec(py, lon).reshape(input_shape)?,
+        PyArray1::from_vec(py, lat).reshape(input_shape)?,
+    ))
+}

--- a/python/healpix-geo/src/mesh.rs
+++ b/python/healpix-geo/src/mesh.rs
@@ -6,7 +6,7 @@ use healpix_geo_core::vectorized::mesh as vectorized;
 
 #[allow(clippy::type_complexity)]
 #[pyfunction]
-pub(crate) fn vertex_coordinates<'py>(
+pub(crate) fn vertex_to_geographic<'py>(
     py: Python<'py>,
     depth: u8,
     ipix: &Bound<'py, PyArrayDyn<u64>>,
@@ -19,7 +19,7 @@ pub(crate) fn vertex_coordinates<'py>(
     let ipix_ = ipix.readonly();
 
     let (lon, lat): (Vec<f64>, Vec<f64>) =
-        vectorized::vertex_coordinates(depth, ipix_.as_slice()?, &ellipsoid, nthreads as usize)
+        vectorized::vertex_to_geographic(depth, ipix_.as_slice()?, &ellipsoid, nthreads as usize)
             .into_iter()
             .unzip();
 

--- a/rust/healpix-geo-core/Cargo.toml
+++ b/rust/healpix-geo-core/Cargo.toml
@@ -17,3 +17,7 @@ num-traits = "0.2.19"
 rayon = { workspace = true }
 serde = "1.0.228"
 serde_json = "1.0.150"
+
+[dev-dependencies]
+assertables = "10.1.0"
+rstest = "0.26.1"

--- a/rust/healpix-geo-core/src/lib.rs
+++ b/rust/healpix-geo-core/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod ellipsoid;
 pub mod geometry;
 pub mod index;
-mod mesh;
 pub mod scalar;
 pub mod vectorized;

--- a/rust/healpix-geo-core/src/lib.rs
+++ b/rust/healpix-geo-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod ellipsoid;
 pub mod geometry;
 pub mod index;
+mod mesh;
 pub mod scalar;
 pub mod vectorized;

--- a/rust/healpix-geo-core/src/mesh.rs
+++ b/rust/healpix-geo-core/src/mesh.rs
@@ -55,21 +55,22 @@ fn encode_in_ring_position(x: f64, ring: u64, nside: u64) -> u64 {
     if pole_distance == 0 {
         0
     } else if pole_distance < nside {
-        let occupied = pole_distance as f64 / nside as f64;
-        let reduced_x = x - (1.0 - occupied) * (2.0 * (x / 2.0).floor() + 1.0);
-        let collapsed_size = 8.0 * pole_distance as f64 / nside as f64;
+        let discretized_x = (nside as f64 * x) as u64;
+        // integer division, the parens are significant
+        let n_gaps = 2 * (discretized_x / (2 * nside)) + 1;
+        let reduced_x = discretized_x - (nside - pole_distance) * n_gaps;
 
-        (nside as f64 / 2.0 * reduced_x.rem_euclid(collapsed_size)).floor() as u64
+        reduced_x.rem_euclid(8 * pole_distance) / 2
     } else {
         let phase = if nside == 1 {
             (ring + 1).rem_euclid(2)
         } else {
             ring.rem_euclid(2)
         };
-        let reduced_x = x - phase as f64 / nside as f64;
 
-        let collapsed_size = 8.0 - phase as f64 / nside as f64;
-        (nside as f64 / 2.0 * reduced_x.rem_euclid(collapsed_size)).floor() as u64
+        let discretized_x = (nside as f64 * x) as u64;
+
+        (discretized_x - phase).rem_euclid(8 * nside - phase) / 2
     }
 }
 
@@ -80,18 +81,15 @@ fn decode_in_ring_position(position: u64, ring: u64, nside: u64) -> f64 {
     if pole_distance == 0 {
         1.0
     } else if pole_distance < nside {
-        let gap = 1.0 - pole_distance as f64 / nside as f64;
-        let completed_blocks = 2 * (position as f64 / pole_distance as f64).floor() as u64 + 1;
+        let gap = nside - pole_distance;
+        // integer division, the parens are significant
+        let completed_blocks = 2 * (position / pole_distance) + 1;
 
-        2.0 / nside as f64 * position as f64 + gap * completed_blocks as f64
+        (2 * position + gap * completed_blocks) as f64 / nside as f64
     } else {
-        let phase = if nside == 1 {
-            (ring + 1).rem_euclid(2)
-        } else {
-            ring.rem_euclid(2)
-        };
+        let phase = (if nside == 1 { ring + 1 } else { ring }).rem_euclid(2);
 
-        (2.0 * position as f64 + phase as f64) / nside as f64
+        (2 * position + phase) as f64 / nside as f64
     }
 }
 

--- a/rust/healpix-geo-core/src/mesh.rs
+++ b/rust/healpix-geo-core/src/mesh.rs
@@ -14,8 +14,8 @@
 //! For the vertex ids, there are a few choices:
 //!
 //! - ring: north pole is 0, numbering along rings of equal latitude
-//! - nested: each base cell contains the southeastern and northeastern boundaries, and on
-//!   conflicts the northernmost base cell wins. The poles are part of the 0th and 11th base cells.
+//! - nested: each base cell its southwestern and northwestern edges, and the western vertex.
+//!   Additionally, the poles are part of the 0th and 11th base cells.
 //! - Try to use a Hilbert curve instead. For this, we somehow need to deal with the jumps in the
 //!   healpix projection space.
 //!
@@ -27,12 +27,329 @@
 //! Other functions:
 //! - vertex_indices: deduplicate the vertex ids and construct the mesh connectivity
 //! - vertex coordinates: given a vertex id, compute the vertex coordinates
+use cdshealpix as healpix;
+// use cdshealpix::unproj;
 
-type CellVertices = (u64, u64, u64, u64);
-type CellIndices = (usize, usize, usize, usize);
+// type CellVertices = (u64, u64, u64, u64);
+// type CellIndices = (usize, usize, usize, usize);
 
-/// Deduplicate and sort the given vertex ids
-pub fn vertex_indices(ipix: &[CellVertices]) -> (Vec<u64>, Vec<CellIndices>) {}
+enum VertexIdScheme {
+    Ring,
+    ZOrder,
+}
 
-/// Convert a vertex id to coordinates
-pub fn vertex_coordinates(hash: u64) -> (f64, f64) {}
+#[inline]
+const fn triangular_number_x4(n: u64) -> u64 {
+    (n * (n + 1)) << 1
+}
+
+#[inline]
+const fn polar_cap_vertices(nside: u32) -> u64 {
+    triangular_number_x4(nside as u64 - 1) + 1
+}
+
+#[inline]
+fn ring(y: f64, nside: u32) -> u64 {
+    ((y + 2.0) * nside as f64).floor() as u64
+}
+
+#[inline]
+fn first_node_in_ring(ring: u64, nside: u64) -> f64 {
+    if ring < nside || (nside >= 2 * nside && nside < 3 * nside) {
+        1.0 - ring.rem_euclid(nside) as f64 / nside as f64
+    } else {
+        ring.rem_euclid(nside) as f64 / nside as f64
+    }
+}
+
+#[inline]
+fn in_ring_position(x: f64, ring: u64, nside: u64) -> u64 {
+    let pole_distance = ring.min(4 * nside - ring);
+
+    if pole_distance == 0 {
+        0
+    } else if pole_distance < nside {
+        let occupied = pole_distance as f64 / nside as f64;
+        let reduced_x = x - (1.0 - occupied) * (2.0 * (x / 2.0).floor() + 1.0);
+        let collapsed_size = 8.0 * pole_distance as f64 / nside as f64;
+
+        (nside as f64 / 2.0 * reduced_x.rem_euclid(collapsed_size)).floor() as u64
+    } else {
+        let phase = if nside == 1 { 0 } else { ring.rem_euclid(2) };
+        let reduced_x = x - phase as f64 / nside as f64;
+
+        let collapsed_ring_size = 8.0 - phase as f64 / nside as f64;
+        (nside as f64 / 2.0 * reduced_x.rem_euclid(collapsed_ring_size)).floor() as u64
+    }
+}
+
+#[inline]
+const fn equatorial_vertices(nside: u32) -> u64 {
+    let nside = nside as u64;
+    let rings = 2 * nside + 1;
+
+    rings * 4 * nside
+}
+
+#[inline]
+fn ring_offset(ring: u64, nside: u64) -> u64 {
+    let pole_distance = ring.min(4 * nside - ring);
+
+    if ring == 0 {
+        0
+    } else if ring < nside {
+        1 + 2 * pole_distance * (pole_distance - 1)
+    } else if ring > 3 * nside {
+        12 * nside.pow(2) + 1 - 2 * (pole_distance + 1) * pole_distance
+    } else {
+        1 + 2 * nside * (nside - 1) + 4 * nside * (ring - nside)
+    }
+}
+
+fn encode_vertex(depth: u8, x: f64, y: f64, scheme: VertexIdScheme) -> u64 {
+    let nside = healpix::nside(depth) as u64;
+
+    match scheme {
+        VertexIdScheme::Ring => {
+            let ring = (nside as f64 * (2.0 - y)).floor() as u64;
+
+            println!(
+                "ring: {ring}, ({} + {}) ({nside})",
+                ring_offset(ring, nside),
+                in_ring_position(x, ring, nside)
+            );
+
+            ring_offset(ring, nside) + in_ring_position(x, ring, nside)
+        }
+        VertexIdScheme::ZOrder => todo!(),
+    }
+}
+
+// fn decode_vertex(vertex_id: u64, scheme: VertexIdScheme) -> (f64, f64) {}
+
+// /// Deduplicate and sort the given vertex ids
+// pub fn vertex_indices(ipix: &[CellVertices]) -> (Vec<u64>, Vec<CellIndices>) {}
+
+// /// Convert a vertex id to coordinates
+// pub fn vertex_coordinates(hash: u64) -> (f64, f64) {
+//     // convert vertex hash to (face, x, y)
+//     // - convert the vertex id into (face, x, y, depth, corner-kind)
+//     // - from there, convert to (x, y) healpix plane coordinates (offset from the healpix
+//     //   center coordinate is 1 / 2**depth)
+//     // - use `unproj` to compute the geographic coordinates
+// }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_polar_cap_vertices() {
+        let actual = polar_cap_vertices(1);
+        assert_eq!(actual, 1);
+
+        let actual = polar_cap_vertices(2);
+        assert_eq!(actual, 5);
+
+        let actual = polar_cap_vertices(4);
+        assert_eq!(actual, 25);
+    }
+
+    #[test]
+    fn test_equatorial_vertices() {
+        let actual = equatorial_vertices(1);
+        assert_eq!(actual, 12);
+
+        let actual = equatorial_vertices(2);
+        assert_eq!(actual, 40);
+
+        let actual = equatorial_vertices(4);
+        assert_eq!(actual, 144);
+    }
+
+    #[test]
+    fn test_in_ring_position_nside_1_polar_caps() {
+        // pole
+        assert_eq!(in_ring_position(1.0, 0, 1), 0);
+        assert_eq!(in_ring_position(3.0, 0, 1), 0);
+        assert_eq!(in_ring_position(5.0, 0, 1), 0);
+        assert_eq!(in_ring_position(7.0, 0, 1), 0);
+
+        assert_eq!(in_ring_position(1.0, 4, 1), 0);
+    }
+
+    #[test]
+    fn test_in_ring_position_nside_1_equatorial_region() {
+        // equatorial region
+        assert_eq!(in_ring_position(0.0, 1, 1), 0);
+        assert_eq!(in_ring_position(4.0, 1, 1), 2);
+        assert_eq!(in_ring_position(8.0, 1, 1), 0);
+
+        assert_eq!(in_ring_position(1.0, 2, 1), 0);
+        assert_eq!(in_ring_position(7.0, 2, 1), 3);
+    }
+
+    #[test]
+    fn test_in_ring_position_nside_2_polar_cap() {
+        // pole
+        assert_eq!(in_ring_position(1.0, 0, 2), 0);
+        // polar cap
+        assert_eq!(in_ring_position(0.5, 1, 2), 0);
+        assert_eq!(in_ring_position(1.5, 1, 2), 1);
+        assert_eq!(in_ring_position(2.5, 1, 2), 1);
+        assert_eq!(in_ring_position(3.5, 1, 2), 2);
+        assert_eq!(in_ring_position(4.5, 1, 2), 2);
+        assert_eq!(in_ring_position(5.5, 1, 2), 3);
+        assert_eq!(in_ring_position(6.5, 1, 2), 3);
+        assert_eq!(in_ring_position(7.5, 1, 2), 0);
+    }
+
+    #[test]
+    fn test_in_ring_position_nside_2_equatorial_region() {
+        // equatorial region
+        assert_eq!(in_ring_position(0.0, 2, 2), 0);
+        assert_eq!(in_ring_position(1.0, 2, 2), 1);
+        assert_eq!(in_ring_position(2.0, 2, 2), 2);
+        assert_eq!(in_ring_position(3.0, 2, 2), 3);
+        assert_eq!(in_ring_position(4.0, 2, 2), 4);
+        assert_eq!(in_ring_position(5.0, 2, 2), 5);
+        assert_eq!(in_ring_position(6.0, 2, 2), 6);
+        assert_eq!(in_ring_position(7.0, 2, 2), 7);
+        assert_eq!(in_ring_position(8.0, 2, 2), 0);
+    }
+
+    #[test]
+    fn test_in_ring_position_nside_4_polar_cap() {
+        assert_eq!(in_ring_position(0.75, 1, 4), 0);
+        assert_eq!(in_ring_position(1.25, 1, 4), 1);
+        assert_eq!(in_ring_position(2.75, 1, 4), 1);
+        assert_eq!(in_ring_position(3.25, 1, 4), 2);
+        assert_eq!(in_ring_position(4.75, 1, 4), 2);
+        assert_eq!(in_ring_position(5.25, 1, 4), 3);
+        assert_eq!(in_ring_position(6.75, 1, 4), 3);
+        assert_eq!(in_ring_position(7.25, 1, 4), 0);
+
+        assert_eq!(in_ring_position(0.25, 3, 4), 0);
+        assert_eq!(in_ring_position(0.75, 3, 4), 1);
+        assert_eq!(in_ring_position(1.25, 3, 4), 2);
+        assert_eq!(in_ring_position(1.75, 3, 4), 3);
+        assert_eq!(in_ring_position(2.25, 3, 4), 3);
+        assert_eq!(in_ring_position(2.75, 3, 4), 4);
+        assert_eq!(in_ring_position(3.25, 3, 4), 5);
+        assert_eq!(in_ring_position(3.75, 3, 4), 6);
+        assert_eq!(in_ring_position(4.25, 3, 4), 6);
+        assert_eq!(in_ring_position(4.75, 3, 4), 7);
+        assert_eq!(in_ring_position(5.25, 3, 4), 8);
+        assert_eq!(in_ring_position(5.75, 3, 4), 9);
+        assert_eq!(in_ring_position(6.25, 3, 4), 9);
+        assert_eq!(in_ring_position(6.75, 3, 4), 10);
+        assert_eq!(in_ring_position(7.25, 3, 4), 11);
+        assert_eq!(in_ring_position(7.75, 3, 4), 0);
+    }
+
+    #[test]
+    fn test_in_ring_position_nside_4_equatorial_region() {
+        assert_eq!(in_ring_position(0.0, 4, 4), 0);
+        assert_eq!(in_ring_position(0.5, 4, 4), 1);
+        assert_eq!(in_ring_position(1.0, 4, 4), 2);
+        assert_eq!(in_ring_position(1.5, 4, 4), 3);
+        assert_eq!(in_ring_position(2.0, 4, 4), 4);
+        assert_eq!(in_ring_position(2.5, 4, 4), 5);
+        assert_eq!(in_ring_position(3.0, 4, 4), 6);
+        assert_eq!(in_ring_position(3.5, 4, 4), 7);
+        assert_eq!(in_ring_position(4.0, 4, 4), 8);
+        assert_eq!(in_ring_position(4.5, 4, 4), 9);
+        assert_eq!(in_ring_position(5.0, 4, 4), 10);
+        assert_eq!(in_ring_position(5.5, 4, 4), 11);
+        assert_eq!(in_ring_position(6.0, 4, 4), 12);
+        assert_eq!(in_ring_position(6.5, 4, 4), 13);
+        assert_eq!(in_ring_position(7.0, 4, 4), 14);
+        assert_eq!(in_ring_position(7.5, 4, 4), 15);
+        assert_eq!(in_ring_position(8.0, 4, 4), 0);
+
+        assert_eq!(in_ring_position(0.25, 5, 4), 0);
+        assert_eq!(in_ring_position(0.75, 5, 4), 1);
+        assert_eq!(in_ring_position(1.25, 5, 4), 2);
+        assert_eq!(in_ring_position(1.75, 5, 4), 3);
+        assert_eq!(in_ring_position(2.25, 5, 4), 4);
+        assert_eq!(in_ring_position(2.75, 5, 4), 5);
+        assert_eq!(in_ring_position(3.25, 5, 4), 6);
+        assert_eq!(in_ring_position(3.75, 5, 4), 7);
+        assert_eq!(in_ring_position(4.25, 5, 4), 8);
+        assert_eq!(in_ring_position(4.75, 5, 4), 9);
+        assert_eq!(in_ring_position(5.25, 5, 4), 10);
+        assert_eq!(in_ring_position(5.75, 5, 4), 11);
+        assert_eq!(in_ring_position(6.25, 5, 4), 12);
+        assert_eq!(in_ring_position(6.75, 5, 4), 13);
+        assert_eq!(in_ring_position(7.25, 5, 4), 14);
+        assert_eq!(in_ring_position(7.75, 5, 4), 15);
+    }
+
+    #[test]
+    fn test_in_ring_position_nside_8_polar_caps() {
+        // polar cap
+        assert_eq!(in_ring_position(0.875, 1, 8), 0);
+        assert_eq!(in_ring_position(2.875, 1, 8), 1);
+        assert_eq!(in_ring_position(4.875, 1, 8), 2);
+        assert_eq!(in_ring_position(6.875, 1, 8), 3);
+
+        assert_eq!(in_ring_position(0.125, 7, 8), 0);
+        assert_eq!(in_ring_position(0.375, 7, 8), 1);
+        assert_eq!(in_ring_position(0.875, 7, 8), 3);
+        assert_eq!(in_ring_position(1.875, 7, 8), 7);
+        assert_eq!(in_ring_position(2.125, 7, 8), 7);
+        assert_eq!(in_ring_position(3.125, 7, 8), 11);
+        assert_eq!(in_ring_position(3.875, 7, 8), 14);
+        assert_eq!(in_ring_position(5.125, 7, 8), 18);
+        assert_eq!(in_ring_position(6.125, 7, 8), 21);
+        assert_eq!(in_ring_position(7.125, 7, 8), 25);
+        assert_eq!(in_ring_position(7.875, 7, 8), 0);
+    }
+
+    #[test]
+    fn test_in_ring_position_nside_8_equatorial_region() {
+        // equatorial region
+        assert_eq!(in_ring_position(0.00, 8, 8), 0);
+        assert_eq!(in_ring_position(0.25, 8, 8), 1);
+        assert_eq!(in_ring_position(1.00, 8, 8), 4);
+        assert_eq!(in_ring_position(2.00, 8, 8), 8);
+        assert_eq!(in_ring_position(4.00, 8, 8), 16);
+        assert_eq!(in_ring_position(7.75, 8, 8), 31);
+        assert_eq!(in_ring_position(0.125, 9, 8), 0);
+        assert_eq!(in_ring_position(0.375, 9, 8), 1);
+        assert_eq!(in_ring_position(1.125, 9, 8), 4);
+        assert_eq!(in_ring_position(2.125, 9, 8), 8);
+        assert_eq!(in_ring_position(4.125, 9, 8), 16);
+        assert_eq!(in_ring_position(7.875, 9, 8), 31);
+    }
+
+    #[test]
+    fn test_ring_offsets() {
+        assert_eq!(ring_offset(0, 1), 0);
+        assert_eq!(ring_offset(1, 1), 1);
+        assert_eq!(ring_offset(3, 1), 9);
+        assert_eq!(ring_offset(4, 1), 13);
+
+        assert_eq!(ring_offset(0, 2), 0);
+        assert_eq!(ring_offset(1, 2), 1);
+        assert_eq!(ring_offset(2, 2), 5);
+        assert_eq!(ring_offset(5, 2), 29);
+        assert_eq!(ring_offset(7, 2), 45);
+        assert_eq!(ring_offset(8, 2), 49);
+
+        assert_eq!(ring_offset(4, 4), 25);
+        assert_eq!(ring_offset(12, 4), 153);
+
+        assert_eq!(ring_offset(8, 8), 113);
+        assert_eq!(ring_offset(24, 8), 625);
+    }
+
+    #[test]
+    fn test_encode_vertex() {
+        // north polar cap
+        assert_eq!(encode_vertex(0, 0.0, 1.0, VertexIdScheme::Ring), 1);
+        assert_eq!(encode_vertex(1, 0.5, 1.5, VertexIdScheme::Ring), 1);
+        assert_eq!(encode_vertex(2, 2.75, 1.75, VertexIdScheme::Ring), 2);
+        assert_eq!(encode_vertex(2, 1.0, 1.5, VertexIdScheme::Ring), 6);
+    }
+}

--- a/rust/healpix-geo-core/src/mesh.rs
+++ b/rust/healpix-geo-core/src/mesh.rs
@@ -1,0 +1,35 @@
+//! Common functionality to convert a cell region to a mesh
+//!
+//! Meshes in the sense of the UGRID conventions require two things:
+//!
+//! - a list of deduplicated vertex coordinates
+//! - indices into the vertex coordinates that form the mesh geometry
+//!
+//! To convert a cell region (given as a list of cell ids), we need to be able to:
+//!
+//! - compute global vertex ids given a cell ids
+//! - compute coordinates for the global vertex ids
+//! - convert vertex ids to indices
+//!
+//! For the vertex ids, there are a few choices:
+//!
+//! - ring: north pole is 0, numbering along rings of equal latitude
+//! - nested: each base cell contains the southeastern and northeastern boundaries, and on
+//!   conflicts the northernmost base cell wins. The poles are part of the 0th and 11th base cells.
+//! - Try to use a Hilbert curve instead. For this, we somehow need to deal with the jumps in the
+//!   healpix projection space.
+//!
+//! The functionality here requires each indexing scheme to implement a function that, given a cell id,
+//! computes the vertex ids (possibly shared by converting to `(nested, depth)` or `(face, x, y, depth)` first).
+//!
+//! For example: vertex_hashes(hash: u64) -> [u64; 4]
+//!
+//! Other functions:
+//! - vertex_indices: deduplicate the vertex ids and construct the mesh connectivity
+//! - vertex coordinates: given a vertex id, compute the vertex coordinates
+
+/// Deduplicate and sort the given vertex ids
+pub fn vertex_indices(ipix: &[[u64; 4]]) -> (Vec<u64>, Vec<[usize; 4]>) {}
+
+/// Convert a vertex id to coordinates
+pub fn vertex_coordinates(hash: u64) -> (f64, f64) {}

--- a/rust/healpix-geo-core/src/mesh.rs
+++ b/rust/healpix-geo-core/src/mesh.rs
@@ -28,7 +28,7 @@
 //! - vertex_indices: deduplicate the vertex ids and construct the mesh connectivity
 //! - vertex coordinates: given a vertex id, compute the vertex coordinates
 use cdshealpix as healpix;
-// use cdshealpix::unproj;
+use cdshealpix::unproj;
 
 // type CellVertices = (u64, u64, u64, u64);
 // type CellIndices = (usize, usize, usize, usize);
@@ -156,17 +156,40 @@ fn decode_vertex(depth: u8, vertex_id: u64, scheme: VertexIdScheme) -> (f64, f64
     }
 }
 
+pub fn vertex_indices(depth: u8, hash: u64) -> (u64, u64, u64, u64) {
+    let layer = healpix::nested::get(depth);
+
+    let [(x_s, y_s), (x_e, y_e), (x_n, y_n), (x_w, y_w)] = layer.projected_vertices(hash);
+
+    (
+        encode_vertex(depth, x_s, y_s, VertexIdScheme::Ring),
+        encode_vertex(depth, x_e, y_e, VertexIdScheme::Ring),
+        encode_vertex(depth, x_n, y_n, VertexIdScheme::Ring),
+        encode_vertex(depth, x_w, y_w, VertexIdScheme::Ring),
+    )
+}
+
 // /// Deduplicate and sort the given vertex ids
 // pub fn vertex_indices(ipix: &[CellVertices]) -> (Vec<u64>, Vec<CellIndices>) {}
 
-// /// Convert a vertex id to coordinates
-// pub fn vertex_coordinates(hash: u64) -> (f64, f64) {
-//     // convert vertex hash to (face, x, y)
-//     // - convert the vertex id into (face, x, y, depth, corner-kind)
-//     // - from there, convert to (x, y) healpix plane coordinates (offset from the healpix
-//     //   center coordinate is 1 / 2**depth)
-//     // - use `unproj` to compute the geographic coordinates
-// }
+/// Convert a vertex id to coordinates
+pub fn vertex_coordinates(depth: u8, hash: u64) -> (f64, f64) {
+    // convert vertex hash to (face, x, y)
+    // - convert the vertex id into (face, x, y, depth, corner-kind)
+    // - from there, convert to (x, y) healpix plane coordinates (offset from the healpix
+    //   center coordinate is 1 / 2**depth)
+    // - use `unproj` to compute the geographic coordinates
+    let (x, y) = decode_vertex(depth, hash, VertexIdScheme::Ring);
+    if y == 2.0 {
+        (0.0, 90.0)
+    } else if y == -2.0 {
+        (0.0, -90.0)
+    } else {
+        let (lon, lat) = unproj(x, y);
+
+        (lon.to_degrees(), lat.to_degrees())
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -528,5 +551,28 @@ mod tests {
         assert_eq!(decode_vertex(1, 5, VertexIdScheme::Ring), (0.0, 1.0));
         assert_eq!(decode_vertex(2, 25, VertexIdScheme::Ring), (0.0, 1.0));
         assert_eq!(decode_vertex(2, 41, VertexIdScheme::Ring), (0.25, 0.75));
+    }
+
+    #[test]
+    fn test_vertex_coordinates() {
+        assert_eq!(vertex_coordinates(0, 0), (0.0, 90.0));
+        assert_eq!(vertex_coordinates(0, 13), (0.0, -90.0));
+        assert_eq!(
+            vertex_coordinates(0, 1),
+            (0.0, healpix::TRANSITION_LATITUDE.to_degrees())
+        );
+
+        assert_eq!(
+            vertex_coordinates(3, 113),
+            (0.0, healpix::TRANSITION_LATITUDE.to_degrees())
+        );
+    }
+
+    #[test]
+    fn test_vertex_indices() {
+        assert_eq!(vertex_indices(0, 0), (5, 2, 0, 1));
+        assert_eq!(vertex_indices(0, 1), (6, 3, 0, 2));
+
+        assert_eq!(vertex_indices(1, 7), (8, 3, 0, 2));
     }
 }

--- a/rust/healpix-geo-core/src/mesh.rs
+++ b/rust/healpix-geo-core/src/mesh.rs
@@ -44,22 +44,8 @@ const fn triangular_number_x4(n: u64) -> u64 {
 }
 
 #[inline]
-const fn polar_cap_vertices(nside: u32) -> u64 {
-    triangular_number_x4(nside as u64 - 1) + 1
-}
-
-#[inline]
 fn ring(y: f64, nside: u32) -> u64 {
     ((y + 2.0) * nside as f64).floor() as u64
-}
-
-#[inline]
-fn first_node_in_ring(ring: u64, nside: u64) -> f64 {
-    if ring < nside || (nside >= 2 * nside && nside < 3 * nside) {
-        1.0 - ring.rem_euclid(nside) as f64 / nside as f64
-    } else {
-        ring.rem_euclid(nside) as f64 / nside as f64
-    }
 }
 
 #[inline]
@@ -84,25 +70,17 @@ fn in_ring_position(x: f64, ring: u64, nside: u64) -> u64 {
 }
 
 #[inline]
-const fn equatorial_vertices(nside: u32) -> u64 {
-    let nside = nside as u64;
-    let rings = 2 * nside + 1;
-
-    rings * 4 * nside
-}
-
-#[inline]
 fn ring_offset(ring: u64, nside: u64) -> u64 {
     let pole_distance = ring.min(4 * nside - ring);
 
     if ring == 0 {
         0
     } else if ring < nside {
-        1 + 2 * pole_distance * (pole_distance - 1)
+        1 + triangular_number_x4(pole_distance - 1)
     } else if ring > 3 * nside {
-        12 * nside.pow(2) + 1 - 2 * (pole_distance + 1) * pole_distance
+        12 * nside.pow(2) + 1 - triangular_number_x4(pole_distance)
     } else {
-        1 + 2 * nside * (nside - 1) + 4 * nside * (ring - nside)
+        1 + triangular_number_x4(nside - 1) + 4 * nside * (ring - nside)
     }
 }
 
@@ -142,30 +120,6 @@ fn encode_vertex(depth: u8, x: f64, y: f64, scheme: VertexIdScheme) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_polar_cap_vertices() {
-        let actual = polar_cap_vertices(1);
-        assert_eq!(actual, 1);
-
-        let actual = polar_cap_vertices(2);
-        assert_eq!(actual, 5);
-
-        let actual = polar_cap_vertices(4);
-        assert_eq!(actual, 25);
-    }
-
-    #[test]
-    fn test_equatorial_vertices() {
-        let actual = equatorial_vertices(1);
-        assert_eq!(actual, 12);
-
-        let actual = equatorial_vertices(2);
-        assert_eq!(actual, 40);
-
-        let actual = equatorial_vertices(4);
-        assert_eq!(actual, 144);
-    }
 
     #[test]
     fn test_in_ring_position_nside_1_polar_caps() {

--- a/rust/healpix-geo-core/src/mesh.rs
+++ b/rust/healpix-geo-core/src/mesh.rs
@@ -22,14 +22,17 @@
 //! The functionality here requires each indexing scheme to implement a function that, given a cell id,
 //! computes the vertex ids (possibly shared by converting to `(nested, depth)` or `(face, x, y, depth)` first).
 //!
-//! For example: vertex_hashes(hash: u64) -> [u64; 4]
+//! For example: vertex_hashes(hash: u64) -> CellVertices
 //!
 //! Other functions:
 //! - vertex_indices: deduplicate the vertex ids and construct the mesh connectivity
 //! - vertex coordinates: given a vertex id, compute the vertex coordinates
 
+type CellVertices = (u64, u64, u64, u64);
+type CellIndices = (usize, usize, usize, usize);
+
 /// Deduplicate and sort the given vertex ids
-pub fn vertex_indices(ipix: &[[u64; 4]]) -> (Vec<u64>, Vec<[usize; 4]>) {}
+pub fn vertex_indices(ipix: &[CellVertices]) -> (Vec<u64>, Vec<CellIndices>) {}
 
 /// Convert a vertex id to coordinates
 pub fn vertex_coordinates(hash: u64) -> (f64, f64) {}

--- a/rust/healpix-geo-core/src/mesh.rs
+++ b/rust/healpix-geo-core/src/mesh.rs
@@ -49,7 +49,7 @@ fn ring(y: f64, nside: u32) -> u64 {
 }
 
 #[inline]
-fn in_ring_position(x: f64, ring: u64, nside: u64) -> u64 {
+fn encode_in_ring_position(x: f64, ring: u64, nside: u64) -> u64 {
     let pole_distance = ring.min(4 * nside - ring);
 
     if pole_distance == 0 {
@@ -61,11 +61,37 @@ fn in_ring_position(x: f64, ring: u64, nside: u64) -> u64 {
 
         (nside as f64 / 2.0 * reduced_x.rem_euclid(collapsed_size)).floor() as u64
     } else {
-        let phase = if nside == 1 { 0 } else { ring.rem_euclid(2) };
+        let phase = if nside == 1 {
+            (ring + 1).rem_euclid(2)
+        } else {
+            ring.rem_euclid(2)
+        };
         let reduced_x = x - phase as f64 / nside as f64;
 
-        let collapsed_ring_size = 8.0 - phase as f64 / nside as f64;
-        (nside as f64 / 2.0 * reduced_x.rem_euclid(collapsed_ring_size)).floor() as u64
+        let collapsed_size = 8.0 - phase as f64 / nside as f64;
+        (nside as f64 / 2.0 * reduced_x.rem_euclid(collapsed_size)).floor() as u64
+    }
+}
+
+#[inline]
+fn decode_in_ring_position(position: u64, ring: u64, nside: u64) -> f64 {
+    let pole_distance = ring.min(4 * nside - ring);
+
+    if pole_distance == 0 {
+        1.0
+    } else if pole_distance < nside {
+        let gap = 1.0 - pole_distance as f64 / nside as f64;
+        let completed_blocks = 2 * (position as f64 / pole_distance as f64).floor() as u64 + 1;
+
+        2.0 / nside as f64 * position as f64 + gap * completed_blocks as f64
+    } else {
+        let phase = if nside == 1 {
+            (ring + 1).rem_euclid(2)
+        } else {
+            ring.rem_euclid(2)
+        };
+
+        (2.0 * position as f64 + phase as f64) / nside as f64
     }
 }
 
@@ -94,10 +120,10 @@ fn encode_vertex(depth: u8, x: f64, y: f64, scheme: VertexIdScheme) -> u64 {
             println!(
                 "ring: {ring}, ({} + {}) ({nside})",
                 ring_offset(ring, nside),
-                in_ring_position(x, ring, nside)
+                encode_in_ring_position(x, ring, nside)
             );
 
-            ring_offset(ring, nside) + in_ring_position(x, ring, nside)
+            ring_offset(ring, nside) + encode_in_ring_position(x, ring, nside)
         }
         VertexIdScheme::ZOrder => todo!(),
     }
@@ -122,159 +148,307 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_in_ring_position_nside_1_polar_caps() {
+    fn test_encode_in_ring_position_nside_1_polar_cap() {
         // pole
-        assert_eq!(in_ring_position(1.0, 0, 1), 0);
-        assert_eq!(in_ring_position(3.0, 0, 1), 0);
-        assert_eq!(in_ring_position(5.0, 0, 1), 0);
-        assert_eq!(in_ring_position(7.0, 0, 1), 0);
+        assert_eq!(encode_in_ring_position(1.0, 0, 1), 0);
+        assert_eq!(encode_in_ring_position(3.0, 0, 1), 0);
+        assert_eq!(encode_in_ring_position(5.0, 0, 1), 0);
+        assert_eq!(encode_in_ring_position(7.0, 0, 1), 0);
 
-        assert_eq!(in_ring_position(1.0, 4, 1), 0);
+        assert_eq!(encode_in_ring_position(1.0, 4, 1), 0);
     }
 
     #[test]
-    fn test_in_ring_position_nside_1_equatorial_region() {
+    fn test_decode_in_ring_position_nside_1_polar_cap() {
+        assert_eq!(decode_in_ring_position(0, 0, 1), 1.0);
+
+        assert_eq!(decode_in_ring_position(0, 4, 1), 1.0);
+    }
+
+    #[test]
+    fn test_encode_in_ring_position_nside_1_equatorial_region() {
         // equatorial region
-        assert_eq!(in_ring_position(0.0, 1, 1), 0);
-        assert_eq!(in_ring_position(4.0, 1, 1), 2);
-        assert_eq!(in_ring_position(8.0, 1, 1), 0);
+        assert_eq!(encode_in_ring_position(0.0, 1, 1), 0);
+        assert_eq!(encode_in_ring_position(4.0, 1, 1), 2);
+        assert_eq!(encode_in_ring_position(8.0, 1, 1), 0);
 
-        assert_eq!(in_ring_position(1.0, 2, 1), 0);
-        assert_eq!(in_ring_position(7.0, 2, 1), 3);
+        assert_eq!(encode_in_ring_position(1.0, 2, 1), 0);
+        assert_eq!(encode_in_ring_position(7.0, 2, 1), 3);
     }
 
     #[test]
-    fn test_in_ring_position_nside_2_polar_cap() {
+    fn test_decode_in_ring_position_nside_1_equatorial_region() {
+        // equatorial region
+        assert_eq!(decode_in_ring_position(0, 1, 1), 0.0);
+        assert_eq!(decode_in_ring_position(2, 1, 1), 4.0);
+        // assert_eq!(decode_in_ring_position(0, 1, 1), 8.0);
+
+        assert_eq!(decode_in_ring_position(0, 2, 1), 1.0);
+        assert_eq!(decode_in_ring_position(3, 2, 1), 7.0);
+        assert_eq!(decode_in_ring_position(0, 3, 1), 0.0);
+    }
+
+    #[test]
+    fn test_encode_in_ring_position_nside_2_polar_cap() {
         // pole
-        assert_eq!(in_ring_position(1.0, 0, 2), 0);
+        assert_eq!(encode_in_ring_position(1.0, 0, 2), 0);
         // polar cap
-        assert_eq!(in_ring_position(0.5, 1, 2), 0);
-        assert_eq!(in_ring_position(1.5, 1, 2), 1);
-        assert_eq!(in_ring_position(2.5, 1, 2), 1);
-        assert_eq!(in_ring_position(3.5, 1, 2), 2);
-        assert_eq!(in_ring_position(4.5, 1, 2), 2);
-        assert_eq!(in_ring_position(5.5, 1, 2), 3);
-        assert_eq!(in_ring_position(6.5, 1, 2), 3);
-        assert_eq!(in_ring_position(7.5, 1, 2), 0);
+        assert_eq!(encode_in_ring_position(0.5, 1, 2), 0);
+        assert_eq!(encode_in_ring_position(1.5, 1, 2), 1);
+        assert_eq!(encode_in_ring_position(2.5, 1, 2), 1);
+        assert_eq!(encode_in_ring_position(3.5, 1, 2), 2);
+        assert_eq!(encode_in_ring_position(4.5, 1, 2), 2);
+        assert_eq!(encode_in_ring_position(5.5, 1, 2), 3);
+        assert_eq!(encode_in_ring_position(6.5, 1, 2), 3);
+        assert_eq!(encode_in_ring_position(7.5, 1, 2), 0);
     }
 
     #[test]
-    fn test_in_ring_position_nside_2_equatorial_region() {
-        // equatorial region
-        assert_eq!(in_ring_position(0.0, 2, 2), 0);
-        assert_eq!(in_ring_position(1.0, 2, 2), 1);
-        assert_eq!(in_ring_position(2.0, 2, 2), 2);
-        assert_eq!(in_ring_position(3.0, 2, 2), 3);
-        assert_eq!(in_ring_position(4.0, 2, 2), 4);
-        assert_eq!(in_ring_position(5.0, 2, 2), 5);
-        assert_eq!(in_ring_position(6.0, 2, 2), 6);
-        assert_eq!(in_ring_position(7.0, 2, 2), 7);
-        assert_eq!(in_ring_position(8.0, 2, 2), 0);
-    }
-
-    #[test]
-    fn test_in_ring_position_nside_4_polar_cap() {
-        assert_eq!(in_ring_position(0.75, 1, 4), 0);
-        assert_eq!(in_ring_position(1.25, 1, 4), 1);
-        assert_eq!(in_ring_position(2.75, 1, 4), 1);
-        assert_eq!(in_ring_position(3.25, 1, 4), 2);
-        assert_eq!(in_ring_position(4.75, 1, 4), 2);
-        assert_eq!(in_ring_position(5.25, 1, 4), 3);
-        assert_eq!(in_ring_position(6.75, 1, 4), 3);
-        assert_eq!(in_ring_position(7.25, 1, 4), 0);
-
-        assert_eq!(in_ring_position(0.25, 3, 4), 0);
-        assert_eq!(in_ring_position(0.75, 3, 4), 1);
-        assert_eq!(in_ring_position(1.25, 3, 4), 2);
-        assert_eq!(in_ring_position(1.75, 3, 4), 3);
-        assert_eq!(in_ring_position(2.25, 3, 4), 3);
-        assert_eq!(in_ring_position(2.75, 3, 4), 4);
-        assert_eq!(in_ring_position(3.25, 3, 4), 5);
-        assert_eq!(in_ring_position(3.75, 3, 4), 6);
-        assert_eq!(in_ring_position(4.25, 3, 4), 6);
-        assert_eq!(in_ring_position(4.75, 3, 4), 7);
-        assert_eq!(in_ring_position(5.25, 3, 4), 8);
-        assert_eq!(in_ring_position(5.75, 3, 4), 9);
-        assert_eq!(in_ring_position(6.25, 3, 4), 9);
-        assert_eq!(in_ring_position(6.75, 3, 4), 10);
-        assert_eq!(in_ring_position(7.25, 3, 4), 11);
-        assert_eq!(in_ring_position(7.75, 3, 4), 0);
-    }
-
-    #[test]
-    fn test_in_ring_position_nside_4_equatorial_region() {
-        assert_eq!(in_ring_position(0.0, 4, 4), 0);
-        assert_eq!(in_ring_position(0.5, 4, 4), 1);
-        assert_eq!(in_ring_position(1.0, 4, 4), 2);
-        assert_eq!(in_ring_position(1.5, 4, 4), 3);
-        assert_eq!(in_ring_position(2.0, 4, 4), 4);
-        assert_eq!(in_ring_position(2.5, 4, 4), 5);
-        assert_eq!(in_ring_position(3.0, 4, 4), 6);
-        assert_eq!(in_ring_position(3.5, 4, 4), 7);
-        assert_eq!(in_ring_position(4.0, 4, 4), 8);
-        assert_eq!(in_ring_position(4.5, 4, 4), 9);
-        assert_eq!(in_ring_position(5.0, 4, 4), 10);
-        assert_eq!(in_ring_position(5.5, 4, 4), 11);
-        assert_eq!(in_ring_position(6.0, 4, 4), 12);
-        assert_eq!(in_ring_position(6.5, 4, 4), 13);
-        assert_eq!(in_ring_position(7.0, 4, 4), 14);
-        assert_eq!(in_ring_position(7.5, 4, 4), 15);
-        assert_eq!(in_ring_position(8.0, 4, 4), 0);
-
-        assert_eq!(in_ring_position(0.25, 5, 4), 0);
-        assert_eq!(in_ring_position(0.75, 5, 4), 1);
-        assert_eq!(in_ring_position(1.25, 5, 4), 2);
-        assert_eq!(in_ring_position(1.75, 5, 4), 3);
-        assert_eq!(in_ring_position(2.25, 5, 4), 4);
-        assert_eq!(in_ring_position(2.75, 5, 4), 5);
-        assert_eq!(in_ring_position(3.25, 5, 4), 6);
-        assert_eq!(in_ring_position(3.75, 5, 4), 7);
-        assert_eq!(in_ring_position(4.25, 5, 4), 8);
-        assert_eq!(in_ring_position(4.75, 5, 4), 9);
-        assert_eq!(in_ring_position(5.25, 5, 4), 10);
-        assert_eq!(in_ring_position(5.75, 5, 4), 11);
-        assert_eq!(in_ring_position(6.25, 5, 4), 12);
-        assert_eq!(in_ring_position(6.75, 5, 4), 13);
-        assert_eq!(in_ring_position(7.25, 5, 4), 14);
-        assert_eq!(in_ring_position(7.75, 5, 4), 15);
-    }
-
-    #[test]
-    fn test_in_ring_position_nside_8_polar_caps() {
+    fn test_decode_in_ring_position_nside_2_polar_cap() {
+        // pole
+        assert_eq!(decode_in_ring_position(0, 0, 2), 1.0);
         // polar cap
-        assert_eq!(in_ring_position(0.875, 1, 8), 0);
-        assert_eq!(in_ring_position(2.875, 1, 8), 1);
-        assert_eq!(in_ring_position(4.875, 1, 8), 2);
-        assert_eq!(in_ring_position(6.875, 1, 8), 3);
-
-        assert_eq!(in_ring_position(0.125, 7, 8), 0);
-        assert_eq!(in_ring_position(0.375, 7, 8), 1);
-        assert_eq!(in_ring_position(0.875, 7, 8), 3);
-        assert_eq!(in_ring_position(1.875, 7, 8), 7);
-        assert_eq!(in_ring_position(2.125, 7, 8), 7);
-        assert_eq!(in_ring_position(3.125, 7, 8), 11);
-        assert_eq!(in_ring_position(3.875, 7, 8), 14);
-        assert_eq!(in_ring_position(5.125, 7, 8), 18);
-        assert_eq!(in_ring_position(6.125, 7, 8), 21);
-        assert_eq!(in_ring_position(7.125, 7, 8), 25);
-        assert_eq!(in_ring_position(7.875, 7, 8), 0);
+        assert_eq!(decode_in_ring_position(0, 1, 2), 0.5);
+        assert_eq!(decode_in_ring_position(1, 1, 2), 2.5);
+        assert_eq!(decode_in_ring_position(2, 1, 2), 4.5);
+        assert_eq!(decode_in_ring_position(3, 1, 2), 6.5);
     }
 
     #[test]
-    fn test_in_ring_position_nside_8_equatorial_region() {
+    fn test_encode_in_ring_position_nside_2_equatorial_region() {
         // equatorial region
-        assert_eq!(in_ring_position(0.00, 8, 8), 0);
-        assert_eq!(in_ring_position(0.25, 8, 8), 1);
-        assert_eq!(in_ring_position(1.00, 8, 8), 4);
-        assert_eq!(in_ring_position(2.00, 8, 8), 8);
-        assert_eq!(in_ring_position(4.00, 8, 8), 16);
-        assert_eq!(in_ring_position(7.75, 8, 8), 31);
-        assert_eq!(in_ring_position(0.125, 9, 8), 0);
-        assert_eq!(in_ring_position(0.375, 9, 8), 1);
-        assert_eq!(in_ring_position(1.125, 9, 8), 4);
-        assert_eq!(in_ring_position(2.125, 9, 8), 8);
-        assert_eq!(in_ring_position(4.125, 9, 8), 16);
-        assert_eq!(in_ring_position(7.875, 9, 8), 31);
+        assert_eq!(encode_in_ring_position(0.0, 2, 2), 0);
+        assert_eq!(encode_in_ring_position(1.0, 2, 2), 1);
+        assert_eq!(encode_in_ring_position(2.0, 2, 2), 2);
+        assert_eq!(encode_in_ring_position(3.0, 2, 2), 3);
+        assert_eq!(encode_in_ring_position(4.0, 2, 2), 4);
+        assert_eq!(encode_in_ring_position(5.0, 2, 2), 5);
+        assert_eq!(encode_in_ring_position(6.0, 2, 2), 6);
+        assert_eq!(encode_in_ring_position(7.0, 2, 2), 7);
+        assert_eq!(encode_in_ring_position(8.0, 2, 2), 0);
+    }
+
+    #[test]
+    fn test_decode_in_ring_position_nside_2_equatorial_region() {
+        // equatorial region
+        assert_eq!(decode_in_ring_position(0, 2, 2), 0.0);
+        assert_eq!(decode_in_ring_position(1, 2, 2), 1.0);
+        assert_eq!(decode_in_ring_position(2, 2, 2), 2.0);
+        assert_eq!(decode_in_ring_position(3, 2, 2), 3.0);
+        assert_eq!(decode_in_ring_position(4, 2, 2), 4.0);
+        assert_eq!(decode_in_ring_position(5, 2, 2), 5.0);
+        assert_eq!(decode_in_ring_position(6, 2, 2), 6.0);
+        assert_eq!(decode_in_ring_position(7, 2, 2), 7.0);
+    }
+
+    #[test]
+    fn test_encode_in_ring_position_nside_4_polar_cap() {
+        assert_eq!(encode_in_ring_position(0.75, 1, 4), 0);
+        assert_eq!(encode_in_ring_position(1.25, 1, 4), 1);
+        assert_eq!(encode_in_ring_position(2.75, 1, 4), 1);
+        assert_eq!(encode_in_ring_position(3.25, 1, 4), 2);
+        assert_eq!(encode_in_ring_position(4.75, 1, 4), 2);
+        assert_eq!(encode_in_ring_position(5.25, 1, 4), 3);
+        assert_eq!(encode_in_ring_position(6.75, 1, 4), 3);
+        assert_eq!(encode_in_ring_position(7.25, 1, 4), 0);
+
+        assert_eq!(encode_in_ring_position(0.25, 3, 4), 0);
+        assert_eq!(encode_in_ring_position(0.75, 3, 4), 1);
+        assert_eq!(encode_in_ring_position(1.25, 3, 4), 2);
+        assert_eq!(encode_in_ring_position(1.75, 3, 4), 3);
+        assert_eq!(encode_in_ring_position(2.25, 3, 4), 3);
+        assert_eq!(encode_in_ring_position(2.75, 3, 4), 4);
+        assert_eq!(encode_in_ring_position(3.25, 3, 4), 5);
+        assert_eq!(encode_in_ring_position(3.75, 3, 4), 6);
+        assert_eq!(encode_in_ring_position(4.25, 3, 4), 6);
+        assert_eq!(encode_in_ring_position(4.75, 3, 4), 7);
+        assert_eq!(encode_in_ring_position(5.25, 3, 4), 8);
+        assert_eq!(encode_in_ring_position(5.75, 3, 4), 9);
+        assert_eq!(encode_in_ring_position(6.25, 3, 4), 9);
+        assert_eq!(encode_in_ring_position(6.75, 3, 4), 10);
+        assert_eq!(encode_in_ring_position(7.25, 3, 4), 11);
+        assert_eq!(encode_in_ring_position(7.75, 3, 4), 0);
+    }
+
+    #[test]
+    fn test_decode_in_ring_position_nside_4_polar_cap() {
+        assert_eq!(decode_in_ring_position(0, 1, 4), 0.75);
+        assert_eq!(decode_in_ring_position(1, 1, 4), 2.75);
+        assert_eq!(decode_in_ring_position(2, 1, 4), 4.75);
+        assert_eq!(decode_in_ring_position(3, 1, 4), 6.75);
+
+        assert_eq!(decode_in_ring_position(0, 2, 4), 0.5);
+        assert_eq!(decode_in_ring_position(1, 2, 4), 1.0);
+        assert_eq!(decode_in_ring_position(2, 2, 4), 2.5);
+
+        assert_eq!(decode_in_ring_position(0, 3, 4), 0.25);
+        assert_eq!(decode_in_ring_position(1, 3, 4), 0.75);
+        assert_eq!(decode_in_ring_position(2, 3, 4), 1.25);
+        // assert_eq!(decode_in_ring_position(3, 3, 4), 1.75);
+        assert_eq!(decode_in_ring_position(3, 3, 4), 2.25);
+        assert_eq!(decode_in_ring_position(4, 3, 4), 2.75);
+        assert_eq!(decode_in_ring_position(5, 3, 4), 3.25);
+        // assert_eq!(decode_in_ring_position(6, 3, 4), 3.75);
+        assert_eq!(decode_in_ring_position(6, 3, 4), 4.25);
+        assert_eq!(decode_in_ring_position(7, 3, 4), 4.75);
+        assert_eq!(decode_in_ring_position(8, 3, 4), 5.25);
+        // assert_eq!(decode_in_ring_position(9, 3, 4), 5.75);
+        assert_eq!(decode_in_ring_position(9, 3, 4), 6.25);
+        assert_eq!(decode_in_ring_position(10, 3, 4), 6.75);
+        assert_eq!(decode_in_ring_position(11, 3, 4), 7.25);
+    }
+
+    #[test]
+    fn test_encode_in_ring_position_nside_4_equatorial_region() {
+        assert_eq!(encode_in_ring_position(0.0, 4, 4), 0);
+        assert_eq!(encode_in_ring_position(0.5, 4, 4), 1);
+        assert_eq!(encode_in_ring_position(1.0, 4, 4), 2);
+        assert_eq!(encode_in_ring_position(1.5, 4, 4), 3);
+        assert_eq!(encode_in_ring_position(2.0, 4, 4), 4);
+        assert_eq!(encode_in_ring_position(2.5, 4, 4), 5);
+        assert_eq!(encode_in_ring_position(3.0, 4, 4), 6);
+        assert_eq!(encode_in_ring_position(3.5, 4, 4), 7);
+        assert_eq!(encode_in_ring_position(4.0, 4, 4), 8);
+        assert_eq!(encode_in_ring_position(4.5, 4, 4), 9);
+        assert_eq!(encode_in_ring_position(5.0, 4, 4), 10);
+        assert_eq!(encode_in_ring_position(5.5, 4, 4), 11);
+        assert_eq!(encode_in_ring_position(6.0, 4, 4), 12);
+        assert_eq!(encode_in_ring_position(6.5, 4, 4), 13);
+        assert_eq!(encode_in_ring_position(7.0, 4, 4), 14);
+        assert_eq!(encode_in_ring_position(7.5, 4, 4), 15);
+        assert_eq!(encode_in_ring_position(8.0, 4, 4), 0);
+
+        assert_eq!(encode_in_ring_position(0.25, 5, 4), 0);
+        assert_eq!(encode_in_ring_position(0.75, 5, 4), 1);
+        assert_eq!(encode_in_ring_position(1.25, 5, 4), 2);
+        assert_eq!(encode_in_ring_position(1.75, 5, 4), 3);
+        assert_eq!(encode_in_ring_position(2.25, 5, 4), 4);
+        assert_eq!(encode_in_ring_position(2.75, 5, 4), 5);
+        assert_eq!(encode_in_ring_position(3.25, 5, 4), 6);
+        assert_eq!(encode_in_ring_position(3.75, 5, 4), 7);
+        assert_eq!(encode_in_ring_position(4.25, 5, 4), 8);
+        assert_eq!(encode_in_ring_position(4.75, 5, 4), 9);
+        assert_eq!(encode_in_ring_position(5.25, 5, 4), 10);
+        assert_eq!(encode_in_ring_position(5.75, 5, 4), 11);
+        assert_eq!(encode_in_ring_position(6.25, 5, 4), 12);
+        assert_eq!(encode_in_ring_position(6.75, 5, 4), 13);
+        assert_eq!(encode_in_ring_position(7.25, 5, 4), 14);
+        assert_eq!(encode_in_ring_position(7.75, 5, 4), 15);
+    }
+
+    #[test]
+    fn test_decode_in_ring_position_nside_4_equatorial_region() {
+        assert_eq!(decode_in_ring_position(0, 4, 4), 0.0);
+        assert_eq!(decode_in_ring_position(1, 4, 4), 0.5);
+        assert_eq!(decode_in_ring_position(2, 4, 4), 1.0);
+        assert_eq!(decode_in_ring_position(3, 4, 4), 1.5);
+        assert_eq!(decode_in_ring_position(4, 4, 4), 2.0);
+        assert_eq!(decode_in_ring_position(5, 4, 4), 2.5);
+        assert_eq!(decode_in_ring_position(6, 4, 4), 3.0);
+        assert_eq!(decode_in_ring_position(7, 4, 4), 3.5);
+        assert_eq!(decode_in_ring_position(8, 4, 4), 4.0);
+        assert_eq!(decode_in_ring_position(9, 4, 4), 4.5);
+        assert_eq!(decode_in_ring_position(10, 4, 4), 5.0);
+        assert_eq!(decode_in_ring_position(11, 4, 4), 5.5);
+        assert_eq!(decode_in_ring_position(12, 4, 4), 6.0);
+        assert_eq!(decode_in_ring_position(13, 4, 4), 6.5);
+        assert_eq!(decode_in_ring_position(14, 4, 4), 7.0);
+        assert_eq!(decode_in_ring_position(15, 4, 4), 7.5);
+        // assert_eq!(decode_in_ring_position(0, 4, 4), 8.0);
+
+        assert_eq!(decode_in_ring_position(0, 5, 4), 0.25);
+        assert_eq!(decode_in_ring_position(1, 5, 4), 0.75);
+        assert_eq!(decode_in_ring_position(2, 5, 4), 1.25);
+        assert_eq!(decode_in_ring_position(3, 5, 4), 1.75);
+        assert_eq!(decode_in_ring_position(4, 5, 4), 2.25);
+        assert_eq!(decode_in_ring_position(5, 5, 4), 2.75);
+        assert_eq!(decode_in_ring_position(6, 5, 4), 3.25);
+        assert_eq!(decode_in_ring_position(7, 5, 4), 3.75);
+        assert_eq!(decode_in_ring_position(8, 5, 4), 4.25);
+        assert_eq!(decode_in_ring_position(9, 5, 4), 4.75);
+        assert_eq!(decode_in_ring_position(10, 5, 4), 5.25);
+        assert_eq!(decode_in_ring_position(11, 5, 4), 5.75);
+        assert_eq!(decode_in_ring_position(12, 5, 4), 6.25);
+        assert_eq!(decode_in_ring_position(13, 5, 4), 6.75);
+        assert_eq!(decode_in_ring_position(14, 5, 4), 7.25);
+        assert_eq!(decode_in_ring_position(15, 5, 4), 7.75);
+    }
+
+    #[test]
+    fn test_encode_in_ring_position_nside_8_polar_cap() {
+        // polar cap
+        assert_eq!(encode_in_ring_position(0.875, 1, 8), 0);
+        assert_eq!(encode_in_ring_position(2.875, 1, 8), 1);
+        assert_eq!(encode_in_ring_position(4.875, 1, 8), 2);
+        assert_eq!(encode_in_ring_position(6.875, 1, 8), 3);
+
+        assert_eq!(encode_in_ring_position(0.125, 7, 8), 0);
+        assert_eq!(encode_in_ring_position(0.375, 7, 8), 1);
+        assert_eq!(encode_in_ring_position(0.875, 7, 8), 3);
+        assert_eq!(encode_in_ring_position(1.875, 7, 8), 7);
+        assert_eq!(encode_in_ring_position(2.125, 7, 8), 7);
+        assert_eq!(encode_in_ring_position(3.125, 7, 8), 11);
+        assert_eq!(encode_in_ring_position(3.875, 7, 8), 14);
+        assert_eq!(encode_in_ring_position(5.125, 7, 8), 18);
+        assert_eq!(encode_in_ring_position(6.125, 7, 8), 21);
+        assert_eq!(encode_in_ring_position(7.125, 7, 8), 25);
+        assert_eq!(encode_in_ring_position(7.875, 7, 8), 0);
+    }
+
+    #[test]
+    fn test_decode_in_ring_position_nside_8_polar_cap() {
+        // polar cap
+        assert_eq!(decode_in_ring_position(0, 1, 8), 0.875);
+        assert_eq!(decode_in_ring_position(1, 1, 8), 2.875);
+        assert_eq!(decode_in_ring_position(2, 1, 8), 4.875);
+        assert_eq!(decode_in_ring_position(3, 1, 8), 6.875);
+
+        assert_eq!(decode_in_ring_position(0, 7, 8), 0.125);
+        assert_eq!(decode_in_ring_position(1, 7, 8), 0.375);
+        assert_eq!(decode_in_ring_position(3, 7, 8), 0.875);
+        // assert_eq!(decode_in_ring_position(7, 7, 8), 1.875);
+        assert_eq!(decode_in_ring_position(7, 7, 8), 2.125);
+        assert_eq!(decode_in_ring_position(11, 7, 8), 3.125);
+        //assert_eq!(decode_in_ring_position(14, 7, 8), 3.875);
+        assert_eq!(decode_in_ring_position(14, 7, 8), 4.125);
+        assert_eq!(decode_in_ring_position(18, 7, 8), 5.125);
+        assert_eq!(decode_in_ring_position(21, 7, 8), 6.125);
+        assert_eq!(decode_in_ring_position(25, 7, 8), 7.125);
+        // assert_eq!(decode_in_ring_position(0, 7, 8), 7.875);
+    }
+
+    #[test]
+    fn test_encode_in_ring_position_nside_8_equatorial_region() {
+        // equatorial region
+        assert_eq!(encode_in_ring_position(0.00, 8, 8), 0);
+        assert_eq!(encode_in_ring_position(0.25, 8, 8), 1);
+        assert_eq!(encode_in_ring_position(1.00, 8, 8), 4);
+        assert_eq!(encode_in_ring_position(2.00, 8, 8), 8);
+        assert_eq!(encode_in_ring_position(4.00, 8, 8), 16);
+        assert_eq!(encode_in_ring_position(7.75, 8, 8), 31);
+        assert_eq!(encode_in_ring_position(0.125, 9, 8), 0);
+        assert_eq!(encode_in_ring_position(0.375, 9, 8), 1);
+        assert_eq!(encode_in_ring_position(1.125, 9, 8), 4);
+        assert_eq!(encode_in_ring_position(2.125, 9, 8), 8);
+        assert_eq!(encode_in_ring_position(4.125, 9, 8), 16);
+        assert_eq!(encode_in_ring_position(7.875, 9, 8), 31);
+    }
+
+    #[test]
+    fn test_decode_in_ring_position_nside_8_equatorial_region() {
+        // equatorial region
+        assert_eq!(decode_in_ring_position(0, 8, 8), 0.00);
+        assert_eq!(decode_in_ring_position(1, 8, 8), 0.25);
+        assert_eq!(decode_in_ring_position(4, 8, 8), 1.00);
+        assert_eq!(decode_in_ring_position(8, 8, 8), 2.00);
+        assert_eq!(decode_in_ring_position(16, 8, 8), 4.00);
+        assert_eq!(decode_in_ring_position(31, 8, 8), 7.75);
+        assert_eq!(decode_in_ring_position(0, 9, 8), 0.125);
+        assert_eq!(decode_in_ring_position(1, 9, 8), 0.375);
+        assert_eq!(decode_in_ring_position(4, 9, 8), 1.125);
+        assert_eq!(decode_in_ring_position(8, 9, 8), 2.125);
+        assert_eq!(decode_in_ring_position(16, 9, 8), 4.125);
+        assert_eq!(decode_in_ring_position(31, 9, 8), 7.875);
     }
 
     #[test]

--- a/rust/healpix-geo-core/src/mesh.rs
+++ b/rust/healpix-geo-core/src/mesh.rs
@@ -44,11 +44,6 @@ const fn triangular_number_x4(n: u64) -> u64 {
 }
 
 #[inline]
-fn ring(y: f64, nside: u32) -> u64 {
-    ((y + 2.0) * nside as f64).floor() as u64
-}
-
-#[inline]
 fn encode_in_ring_position(x: f64, ring: u64, nside: u64) -> u64 {
     let pole_distance = ring.min(4 * nside - ring);
 
@@ -108,6 +103,21 @@ fn ring_offset(ring: u64, nside: u64) -> u64 {
     }
 }
 
+#[inline]
+fn extract_ring(vertex_id: u64, nside: u64, n_vertices: u64, triangular_number: u64) -> u64 {
+    if vertex_id == 0 {
+        0
+    } else if vertex_id == n_vertices - 1 {
+        4 * nside
+    } else if vertex_id < triangular_number + 1 {
+        ((1 + (2 * vertex_id - 1).isqrt()) as f64 / 2.0).ceil() as u64
+    } else if vertex_id > n_vertices - triangular_number - 1 {
+        4 * nside - (3 + (2 * (n_vertices - vertex_id) - 1).isqrt()) / 2
+    } else {
+        nside + (vertex_id - triangular_number - 1) / (4 * nside)
+    }
+}
+
 fn encode_vertex(depth: u8, x: f64, y: f64, scheme: VertexIdScheme) -> u64 {
     let nside = healpix::nside(depth) as u64;
 
@@ -115,19 +125,36 @@ fn encode_vertex(depth: u8, x: f64, y: f64, scheme: VertexIdScheme) -> u64 {
         VertexIdScheme::Ring => {
             let ring = (nside as f64 * (2.0 - y)).floor() as u64;
 
-            println!(
-                "ring: {ring}, ({} + {}) ({nside})",
-                ring_offset(ring, nside),
-                encode_in_ring_position(x, ring, nside)
-            );
-
             ring_offset(ring, nside) + encode_in_ring_position(x, ring, nside)
         }
         VertexIdScheme::ZOrder => todo!(),
     }
 }
 
-// fn decode_vertex(vertex_id: u64, scheme: VertexIdScheme) -> (f64, f64) {}
+fn decode_vertex(depth: u8, vertex_id: u64, scheme: VertexIdScheme) -> (f64, f64) {
+    let nside = healpix::nside(depth) as u64;
+
+    match scheme {
+        VertexIdScheme::Ring => {
+            let n_vertices = 12 * nside * nside + 2;
+            if vertex_id == 0 {
+                (1.0, 2.0)
+            } else if vertex_id == n_vertices - 1 {
+                (1.0, -2.0)
+            } else {
+                let triangular_number = triangular_number_x4(nside - 1);
+                let ring = extract_ring(vertex_id, nside, n_vertices, triangular_number);
+
+                let in_ring_offset = vertex_id - ring_offset(ring, nside);
+                let x = decode_in_ring_position(in_ring_offset, ring, nside);
+                let y = 2.0 - ring as f64 / nside as f64;
+
+                (x, y)
+            }
+        }
+        VertexIdScheme::ZOrder => todo!(),
+    }
+}
 
 // /// Deduplicate and sort the given vertex ids
 // pub fn vertex_indices(ipix: &[CellVertices]) -> (Vec<u64>, Vec<CellIndices>) {}
@@ -471,11 +498,35 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_ring() {
+        assert_eq!(extract_ring(0, 1, 14, 0), 0);
+        assert_eq!(extract_ring(1, 1, 14, 0), 1);
+        assert_eq!(extract_ring(6, 1, 14, 0), 2);
+        assert_eq!(extract_ring(13, 2, 50, 4), 3);
+    }
+
+    #[test]
     fn test_encode_vertex() {
         // north polar cap
         assert_eq!(encode_vertex(0, 0.0, 1.0, VertexIdScheme::Ring), 1);
         assert_eq!(encode_vertex(1, 0.5, 1.5, VertexIdScheme::Ring), 1);
         assert_eq!(encode_vertex(2, 2.75, 1.75, VertexIdScheme::Ring), 2);
         assert_eq!(encode_vertex(2, 1.0, 1.5, VertexIdScheme::Ring), 6);
+    }
+
+    #[test]
+    fn test_decode_vertex() {
+        assert_eq!(decode_vertex(0, 0, VertexIdScheme::Ring), (1.0, 2.0));
+        assert_eq!(decode_vertex(0, 13, VertexIdScheme::Ring), (1.0, -2.0));
+        // north polar cap
+        assert_eq!(decode_vertex(0, 1, VertexIdScheme::Ring), (0.0, 1.0));
+        assert_eq!(decode_vertex(1, 1, VertexIdScheme::Ring), (0.5, 1.5));
+        assert_eq!(decode_vertex(2, 2, VertexIdScheme::Ring), (2.75, 1.75));
+        assert_eq!(decode_vertex(2, 6, VertexIdScheme::Ring), (1.0, 1.5));
+
+        // equator
+        assert_eq!(decode_vertex(1, 5, VertexIdScheme::Ring), (0.0, 1.0));
+        assert_eq!(decode_vertex(2, 25, VertexIdScheme::Ring), (0.0, 1.0));
+        assert_eq!(decode_vertex(2, 41, VertexIdScheme::Ring), (0.25, 0.75));
     }
 }

--- a/rust/healpix-geo-core/src/scalar/mesh.rs
+++ b/rust/healpix-geo-core/src/scalar/mesh.rs
@@ -49,6 +49,11 @@ fn encode_in_ring_position(x: f64, ring: u64, nside: u64) -> u64 {
     if pole_distance == 0 {
         0
     } else if pole_distance < nside {
+        // original formula:
+        //   i = N / 2 * ( (x - (1 - d / N) (2 floor(x/2) + 1)) mod (8d / N) )
+        // floating-point optimized formula (uses only integer math)
+        //   m = Nx
+        //   i = ((m - (N - d) (2 (m/(2N)) + 1)) mod 4d) / 2
         let discretized_x = (nside as f64 * x) as u64;
         // integer division, the parens are significant
         let n_gaps = 2 * (discretized_x / (2 * nside)) + 1;
@@ -56,6 +61,11 @@ fn encode_in_ring_position(x: f64, ring: u64, nside: u64) -> u64 {
 
         reduced_x.rem_euclid(8 * pole_distance) / 2
     } else {
+        // original formula
+        //   p = (r + 1) mod 2 if N = 1, else r mod 2
+        //   i = N / 2 ((x - p / N) mod (8 - p / N))
+        // optimized formula (all integer arithmetic)
+        //   i = ((N x - p) mod (8N - p)) / 2
         let phase = if nside == 1 {
             (ring + 1).rem_euclid(2)
         } else {
@@ -75,12 +85,21 @@ fn decode_in_ring_position(position: u64, ring: u64, nside: u64) -> f64 {
     if pole_distance == 0 {
         1.0
     } else if pole_distance < nside {
+        // original formula:
+        //   x = 2 / N i + (1 - d / N) (2 floor(i / d) + 1)
+        // optimized formula (integer arithmetic except for the last division)
+        //   x = (2i + (N - d) (2 (i / d) + 1)) / N
+
         let gap = nside - pole_distance;
         // integer division, the parens are significant
         let completed_blocks = 2 * (position / pole_distance) + 1;
 
         (2 * position + gap * completed_blocks) as f64 / nside as f64
     } else {
+        // original formula:
+        //   x = 2/N i + p / N
+        // optimized formula (division is floating point):
+        //   x = (2 i + p) / N
         let phase = (if nside == 1 { ring + 1 } else { ring }).rem_euclid(2);
 
         (2 * position + phase) as f64 / nside as f64
@@ -94,10 +113,13 @@ fn ring_offset(ring: u64, nside: u64) -> u64 {
     if ring == 0 {
         0
     } else if ring < nside {
+        // i_r = 1 + 2(r-1)(r-2)
         1 + triangular_number_x4(pole_distance - 1)
     } else if ring > 3 * nside {
+        // i_r = 12N² + 2 - 1 - 2r(r-1)
         12 * nside.pow(2) + 1 - triangular_number_x4(pole_distance)
     } else {
+        // i_r = 1 + 2(N-1)(N-2) + 4N * (r - N)
         1 + triangular_number_x4(nside - 1) + 4 * nside * (ring - nside)
     }
 }

--- a/rust/healpix-geo-core/src/scalar/mesh.rs
+++ b/rust/healpix-geo-core/src/scalar/mesh.rs
@@ -540,6 +540,7 @@ mod tests {
         assert_eq!(extract_ring(1, 1, 14, 0), 1);
         assert_eq!(extract_ring(6, 1, 14, 0), 2);
         assert_eq!(extract_ring(13, 2, 50, 4), 3);
+        assert_eq!(extract_ring(32, 2, 50, 4), 5);
         assert_eq!(extract_ring(21, 8, 768, 84), 3);
     }
 
@@ -559,12 +560,15 @@ mod tests {
         // north polar cap
         assert_eq!(decode_vertex(0, 1, VertexIdScheme::Ring), (0.0, 1.0));
         assert_eq!(decode_vertex(1, 1, VertexIdScheme::Ring), (0.5, 1.5));
+        assert_eq!(decode_vertex(1, 3, VertexIdScheme::Ring), (4.5, 1.5));
         assert_eq!(decode_vertex(2, 2, VertexIdScheme::Ring), (2.75, 1.75));
         assert_eq!(decode_vertex(2, 6, VertexIdScheme::Ring), (1.0, 1.5));
 
         // equator
         assert_eq!(decode_vertex(1, 5, VertexIdScheme::Ring), (0.0, 1.0));
+        assert_eq!(decode_vertex(1, 7, VertexIdScheme::Ring), (2.0, 1.0));
         assert_eq!(decode_vertex(2, 25, VertexIdScheme::Ring), (0.0, 1.0));
+        assert_eq!(decode_vertex(2, 32, VertexIdScheme::Ring), (3.5, 1.0));
         assert_eq!(decode_vertex(2, 41, VertexIdScheme::Ring), (0.25, 0.75));
     }
 
@@ -582,6 +586,14 @@ mod tests {
         assert_eq!(
             vertex_to_geographic(0, &1, &sphere),
             (0.0, healpix::TRANSITION_LATITUDE.to_degrees())
+        );
+        assert_eq!(
+            vertex_to_geographic(1, &29, &sphere),
+            (22.5, -19.47122063449069)
+        );
+        assert_eq!(
+            vertex_to_geographic(1, &36, &sphere),
+            (337.5, -19.47122063449069)
         );
 
         assert_eq!(

--- a/rust/healpix-geo-core/src/scalar/mesh.rs
+++ b/rust/healpix-geo-core/src/scalar/mesh.rs
@@ -134,7 +134,7 @@ fn extract_ring(vertex_id: u64, nside: u64, n_vertices: u64, triangular_number: 
     } else if vertex_id < triangular_number + 1 {
         ((1 + (2 * vertex_id - 1).isqrt()) as f64 / 2.0).floor() as u64
     } else if vertex_id > n_vertices - triangular_number - 1 {
-        4 * nside - (3 + (2 * (n_vertices - vertex_id) - 1).isqrt()) / 2
+        4 * nside + 1 - (3 + (2 * (n_vertices - vertex_id) - 1).isqrt()) / 2
     } else {
         nside + (vertex_id - triangular_number - 1) / (4 * nside)
     }
@@ -564,6 +564,10 @@ mod tests {
         assert_eq!(decode_vertex(2, 2, VertexIdScheme::Ring), (2.75, 1.75));
         assert_eq!(decode_vertex(2, 6, VertexIdScheme::Ring), (1.0, 1.5));
 
+        // south polar cap
+        assert_eq!(decode_vertex(0, 12, VertexIdScheme::Ring), (6.0, -1.0));
+        assert_eq!(decode_vertex(1, 46, VertexIdScheme::Ring), (2.5, -1.5));
+
         // equator
         assert_eq!(decode_vertex(1, 5, VertexIdScheme::Ring), (0.0, 1.0));
         assert_eq!(decode_vertex(1, 7, VertexIdScheme::Ring), (2.0, 1.0));
@@ -594,6 +598,10 @@ mod tests {
         assert_eq!(
             vertex_to_geographic(1, &36, &sphere),
             (337.5, -19.47122063449069)
+        );
+        assert_eq!(
+            vertex_to_geographic(1, &46, &sphere),
+            (90.0, -66.44353569089878),
         );
 
         assert_eq!(

--- a/rust/healpix-geo-core/src/scalar/mesh.rs
+++ b/rust/healpix-geo-core/src/scalar/mesh.rs
@@ -27,6 +27,7 @@
 //! Other functions:
 //! - vertex_indices: deduplicate the vertex ids and construct the mesh connectivity
 //! - vertex coordinates: given a vertex id, compute the vertex coordinates
+use crate::ellipsoid::{Ellipsoid, ReferenceBody};
 use cdshealpix as healpix;
 use cdshealpix::unproj;
 
@@ -181,7 +182,7 @@ fn decode_vertex(depth: u8, vertex_id: u64, scheme: VertexIdScheme) -> (f64, f64
 // pub fn vertex_indices(ipix: &[CellVertices]) -> (Vec<u64>, Vec<CellIndices>) {}
 
 /// Convert a vertex id to coordinates
-pub fn vertex_coordinates(depth: u8, hash: &u64) -> (f64, f64) {
+pub fn vertex_coordinates(depth: u8, hash: &u64, ellipsoid: &Ellipsoid) -> (f64, f64) {
     // convert vertex hash to (face, x, y)
     // - convert the vertex id into (face, x, y, depth, corner-kind)
     // - from there, convert to (x, y) healpix plane coordinates (offset from the healpix
@@ -195,7 +196,10 @@ pub fn vertex_coordinates(depth: u8, hash: &u64) -> (f64, f64) {
     } else {
         let (lon, lat) = unproj(x, y);
 
-        (lon.to_degrees(), lat.to_degrees())
+        (
+            lon.to_degrees().rem_euclid(360.0),
+            ellipsoid.latitude_authalic_to_geographic(lat).to_degrees(),
+        )
     }
 }
 

--- a/rust/healpix-geo-core/src/scalar/mesh.rs
+++ b/rust/healpix-geo-core/src/scalar/mesh.rs
@@ -33,9 +33,8 @@ use cdshealpix::unproj;
 // type CellVertices = (u64, u64, u64, u64);
 // type CellIndices = (usize, usize, usize, usize);
 
-enum VertexIdScheme {
+pub(crate) enum VertexIdScheme {
     Ring,
-    ZOrder,
 }
 
 #[inline]
@@ -118,7 +117,8 @@ fn extract_ring(vertex_id: u64, nside: u64, n_vertices: u64, triangular_number: 
     }
 }
 
-fn encode_vertex(depth: u8, x: f64, y: f64, scheme: VertexIdScheme) -> u64 {
+#[inline]
+pub(crate) fn encode_vertex(depth: u8, x: f64, y: f64, scheme: VertexIdScheme) -> u64 {
     let nside = healpix::nside(depth) as u64;
 
     match scheme {
@@ -127,10 +127,10 @@ fn encode_vertex(depth: u8, x: f64, y: f64, scheme: VertexIdScheme) -> u64 {
 
             ring_offset(ring, nside) + encode_in_ring_position(x, ring, nside)
         }
-        VertexIdScheme::ZOrder => todo!(),
     }
 }
 
+#[inline]
 fn decode_vertex(depth: u8, vertex_id: u64, scheme: VertexIdScheme) -> (f64, f64) {
     let nside = healpix::nside(depth) as u64;
 
@@ -152,21 +152,7 @@ fn decode_vertex(depth: u8, vertex_id: u64, scheme: VertexIdScheme) -> (f64, f64
                 (x, y)
             }
         }
-        VertexIdScheme::ZOrder => todo!(),
     }
-}
-
-pub fn vertex_indices(depth: u8, hash: u64) -> (u64, u64, u64, u64) {
-    let layer = healpix::nested::get(depth);
-
-    let [(x_s, y_s), (x_e, y_e), (x_n, y_n), (x_w, y_w)] = layer.projected_vertices(hash);
-
-    (
-        encode_vertex(depth, x_s, y_s, VertexIdScheme::Ring),
-        encode_vertex(depth, x_e, y_e, VertexIdScheme::Ring),
-        encode_vertex(depth, x_n, y_n, VertexIdScheme::Ring),
-        encode_vertex(depth, x_w, y_w, VertexIdScheme::Ring),
-    )
 }
 
 // /// Deduplicate and sort the given vertex ids
@@ -566,13 +552,5 @@ mod tests {
             vertex_coordinates(3, 113),
             (0.0, healpix::TRANSITION_LATITUDE.to_degrees())
         );
-    }
-
-    #[test]
-    fn test_vertex_indices() {
-        assert_eq!(vertex_indices(0, 0), (5, 2, 0, 1));
-        assert_eq!(vertex_indices(0, 1), (6, 3, 0, 2));
-
-        assert_eq!(vertex_indices(1, 7), (8, 3, 0, 2));
     }
 }

--- a/rust/healpix-geo-core/src/scalar/mesh.rs
+++ b/rust/healpix-geo-core/src/scalar/mesh.rs
@@ -584,28 +584,28 @@ mod tests {
     }
 
     #[rstest]
-    #[case(0, 0, TestEllipsoid::Sphere, (0.0, 90.0))]
-    #[case(0, 13, TestEllipsoid::Sphere, (0.0, -90.0))]
-    #[case(
+    #[case::l0_sphere_north_pole(0, 0, TestEllipsoid::Sphere, (0.0, 90.0))]
+    #[case::l0_sphere_south_pole(0, 13, TestEllipsoid::Sphere, (0.0, -90.0))]
+    #[case::l0_sphere_transition_vertex(
         0, 1, TestEllipsoid::Sphere,
         (0.0, healpix::TRANSITION_LATITUDE.to_degrees()))]
-    #[case(
+    #[case::l1_sphere_equatorial1(
             1, 29, TestEllipsoid::Sphere,
             (22.5, -19.47122063449069))]
-    #[case(
+    #[case::l1_sphere_equatorial2(
         1, 36, TestEllipsoid::Sphere,
         (337.5, -19.47122063449069))]
-    #[case(
+    #[case::l1_sphere_south_polar_cap(
         1, 46, TestEllipsoid::Sphere,
         (90.0, -66.44353569089878))]
-    #[case(
+    #[case::l3_sphere_transition_vertex(
         3, 113, TestEllipsoid::Sphere,
         (0.0, healpix::TRANSITION_LATITUDE.to_degrees()))]
-    #[case(0, 5, TestEllipsoid::Ellipsoid, (45.0, 0.0))]
-    #[case(
+    #[case::l0_ellipsoid_equatorial(0, 5, TestEllipsoid::Ellipsoid, (45.0, 0.0))]
+    #[case::l2_ellipsoid_equatorial(
         2, 87, TestEllipsoid::Ellipsoid,
         (326.25, 9.636338620241146))]
-    #[case(
+    #[case::l3_ellipsoid_north_polar_cap(
         3, 21, TestEllipsoid::Ellipsoid,
         (239.99999999999997, 72.46140571909436))]
     fn test_vertex_to_geographic(

--- a/rust/healpix-geo-core/src/scalar/mesh.rs
+++ b/rust/healpix-geo-core/src/scalar/mesh.rs
@@ -132,7 +132,7 @@ fn extract_ring(vertex_id: u64, nside: u64, n_vertices: u64, triangular_number: 
     } else if vertex_id == n_vertices - 1 {
         4 * nside
     } else if vertex_id < triangular_number + 1 {
-        ((1 + (2 * vertex_id - 1).isqrt()) as f64 / 2.0).ceil() as u64
+        ((1 + (2 * vertex_id - 1).isqrt()) as f64 / 2.0).floor() as u64
     } else if vertex_id > n_vertices - triangular_number - 1 {
         4 * nside - (3 + (2 * (n_vertices - vertex_id) - 1).isqrt()) / 2
     } else {
@@ -206,6 +206,8 @@ pub fn vertex_coordinates(depth: u8, hash: &u64, ellipsoid: &Ellipsoid) -> (f64,
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ellipsoid::{ReferenceEllipsoid, ReferenceSphere};
+    use geodesy::ellps::Ellipsoid as GeodesyEllipsoid;
 
     #[test]
     fn test_encode_in_ring_position_nside_1_polar_cap() {
@@ -538,6 +540,7 @@ mod tests {
         assert_eq!(extract_ring(1, 1, 14, 0), 1);
         assert_eq!(extract_ring(6, 1, 14, 0), 2);
         assert_eq!(extract_ring(13, 2, 50, 4), 3);
+        assert_eq!(extract_ring(21, 8, 768, 84), 3);
     }
 
     #[test]
@@ -567,16 +570,33 @@ mod tests {
 
     #[test]
     fn test_vertex_coordinates() {
-        assert_eq!(vertex_coordinates(0, &0), (0.0, 90.0));
-        assert_eq!(vertex_coordinates(0, &13), (0.0, -90.0));
+        let sphere = Ellipsoid::Sphere(ReferenceSphere::new(
+            GeodesyEllipsoid::named("sphere").unwrap(),
+        ));
+        let ellipsoid = Ellipsoid::Ellipsoid(ReferenceEllipsoid::new(
+            GeodesyEllipsoid::named("WGS84").unwrap(),
+        ));
+
+        assert_eq!(vertex_coordinates(0, &0, &sphere), (0.0, 90.0));
+        assert_eq!(vertex_coordinates(0, &13, &sphere), (0.0, -90.0));
         assert_eq!(
-            vertex_coordinates(0, &1),
+            vertex_coordinates(0, &1, &sphere),
             (0.0, healpix::TRANSITION_LATITUDE.to_degrees())
         );
 
         assert_eq!(
-            vertex_coordinates(3, &113),
+            vertex_coordinates(3, &113, &sphere),
             (0.0, healpix::TRANSITION_LATITUDE.to_degrees())
+        );
+
+        assert_eq!(vertex_coordinates(0, &5, &ellipsoid), (45.0, 0.0));
+        assert_eq!(
+            vertex_coordinates(2, &87, &ellipsoid),
+            (326.25, 9.636338620241146)
+        );
+        assert_eq!(
+            vertex_coordinates(3, &21, &ellipsoid),
+            (239.99999999999997, 72.46140571909436)
         );
     }
 }

--- a/rust/healpix-geo-core/src/scalar/mesh.rs
+++ b/rust/healpix-geo-core/src/scalar/mesh.rs
@@ -207,7 +207,9 @@ pub fn vertex_to_geographic(depth: u8, hash: &u64, ellipsoid: &Ellipsoid) -> (f6
 mod tests {
     use super::*;
     use crate::ellipsoid::{ReferenceEllipsoid, ReferenceSphere};
+    use assertables::assert_approx_eq;
     use geodesy::ellps::Ellipsoid as GeodesyEllipsoid;
+    use rstest::rstest;
 
     #[test]
     fn test_encode_in_ring_position_nside_1_polar_cap() {
@@ -576,47 +578,53 @@ mod tests {
         assert_eq!(decode_vertex(2, 41, VertexIdScheme::Ring), (0.25, 0.75));
     }
 
-    #[test]
-    fn test_vertex_to_geographic() {
-        let sphere = Ellipsoid::Sphere(ReferenceSphere::new(
-            GeodesyEllipsoid::named("sphere").unwrap(),
-        ));
-        let ellipsoid = Ellipsoid::Ellipsoid(ReferenceEllipsoid::new(
-            GeodesyEllipsoid::named("WGS84").unwrap(),
-        ));
+    enum TestEllipsoid {
+        Sphere,
+        Ellipsoid,
+    }
 
-        assert_eq!(vertex_to_geographic(0, &0, &sphere), (0.0, 90.0));
-        assert_eq!(vertex_to_geographic(0, &13, &sphere), (0.0, -90.0));
-        assert_eq!(
-            vertex_to_geographic(0, &1, &sphere),
-            (0.0, healpix::TRANSITION_LATITUDE.to_degrees())
-        );
-        assert_eq!(
-            vertex_to_geographic(1, &29, &sphere),
-            (22.5, -19.47122063449069)
-        );
-        assert_eq!(
-            vertex_to_geographic(1, &36, &sphere),
-            (337.5, -19.47122063449069)
-        );
-        assert_eq!(
-            vertex_to_geographic(1, &46, &sphere),
-            (90.0, -66.44353569089878),
-        );
+    #[rstest]
+    #[case(0, 0, TestEllipsoid::Sphere, (0.0, 90.0))]
+    #[case(0, 13, TestEllipsoid::Sphere, (0.0, -90.0))]
+    #[case(
+        0, 1, TestEllipsoid::Sphere,
+        (0.0, healpix::TRANSITION_LATITUDE.to_degrees()))]
+    #[case(
+            1, 29, TestEllipsoid::Sphere,
+            (22.5, -19.47122063449069))]
+    #[case(
+        1, 36, TestEllipsoid::Sphere,
+        (337.5, -19.47122063449069))]
+    #[case(
+        1, 46, TestEllipsoid::Sphere,
+        (90.0, -66.44353569089878))]
+    #[case(
+        3, 113, TestEllipsoid::Sphere,
+        (0.0, healpix::TRANSITION_LATITUDE.to_degrees()))]
+    #[case(0, 5, TestEllipsoid::Ellipsoid, (45.0, 0.0))]
+    #[case(
+        2, 87, TestEllipsoid::Ellipsoid,
+        (326.25, 9.636338620241146))]
+    #[case(
+        3, 21, TestEllipsoid::Ellipsoid,
+        (239.99999999999997, 72.46140571909436))]
+    fn test_vertex_to_geographic(
+        #[case] level: u8,
+        #[case] vertex_id: u64,
+        #[case] ellipsoid_kind: TestEllipsoid,
+        #[case] expected: (f64, f64),
+    ) {
+        let ellipsoid = match ellipsoid_kind {
+            TestEllipsoid::Sphere => Ellipsoid::Sphere(ReferenceSphere::new(
+                GeodesyEllipsoid::named("sphere").unwrap(),
+            )),
+            TestEllipsoid::Ellipsoid => Ellipsoid::Ellipsoid(ReferenceEllipsoid::new(
+                GeodesyEllipsoid::named("WGS84").unwrap(),
+            )),
+        };
 
-        assert_eq!(
-            vertex_to_geographic(3, &113, &sphere),
-            (0.0, healpix::TRANSITION_LATITUDE.to_degrees())
-        );
-
-        assert_eq!(vertex_to_geographic(0, &5, &ellipsoid), (45.0, 0.0));
-        assert_eq!(
-            vertex_to_geographic(2, &87, &ellipsoid),
-            (326.25, 9.636338620241146)
-        );
-        assert_eq!(
-            vertex_to_geographic(3, &21, &ellipsoid),
-            (239.99999999999997, 72.46140571909436)
-        );
+        let actual = vertex_to_geographic(level, &vertex_id, &ellipsoid);
+        assert_approx_eq!(actual.0, expected.0);
+        assert_approx_eq!(actual.1, expected.1);
     }
 }

--- a/rust/healpix-geo-core/src/scalar/mesh.rs
+++ b/rust/healpix-geo-core/src/scalar/mesh.rs
@@ -181,13 +181,13 @@ fn decode_vertex(depth: u8, vertex_id: u64, scheme: VertexIdScheme) -> (f64, f64
 // pub fn vertex_indices(ipix: &[CellVertices]) -> (Vec<u64>, Vec<CellIndices>) {}
 
 /// Convert a vertex id to coordinates
-pub fn vertex_coordinates(depth: u8, hash: u64) -> (f64, f64) {
+pub fn vertex_coordinates(depth: u8, hash: &u64) -> (f64, f64) {
     // convert vertex hash to (face, x, y)
     // - convert the vertex id into (face, x, y, depth, corner-kind)
     // - from there, convert to (x, y) healpix plane coordinates (offset from the healpix
     //   center coordinate is 1 / 2**depth)
     // - use `unproj` to compute the geographic coordinates
-    let (x, y) = decode_vertex(depth, hash, VertexIdScheme::Ring);
+    let (x, y) = decode_vertex(depth, *hash, VertexIdScheme::Ring);
     if y == 2.0 {
         (0.0, 90.0)
     } else if y == -2.0 {
@@ -563,15 +563,15 @@ mod tests {
 
     #[test]
     fn test_vertex_coordinates() {
-        assert_eq!(vertex_coordinates(0, 0), (0.0, 90.0));
-        assert_eq!(vertex_coordinates(0, 13), (0.0, -90.0));
+        assert_eq!(vertex_coordinates(0, &0), (0.0, 90.0));
+        assert_eq!(vertex_coordinates(0, &13), (0.0, -90.0));
         assert_eq!(
-            vertex_coordinates(0, 1),
+            vertex_coordinates(0, &1),
             (0.0, healpix::TRANSITION_LATITUDE.to_degrees())
         );
 
         assert_eq!(
-            vertex_coordinates(3, 113),
+            vertex_coordinates(3, &113),
             (0.0, healpix::TRANSITION_LATITUDE.to_degrees())
         );
     }

--- a/rust/healpix-geo-core/src/scalar/mesh.rs
+++ b/rust/healpix-geo-core/src/scalar/mesh.rs
@@ -182,7 +182,7 @@ fn decode_vertex(depth: u8, vertex_id: u64, scheme: VertexIdScheme) -> (f64, f64
 // pub fn vertex_indices(ipix: &[CellVertices]) -> (Vec<u64>, Vec<CellIndices>) {}
 
 /// Convert a vertex id to coordinates
-pub fn vertex_coordinates(depth: u8, hash: &u64, ellipsoid: &Ellipsoid) -> (f64, f64) {
+pub fn vertex_to_geographic(depth: u8, hash: &u64, ellipsoid: &Ellipsoid) -> (f64, f64) {
     // convert vertex hash to (face, x, y)
     // - convert the vertex id into (face, x, y, depth, corner-kind)
     // - from there, convert to (x, y) healpix plane coordinates (offset from the healpix
@@ -569,7 +569,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vertex_coordinates() {
+    fn test_vertex_to_geographic() {
         let sphere = Ellipsoid::Sphere(ReferenceSphere::new(
             GeodesyEllipsoid::named("sphere").unwrap(),
         ));
@@ -577,25 +577,25 @@ mod tests {
             GeodesyEllipsoid::named("WGS84").unwrap(),
         ));
 
-        assert_eq!(vertex_coordinates(0, &0, &sphere), (0.0, 90.0));
-        assert_eq!(vertex_coordinates(0, &13, &sphere), (0.0, -90.0));
+        assert_eq!(vertex_to_geographic(0, &0, &sphere), (0.0, 90.0));
+        assert_eq!(vertex_to_geographic(0, &13, &sphere), (0.0, -90.0));
         assert_eq!(
-            vertex_coordinates(0, &1, &sphere),
+            vertex_to_geographic(0, &1, &sphere),
             (0.0, healpix::TRANSITION_LATITUDE.to_degrees())
         );
 
         assert_eq!(
-            vertex_coordinates(3, &113, &sphere),
+            vertex_to_geographic(3, &113, &sphere),
             (0.0, healpix::TRANSITION_LATITUDE.to_degrees())
         );
 
-        assert_eq!(vertex_coordinates(0, &5, &ellipsoid), (45.0, 0.0));
+        assert_eq!(vertex_to_geographic(0, &5, &ellipsoid), (45.0, 0.0));
         assert_eq!(
-            vertex_coordinates(2, &87, &ellipsoid),
+            vertex_to_geographic(2, &87, &ellipsoid),
             (326.25, 9.636338620241146)
         );
         assert_eq!(
-            vertex_coordinates(3, &21, &ellipsoid),
+            vertex_to_geographic(3, &21, &ellipsoid),
             (239.99999999999997, 72.46140571909436)
         );
     }

--- a/rust/healpix-geo-core/src/scalar/mod.rs
+++ b/rust/healpix-geo-core/src/scalar/mod.rs
@@ -3,3 +3,4 @@ pub mod ring;
 pub mod zuniq;
 
 pub mod geometry;
+pub mod mesh;

--- a/rust/healpix-geo-core/src/scalar/nested/mesh.rs
+++ b/rust/healpix-geo-core/src/scalar/nested/mesh.rs
@@ -1,0 +1,28 @@
+use crate::scalar::mesh::{VertexIdScheme, encode_vertex};
+use cdshealpix as healpix;
+
+pub fn vertex_indices(depth: u8, hash: u64) -> (u64, u64, u64, u64) {
+    let layer = healpix::nested::get(depth);
+
+    let [(x_s, y_s), (x_e, y_e), (x_n, y_n), (x_w, y_w)] = layer.projected_vertices(hash);
+
+    (
+        encode_vertex(depth, x_s, y_s, VertexIdScheme::Ring),
+        encode_vertex(depth, x_e, y_e, VertexIdScheme::Ring),
+        encode_vertex(depth, x_n, y_n, VertexIdScheme::Ring),
+        encode_vertex(depth, x_w, y_w, VertexIdScheme::Ring),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vertex_indices() {
+        assert_eq!(vertex_indices(0, 0), (5, 2, 0, 1));
+        assert_eq!(vertex_indices(0, 1), (6, 3, 0, 2));
+
+        assert_eq!(vertex_indices(1, 7), (8, 3, 0, 2));
+    }
+}

--- a/rust/healpix-geo-core/src/scalar/nested/mesh.rs
+++ b/rust/healpix-geo-core/src/scalar/nested/mesh.rs
@@ -24,5 +24,6 @@ mod tests {
         assert_eq!(vertex_indices(0, &1), (6, 3, 0, 2));
 
         assert_eq!(vertex_indices(1, &7), (8, 3, 0, 2));
+        assert_eq!(vertex_indices(1, &16), (37, 29, 21, 36));
     }
 }

--- a/rust/healpix-geo-core/src/scalar/nested/mesh.rs
+++ b/rust/healpix-geo-core/src/scalar/nested/mesh.rs
@@ -7,10 +7,10 @@ pub fn vertex_indices(depth: u8, hash: &u64) -> (u64, u64, u64, u64) {
     let [(x_s, y_s), (x_e, y_e), (x_n, y_n), (x_w, y_w)] = layer.projected_vertices(*hash);
 
     (
-        encode_vertex(depth, x_s, y_s, VertexIdScheme::Ring),
-        encode_vertex(depth, x_e, y_e, VertexIdScheme::Ring),
-        encode_vertex(depth, x_n, y_n, VertexIdScheme::Ring),
-        encode_vertex(depth, x_w, y_w, VertexIdScheme::Ring),
+        encode_vertex(depth, x_s.rem_euclid(8.0), y_s, VertexIdScheme::Ring),
+        encode_vertex(depth, x_e.rem_euclid(8.0), y_e, VertexIdScheme::Ring),
+        encode_vertex(depth, x_n.rem_euclid(8.0), y_n, VertexIdScheme::Ring),
+        encode_vertex(depth, x_w.rem_euclid(8.0), y_w, VertexIdScheme::Ring),
     )
 }
 

--- a/rust/healpix-geo-core/src/scalar/nested/mesh.rs
+++ b/rust/healpix-geo-core/src/scalar/nested/mesh.rs
@@ -1,10 +1,10 @@
 use crate::scalar::mesh::{VertexIdScheme, encode_vertex};
 use cdshealpix as healpix;
 
-pub fn vertex_indices(depth: u8, hash: u64) -> (u64, u64, u64, u64) {
+pub fn vertex_indices(depth: u8, hash: &u64) -> (u64, u64, u64, u64) {
     let layer = healpix::nested::get(depth);
 
-    let [(x_s, y_s), (x_e, y_e), (x_n, y_n), (x_w, y_w)] = layer.projected_vertices(hash);
+    let [(x_s, y_s), (x_e, y_e), (x_n, y_n), (x_w, y_w)] = layer.projected_vertices(*hash);
 
     (
         encode_vertex(depth, x_s, y_s, VertexIdScheme::Ring),
@@ -20,9 +20,9 @@ mod tests {
 
     #[test]
     fn test_vertex_indices() {
-        assert_eq!(vertex_indices(0, 0), (5, 2, 0, 1));
-        assert_eq!(vertex_indices(0, 1), (6, 3, 0, 2));
+        assert_eq!(vertex_indices(0, &0), (5, 2, 0, 1));
+        assert_eq!(vertex_indices(0, &1), (6, 3, 0, 2));
 
-        assert_eq!(vertex_indices(1, 7), (8, 3, 0, 2));
+        assert_eq!(vertex_indices(1, &7), (8, 3, 0, 2));
     }
 }

--- a/rust/healpix-geo-core/src/scalar/nested/mod.rs
+++ b/rust/healpix-geo-core/src/scalar/nested/mod.rs
@@ -2,3 +2,4 @@ pub mod conversion;
 pub mod coordinates;
 pub mod coverage;
 pub mod hierarchy;
+pub mod mesh;

--- a/rust/healpix-geo-core/src/scalar/ring/mesh.rs
+++ b/rust/healpix-geo-core/src/scalar/ring/mesh.rs
@@ -1,9 +1,9 @@
 use crate::scalar::mesh::{VertexIdScheme, encode_vertex};
 use cdshealpix as healpix;
 
-pub fn vertex_indices(depth: u8, hash: u64) -> (u64, u64, u64, u64) {
+pub fn vertex_indices(depth: u8, hash: &u64) -> (u64, u64, u64, u64) {
     let layer = healpix::nested::get(depth);
-    let nested = layer.from_ring(hash);
+    let nested = layer.from_ring(*hash);
 
     let [(x_s, y_s), (x_e, y_e), (x_n, y_n), (x_w, y_w)] = layer.projected_vertices(nested);
 

--- a/rust/healpix-geo-core/src/scalar/ring/mesh.rs
+++ b/rust/healpix-geo-core/src/scalar/ring/mesh.rs
@@ -8,10 +8,10 @@ pub fn vertex_indices(depth: u8, hash: &u64) -> (u64, u64, u64, u64) {
     let [(x_s, y_s), (x_e, y_e), (x_n, y_n), (x_w, y_w)] = layer.projected_vertices(nested);
 
     (
-        encode_vertex(depth, x_s, y_s, VertexIdScheme::Ring),
-        encode_vertex(depth, x_e, y_e, VertexIdScheme::Ring),
-        encode_vertex(depth, x_n, y_n, VertexIdScheme::Ring),
-        encode_vertex(depth, x_w, y_w, VertexIdScheme::Ring),
+        encode_vertex(depth, x_s.rem_euclid(8.0), y_s, VertexIdScheme::Ring),
+        encode_vertex(depth, x_e.rem_euclid(8.0), y_e, VertexIdScheme::Ring),
+        encode_vertex(depth, x_n.rem_euclid(8.0), y_n, VertexIdScheme::Ring),
+        encode_vertex(depth, x_w.rem_euclid(8.0), y_w, VertexIdScheme::Ring),
     )
 }
 

--- a/rust/healpix-geo-core/src/scalar/ring/mesh.rs
+++ b/rust/healpix-geo-core/src/scalar/ring/mesh.rs
@@ -1,0 +1,16 @@
+use crate::scalar::mesh::{VertexIdScheme, encode_vertex};
+use cdshealpix as healpix;
+
+pub fn vertex_indices(depth: u8, hash: u64) -> (u64, u64, u64, u64) {
+    let layer = healpix::nested::get(depth);
+    let nested = layer.from_ring(hash);
+
+    let [(x_s, y_s), (x_e, y_e), (x_n, y_n), (x_w, y_w)] = layer.projected_vertices(nested);
+
+    (
+        encode_vertex(depth, x_s, y_s, VertexIdScheme::Ring),
+        encode_vertex(depth, x_e, y_e, VertexIdScheme::Ring),
+        encode_vertex(depth, x_n, y_n, VertexIdScheme::Ring),
+        encode_vertex(depth, x_w, y_w, VertexIdScheme::Ring),
+    )
+}

--- a/rust/healpix-geo-core/src/scalar/ring/mesh.rs
+++ b/rust/healpix-geo-core/src/scalar/ring/mesh.rs
@@ -14,3 +14,17 @@ pub fn vertex_indices(depth: u8, hash: &u64) -> (u64, u64, u64, u64) {
         encode_vertex(depth, x_w, y_w, VertexIdScheme::Ring),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vertex_indices() {
+        assert_eq!(vertex_indices(0, &0), (5, 2, 0, 1));
+        assert_eq!(vertex_indices(0, &4), (9, 5, 1, 8));
+
+        assert_eq!(vertex_indices(1, &7), (16, 9, 3, 8));
+        assert_eq!(vertex_indices(1, &16), (25, 17, 9, 16));
+    }
+}

--- a/rust/healpix-geo-core/src/scalar/ring/mod.rs
+++ b/rust/healpix-geo-core/src/scalar/ring/mod.rs
@@ -2,3 +2,4 @@ pub mod conversion;
 pub mod coordinates;
 pub mod coverage;
 pub mod hierarchy;
+pub mod mesh;

--- a/rust/healpix-geo-core/src/scalar/zuniq/mesh.rs
+++ b/rust/healpix-geo-core/src/scalar/zuniq/mesh.rs
@@ -1,8 +1,8 @@
 use crate::scalar::mesh::{VertexIdScheme, encode_vertex};
 use cdshealpix as healpix;
 
-pub fn vertex_indices(hash: u64) -> (u64, u64, u64, u64) {
-    let (depth, nested) = healpix::nested::from_zuniq(hash);
+pub fn vertex_indices(hash: &u64) -> (u64, u64, u64, u64) {
+    let (depth, nested) = healpix::nested::from_zuniq(*hash);
     let layer = healpix::nested::get(depth);
 
     let [(x_s, y_s), (x_e, y_e), (x_n, y_n), (x_w, y_w)] = layer.projected_vertices(nested);

--- a/rust/healpix-geo-core/src/scalar/zuniq/mesh.rs
+++ b/rust/healpix-geo-core/src/scalar/zuniq/mesh.rs
@@ -8,10 +8,10 @@ pub fn vertex_indices(hash: &u64) -> (u64, u64, u64, u64) {
     let [(x_s, y_s), (x_e, y_e), (x_n, y_n), (x_w, y_w)] = layer.projected_vertices(nested);
 
     (
-        encode_vertex(depth, x_s, y_s, VertexIdScheme::Ring),
-        encode_vertex(depth, x_e, y_e, VertexIdScheme::Ring),
-        encode_vertex(depth, x_n, y_n, VertexIdScheme::Ring),
-        encode_vertex(depth, x_w, y_w, VertexIdScheme::Ring),
+        encode_vertex(depth, x_s.rem_euclid(8.0), y_s, VertexIdScheme::Ring),
+        encode_vertex(depth, x_e.rem_euclid(8.0), y_e, VertexIdScheme::Ring),
+        encode_vertex(depth, x_n.rem_euclid(8.0), y_n, VertexIdScheme::Ring),
+        encode_vertex(depth, x_w.rem_euclid(8.0), y_w, VertexIdScheme::Ring),
     )
 }
 

--- a/rust/healpix-geo-core/src/scalar/zuniq/mesh.rs
+++ b/rust/healpix-geo-core/src/scalar/zuniq/mesh.rs
@@ -1,0 +1,16 @@
+use crate::scalar::mesh::{VertexIdScheme, encode_vertex};
+use cdshealpix as healpix;
+
+pub fn vertex_indices(hash: u64) -> (u64, u64, u64, u64) {
+    let (depth, nested) = healpix::nested::from_zuniq(hash);
+    let layer = healpix::nested::get(depth);
+
+    let [(x_s, y_s), (x_e, y_e), (x_n, y_n), (x_w, y_w)] = layer.projected_vertices(nested);
+
+    (
+        encode_vertex(depth, x_s, y_s, VertexIdScheme::Ring),
+        encode_vertex(depth, x_e, y_e, VertexIdScheme::Ring),
+        encode_vertex(depth, x_n, y_n, VertexIdScheme::Ring),
+        encode_vertex(depth, x_w, y_w, VertexIdScheme::Ring),
+    )
+}

--- a/rust/healpix-geo-core/src/scalar/zuniq/mesh.rs
+++ b/rust/healpix-geo-core/src/scalar/zuniq/mesh.rs
@@ -14,3 +14,17 @@ pub fn vertex_indices(hash: &u64) -> (u64, u64, u64, u64) {
         encode_vertex(depth, x_w, y_w, VertexIdScheme::Ring),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vertex_indices() {
+        assert_eq!(vertex_indices(&288230376151711744), (5, 2, 0, 1));
+        assert_eq!(vertex_indices(&864691128455135232), (6, 3, 0, 2));
+
+        assert_eq!(vertex_indices(&1080863910568919040), (8, 3, 0, 2));
+        assert_eq!(vertex_indices(&2377900603251621888), (37, 29, 21, 36));
+    }
+}

--- a/rust/healpix-geo-core/src/scalar/zuniq/mod.rs
+++ b/rust/healpix-geo-core/src/scalar/zuniq/mod.rs
@@ -2,3 +2,4 @@ pub mod conversion;
 pub mod coordinates;
 pub mod coverage;
 pub mod hierarchy;
+pub mod mesh;

--- a/rust/healpix-geo-core/src/vectorized/mesh.rs
+++ b/rust/healpix-geo-core/src/vectorized/mesh.rs
@@ -2,13 +2,19 @@ use crate::maybe_parallelize;
 #[cfg(not(target_arch = "wasm32"))]
 use rayon::prelude::*;
 
+use crate::ellipsoid::Ellipsoid;
 use crate::scalar::mesh as scalar;
 
-pub fn vertex_coordinates(depth: u8, hashes: &[u64], nthreads: usize) -> Vec<(f64, f64)> {
+pub fn vertex_coordinates(
+    depth: u8,
+    hashes: &[u64],
+    ellipsoid: &Ellipsoid,
+    nthreads: usize,
+) -> Vec<(f64, f64)> {
     let mut result = Vec::<(f64, f64)>::with_capacity(hashes.len());
 
     maybe_parallelize!(nthreads, hashes, result, |hash| scalar::vertex_coordinates(
-        depth, hash
+        depth, hash, ellipsoid
     ));
 
     result

--- a/rust/healpix-geo-core/src/vectorized/mesh.rs
+++ b/rust/healpix-geo-core/src/vectorized/mesh.rs
@@ -1,0 +1,15 @@
+use crate::maybe_parallelize;
+#[cfg(not(target_arch = "wasm32"))]
+use rayon::prelude::*;
+
+use crate::scalar::mesh as scalar;
+
+pub fn vertex_coordinates(depth: u8, hashes: &[u64], nthreads: usize) -> Vec<(f64, f64)> {
+    let mut result = Vec::<(f64, f64)>::with_capacity(hashes.len());
+
+    maybe_parallelize!(nthreads, hashes, result, |hash| scalar::vertex_coordinates(
+        depth, hash
+    ));
+
+    result
+}

--- a/rust/healpix-geo-core/src/vectorized/mesh.rs
+++ b/rust/healpix-geo-core/src/vectorized/mesh.rs
@@ -5,7 +5,7 @@ use rayon::prelude::*;
 use crate::ellipsoid::Ellipsoid;
 use crate::scalar::mesh as scalar;
 
-pub fn vertex_coordinates(
+pub fn vertex_to_geographic(
     depth: u8,
     hashes: &[u64],
     ellipsoid: &Ellipsoid,
@@ -13,9 +13,9 @@ pub fn vertex_coordinates(
 ) -> Vec<(f64, f64)> {
     let mut result = Vec::<(f64, f64)>::with_capacity(hashes.len());
 
-    maybe_parallelize!(nthreads, hashes, result, |hash| scalar::vertex_coordinates(
-        depth, hash, ellipsoid
-    ));
+    maybe_parallelize!(nthreads, hashes, result, |hash| {
+        scalar::vertex_to_geographic(depth, hash, ellipsoid)
+    });
 
     result
 }

--- a/rust/healpix-geo-core/src/vectorized/mod.rs
+++ b/rust/healpix-geo-core/src/vectorized/mod.rs
@@ -5,3 +5,4 @@ pub mod ring;
 pub mod zuniq;
 
 pub mod geometry;
+pub mod mesh;

--- a/rust/healpix-geo-core/src/vectorized/nested/mesh.rs
+++ b/rust/healpix-geo-core/src/vectorized/nested/mesh.rs
@@ -1,0 +1,14 @@
+use crate::maybe_parallelize;
+use crate::scalar::nested::mesh as scalar;
+#[cfg(not(target_arch = "wasm32"))]
+use rayon::prelude::*;
+
+pub fn vertex_indices(depth: u8, hashes: &[u64], nthreads: usize) -> Vec<(u64, u64, u64, u64)> {
+    let mut result = Vec::<(u64, u64, u64, u64)>::with_capacity(hashes.len());
+
+    maybe_parallelize!(nthreads, hashes, result, |hash| scalar::vertex_indices(
+        depth, hash
+    ));
+
+    result
+}

--- a/rust/healpix-geo-core/src/vectorized/nested/mod.rs
+++ b/rust/healpix-geo-core/src/vectorized/nested/mod.rs
@@ -2,3 +2,4 @@ pub mod coordinates;
 pub mod coverage;
 pub mod distances;
 pub mod hierarchy;
+pub mod mesh;

--- a/rust/healpix-geo-core/src/vectorized/ring/mesh.rs
+++ b/rust/healpix-geo-core/src/vectorized/ring/mesh.rs
@@ -1,0 +1,14 @@
+use crate::maybe_parallelize;
+use crate::scalar::ring::mesh as scalar;
+#[cfg(not(target_arch = "wasm32"))]
+use rayon::prelude::*;
+
+pub fn vertex_indices(depth: u8, hashes: &[u64], nthreads: usize) -> Vec<(u64, u64, u64, u64)> {
+    let mut result = Vec::<(u64, u64, u64, u64)>::with_capacity(hashes.len());
+
+    maybe_parallelize!(nthreads, hashes, result, |hash| scalar::vertex_indices(
+        depth, hash
+    ));
+
+    result
+}

--- a/rust/healpix-geo-core/src/vectorized/ring/mod.rs
+++ b/rust/healpix-geo-core/src/vectorized/ring/mod.rs
@@ -2,3 +2,4 @@ pub mod coordinates;
 pub mod coverage;
 pub mod distances;
 pub mod hierarchy;
+pub mod mesh;

--- a/rust/healpix-geo-core/src/vectorized/zuniq/mesh.rs
+++ b/rust/healpix-geo-core/src/vectorized/zuniq/mesh.rs
@@ -1,0 +1,12 @@
+use crate::maybe_parallelize;
+use crate::scalar::zuniq::mesh as scalar;
+#[cfg(not(target_arch = "wasm32"))]
+use rayon::prelude::*;
+
+pub fn vertex_indices(hashes: &[u64], nthreads: usize) -> Vec<(u64, u64, u64, u64)> {
+    let mut result = Vec::<(u64, u64, u64, u64)>::with_capacity(hashes.len());
+
+    maybe_parallelize!(nthreads, hashes, result, scalar::vertex_indices);
+
+    result
+}

--- a/rust/healpix-geo-core/src/vectorized/zuniq/mod.rs
+++ b/rust/healpix-geo-core/src/vectorized/zuniq/mod.rs
@@ -2,3 +2,4 @@ pub mod conversion;
 pub mod coordinates;
 pub mod coverage;
 pub mod hierarchy;
+pub mod mesh;


### PR DESCRIPTION
during the conference last week I've been trying to figure out how to convert healpix cell ids to meshes (i.e. node coordinates and face-node connectivity). The idea is pretty simple: if I can assign integer ids to each node, computing the face-node connectivity becomes really simple. Additionally, if the cells cover the entire domain and all cells have the same refinement level we don't even need any additional deduplication step to get the face-node connectivity.

~There are still some problems with how the vertex coordinates are computed (e.g. L=1, vid=32), but assuming I can correct that without adding additional runtime cost (once I'm back from holidays in a week)~ (resolved) and that I'm actually comparing the same thing, it appears we can beat `uxarray`'s current implementation by a factor of 4-5: on my machine, the entire computation including the construction of the `uxarray.Grid` object at refinement / zoom level 10 takes about 3s while `uxarray.Grid.from_healpix` takes about 13s.

cc @erogluorhan, @carloshorn