### PR TITLE
js: reusable `Ellipsoid` handle, `createGrid`, and bulk typed-array APIs

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -45,6 +45,39 @@ Three things worth knowing:
   the `semiMajorAxis` / `flattening` / `isSphere` getters, which return plain
   numbers.
 
+### bulk methods
+
+Four methods run the whole loop inside WASM and hand back a single typed
+array, which is what makes a per-vertex mesh build practical:
+
+```typescript
+const grid = new Grid({ scheme: "nested", level: 4 });
+
+// steps x steps vertices of one cell, [lon0, lat0, lon1, lat1, ...]
+// (i outer, j inner, matching vertex(cell, i / (steps - 1), j / (steps - 1)))
+const mesh: Float64Array = grid.vertices(164n, 65);
+
+// centers of many cells, same interleaving
+const centers: Float64Array = grid.healpixToLonLat(
+  new BigUint64Array([0n, 164n]),
+);
+
+// and back: one cell id per [lon, lat] pair
+const cells: BigUint64Array = grid.lonLatToHealpix(centers);
+
+// entry `row * size + col` is `bitCombine(col, row)` — the layout for
+// unshuffling a z-order-flattened size x size chunk into row-major order
+const table: BigUint64Array = grid.bitCombineTable(8);
+```
+
+A batch is rejected as a whole, naming the offending index
+(`cells[2]: ...`, `lonlats[2]: ...`), rather than trapping on one bad element.
+
+Note that `healpixToLonLat` and `lonLatToHealpix` are only exact inverses
+within one level: on a `zuniq` grid `healpixToLonLat` reads each id at its
+embedded level while `lonLatToHealpix` encodes at the grid's level, so a
+coarse id in a mixed-level batch comes back refined.
+
 ## Low-level scheme functions
 
 The `nested` / `ring` / `zuniq` namespaces expose the per-scheme functions

--- a/js/README.md
+++ b/js/README.md
@@ -2,7 +2,55 @@
 
 This module provides javascript / typescript bindings to the `healpix_geo_core::scalar` crate.
 
-Usage:
+## `Grid`
+
+`Grid` is the recommended entry point: it holds the scheme, the refinement
+level and the parsed ellipsoid state (including the authalic-latitude
+coefficients), so the per-call overhead is the coordinate math alone, and
+every scheme gets the same call shape.
+
+```typescript
+import init, { Grid } from "healpix-geo";
+
+await init(); // or use a bundler
+
+const grid = new Grid({
+  scheme: "nested", // or "ring" or "zuniq"
+  level: 4, // 0-indexed; level 0 is the 12 base cells
+  ellipsoid: { semi_major_axis: 6378137.0, inverse_flattening: 298.257223563 },
+}); // `ellipsoid` is optional; omit it for the default sphere
+
+const corner = grid.vertex(164n, 0, 0); // u, v are cell-local offsets in [0, 1]
+const cell = grid.bitCombine(3, 5);
+const ring = grid.toScheme(cell, "ring");
+const coarse = grid.toScheme(5n, "zuniq", 0); // read (and encode) 5n at level 0
+```
+
+Every method reports misuse — a cell id out of range at the grid's level, a
+vertex offset outside `[0, 1]`, a non-integer z-order coordinate — as a
+catchable JS `Error` rather than trapping the wasm instance.
+
+Three things worth knowing:
+
+- For the `zuniq` scheme, methods that read a cell id use the level **embedded
+  in the id**, not the grid's level; methods that produce one encode the
+  grid's level. So `zuniq` → `zuniq` is the identity, and a coarse id survives
+  a read unchanged.
+- `toScheme` takes an optional `level` that overrides the level the cell is
+  read and encoded at. It is only valid when converting to a scheme that
+  encodes the level in its cell ids (`"zuniq"` today) and from one that does
+  not; anything else throws.
+- `grid.ellipsoid` allocates a **new** handle on every read (wasm allocation +
+  JS wrapper + finalizer). Hoist it out of hot paths and `free()` it, or use
+  the `semiMajorAxis` / `flattening` / `isSphere` getters, which return plain
+  numbers.
+
+## Low-level scheme functions
+
+The `nested` / `ring` / `zuniq` namespaces expose the per-scheme functions
+`Grid` is built on (their `depth` parameter is the same 0-indexed quantity as
+the grid's `level`). Reach for them when a single call is all you need;
+otherwise prefer `Grid`, which parses the ellipsoid once instead of per call.
 
 ```typescript
 import init, * as healpixGeo from "healpix-geo";

--- a/js/README.md
+++ b/js/README.md
@@ -9,7 +9,13 @@ import init, * as healpixGeo from "healpix-geo";
 
 await init(); // or use a bundler
 
-const cellId: bigint = 10;
+// parse once, reuse for any number of calls
+const ellipsoid = healpixGeo.Ellipsoid.from({
+  semi_major_axis: 6378137.0,
+  inverse_flattening: 298.257223563,
+}); // or Ellipsoid.from(null) for the default sphere
+
+const cellId: bigint = 10n;
 const level: number = 2;
 const { lon, lat } = healpixGeo.nested.healpixToLonLat(
   cellId,

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -13,40 +13,6 @@
         "vitest": "^4.1.9"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -54,29 +20,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.3"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
     "node_modules/@oxc-project/types": {
-      "version": "0.138.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
-      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+      "version": "0.144.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
+      "integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -84,9 +31,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
-      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
+      "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
       "cpu": [
         "arm64"
       ],
@@ -101,9 +48,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
-      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
       "cpu": [
         "arm64"
       ],
@@ -118,9 +65,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
-      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
       "cpu": [
         "x64"
       ],
@@ -135,9 +82,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
-      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
+      "integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
       "cpu": [
         "x64"
       ],
@@ -152,9 +99,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
-      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
+      "integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
       "cpu": [
         "arm"
       ],
@@ -169,13 +116,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
-      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
+      "integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -186,13 +136,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
-      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
+      "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -203,13 +156,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
-      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
+      "integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -220,13 +176,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
-      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
+      "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -237,13 +196,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
-      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
+      "integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -254,13 +216,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
-      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
+      "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -271,9 +236,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
-      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
+      "integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
       "cpu": [
         "arm64"
       ],
@@ -287,29 +252,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
-      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.11.1",
-        "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.1.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
-      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
+      "integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
       "cpu": [
         "arm64"
       ],
@@ -324,9 +270,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
-      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
+      "integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
       "cpu": [
         "x64"
       ],
@@ -354,17 +300,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -390,29 +325,17 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/node": {
-      "version": "24.13.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
-      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.18.0"
-      }
-    },
     "node_modules/@vitest/expect": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
-      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -421,13 +344,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
-      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.9",
+        "@vitest/spy": "4.1.10",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -448,9 +371,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
-      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -461,13 +384,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
-      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.9",
+        "@vitest/utils": "4.1.10",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -475,14 +398,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
-      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -491,9 +414,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
-      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -501,13 +424,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
-      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.9",
+        "@vitest/pretty-format": "4.1.10",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -613,9 +536,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -629,23 +552,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
       "cpu": [
         "arm64"
       ],
@@ -664,9 +587,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
       "cpu": [
         "arm64"
       ],
@@ -685,9 +608,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
       "cpu": [
         "x64"
       ],
@@ -706,9 +629,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
       "cpu": [
         "x64"
       ],
@@ -727,9 +650,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
       "cpu": [
         "arm"
       ],
@@ -748,13 +671,16 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -769,13 +695,16 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -790,13 +719,16 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -811,13 +743,16 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -832,9 +767,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
       "cpu": [
         "arm64"
       ],
@@ -853,9 +788,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
       "cpu": [
         "x64"
       ],
@@ -884,9 +819,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -944,9 +879,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -964,7 +899,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -973,13 +908,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
-      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
+      "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.138.0",
+        "@oxc-project/types": "=0.144.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -989,21 +924,20 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.1.4",
-        "@rolldown/binding-darwin-arm64": "1.1.4",
-        "@rolldown/binding-darwin-x64": "1.1.4",
-        "@rolldown/binding-freebsd-x64": "1.1.4",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
-        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
-        "@rolldown/binding-linux-arm64-musl": "1.1.4",
-        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
-        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
-        "@rolldown/binding-linux-x64-gnu": "1.1.4",
-        "@rolldown/binding-linux-x64-musl": "1.1.4",
-        "@rolldown/binding-openharmony-arm64": "1.1.4",
-        "@rolldown/binding-wasm32-wasi": "1.1.4",
-        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
-        "@rolldown/binding-win32-x64-msvc": "1.1.4"
+        "@rolldown/binding-android-arm64": "1.2.4",
+        "@rolldown/binding-darwin-arm64": "1.2.4",
+        "@rolldown/binding-darwin-x64": "1.2.4",
+        "@rolldown/binding-freebsd-x64": "1.2.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.4",
+        "@rolldown/binding-linux-arm64-musl": "1.2.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-musl": "1.2.4",
+        "@rolldown/binding-openharmony-arm64": "1.2.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.4",
+        "@rolldown/binding-win32-x64-msvc": "1.2.4"
       }
     },
     "node_modules/siginfo": {
@@ -1072,22 +1006,14 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -1103,26 +1029,17 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/vite": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
-      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.3",
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -1139,7 +1056,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.3.0",
+        "@vitejs/devtools": "^0.4.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -1191,19 +1108,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
-      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.9",
-        "@vitest/mocker": "4.1.9",
-        "@vitest/pretty-format": "4.1.9",
-        "@vitest/runner": "4.1.9",
-        "@vitest/snapshot": "4.1.9",
-        "@vitest/spy": "4.1.9",
-        "@vitest/utils": "4.1.9",
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -1231,12 +1148,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.9",
-        "@vitest/browser-preview": "4.1.9",
-        "@vitest/browser-webdriverio": "4.1.9",
-        "@vitest/coverage-istanbul": "4.1.9",
-        "@vitest/coverage-v8": "4.1.9",
-        "@vitest/ui": "4.1.9",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
+        "typescript": "^5.9.3",
         "vitest": "^4.1.9"
       }
     },
@@ -175,9 +176,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -195,9 +193,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -215,9 +210,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -235,9 +227,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -255,9 +244,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -275,9 +261,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -406,6 +389,18 @@
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.9",
@@ -760,9 +755,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -784,9 +776,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -808,9 +797,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -832,9 +818,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1105,6 +1088,29 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/vite": {
       "version": "8.1.3",

--- a/js/package.json
+++ b/js/package.json
@@ -13,6 +13,7 @@
     "test": "npm run build:node && npm run test:js"
   },
   "devDependencies": {
+    "typescript": "^5.9.3",
     "vitest": "^4.1.9"
   }
 }

--- a/js/src/ellipsoid.rs
+++ b/js/src/ellipsoid.rs
@@ -1,13 +1,36 @@
 use geodesy::ellps::Ellipsoid as GeodesyEllipsoid;
+use geodesy::prelude::EllipsoidBase;
 use healpix_geo_core::ellipsoid::{
-    Ellipsoid as RustEllipsoid, ReferenceEllipsoid, ReferenceSphere,
+    Ellipsoid as RustEllipsoid, ReferenceBody, ReferenceEllipsoid, ReferenceSphere,
 };
 use serde::Deserialize;
 use serde_wasm_bindgen::from_value;
 use wasm_bindgen::prelude::*;
 
+/// The plain-object shapes accepted wherever an ellipsoid is expected.
+///
+/// Mirrors [`EllipsoidLike`], which is an input (deserialization) type only
+/// and is therefore not exported as a class.
+///
+/// The `{ [key: string]: unknown }` intersection is what makes the documented
+/// "extra keys are ignored" behavior type-check: without it TypeScript's
+/// excess-property check rejects a fresh object literal carrying the `name` /
+/// `epsg` keys that ellipsoid catalogues ship with.
+#[wasm_bindgen(typescript_custom_section)]
+const ELLIPSOID_INPUT: &'static str = r#"
+export type EllipsoidInput = { [key: string]: unknown } & (
+    | { radius: number }
+    | { semi_major_axis: number; inverse_flattening: number }
+    | { semi_major_axis: number; semi_minor_axis: number }
+);
+"#;
+
+/// Plain-object shapes accepted as ellipsoid definitions.
+///
+/// This is an input (deserialization) type only; the parsed, reusable state
+/// lives in [`Ellipsoid`]. The TypeScript view of it is `EllipsoidInput`
+/// (see the custom section above).
 #[derive(Deserialize, Debug, PartialEq)]
-#[wasm_bindgen]
 pub enum EllipsoidLike {
     #[serde(untagged)]
     EllipsoidInverseFlattening(EllipsoidInverseFlattening),
@@ -18,14 +41,12 @@ pub enum EllipsoidLike {
 }
 
 #[derive(Deserialize, Debug, PartialEq)]
-#[wasm_bindgen]
 pub struct EllipsoidInverseFlattening {
     pub semi_major_axis: f64,
     pub inverse_flattening: f64,
 }
 
 #[derive(Deserialize, Debug, PartialEq)]
-#[wasm_bindgen]
 pub struct EllipsoidSemiMinorAxis {
     pub semi_major_axis: f64,
     pub semi_minor_axis: f64,
@@ -44,7 +65,6 @@ impl From<EllipsoidSemiMinorAxis> for EllipsoidInverseFlattening {
 }
 
 #[derive(Deserialize, Debug, PartialEq)]
-#[wasm_bindgen]
 pub struct Sphere {
     pub radius: f64,
 }
@@ -55,19 +75,61 @@ impl Default for Sphere {
     }
 }
 
-#[wasm_bindgen(js_name = parseEllipsoid)]
-pub fn parse_ellipsoid(obj: JsValue) -> Result<EllipsoidLike, JsValue> {
-    let ellipsoid_like = if obj.is_null() {
-        EllipsoidLike::Sphere(Sphere::default())
+/// Reject an axis that is not a positive, finite length.
+fn check_axis(value: f64, name: &str) -> Result<(), String> {
+    if value.is_finite() && value > 0.0 {
+        Ok(())
     } else {
-        from_value(obj)?
-    };
-    Ok(ellipsoid_like)
+        Err(format!(
+            "`{}` must be a positive, finite number, got {}",
+            name, value
+        ))
+    }
 }
 
 impl EllipsoidLike {
-    pub fn into_ellipsoid(self) -> RustEllipsoid {
+    /// Reject reference bodies that are not physically meaningful.
+    ///
+    /// `geodesy` builds an ellipsoid out of whatever numbers it is handed: a
+    /// zero or negative axis goes straight through, and
+    /// `inverse_flattening: 0` yields `flattening: Infinity` rather than the
+    /// sphere the caller almost certainly meant. Neither is caught downstream,
+    /// so the check belongs here, at the parse boundary.
+    fn validate(&self) -> Result<(), String> {
         match self {
+            Self::EllipsoidInverseFlattening(ell) => {
+                check_axis(ell.semi_major_axis, "semi_major_axis")?;
+
+                // `<= 1` also covers NaN by way of the explicit test: a
+                // flattening of 1 or more collapses the body onto its axis
+                if ell.inverse_flattening.is_nan() || ell.inverse_flattening <= 1.0 {
+                    return Err(format!(
+                        "`inverse_flattening` must be greater than 1, got {} (use `{{ radius }}` for a sphere)",
+                        ell.inverse_flattening
+                    ));
+                }
+            }
+            Self::EllipsoidSemiMinorAxis(ell) => {
+                check_axis(ell.semi_major_axis, "semi_major_axis")?;
+                check_axis(ell.semi_minor_axis, "semi_minor_axis")?;
+
+                if ell.semi_minor_axis > ell.semi_major_axis {
+                    return Err(format!(
+                        "`semi_minor_axis` ({}) must not exceed `semi_major_axis` ({})",
+                        ell.semi_minor_axis, ell.semi_major_axis
+                    ));
+                }
+            }
+            Self::Sphere(sphere) => check_axis(sphere.radius, "radius")?,
+        }
+
+        Ok(())
+    }
+
+    pub fn into_ellipsoid(self) -> Result<RustEllipsoid, String> {
+        self.validate()?;
+
+        Ok(match self {
             Self::EllipsoidInverseFlattening(ell) => {
                 let ellipsoid =
                     GeodesyEllipsoid::new(ell.semi_major_axis, 1.0f64 / ell.inverse_flattening);
@@ -87,15 +149,88 @@ impl EllipsoidLike {
 
                 RustEllipsoid::Sphere(ReferenceSphere::new(ellipsoid))
             }
+        })
+    }
+}
+
+/// A parsed, reusable reference body.
+///
+/// The handle is passed to functions by reference and can be reused for any
+/// number of calls. Parsing and the authalic-latitude Fourier coefficient
+/// computation happen once, at construction.
+#[wasm_bindgen]
+pub struct Ellipsoid {
+    pub(crate) inner: RustEllipsoid,
+}
+
+impl Default for Ellipsoid {
+    /// The default sphere (radius 6370997 m), equivalent to
+    /// `Ellipsoid.from(null)`.
+    fn default() -> Ellipsoid {
+        Ellipsoid {
+            inner: RustEllipsoid::default(),
         }
+    }
+}
+
+#[wasm_bindgen]
+impl Ellipsoid {
+    /// Parse a plain object (or `null` for the default sphere) into a
+    /// reusable ellipsoid handle.
+    ///
+    /// Accepted shapes:
+    /// - `null` or `undefined` (including a missing argument) — the default
+    ///   sphere (radius 6370997 m)
+    /// - `{ radius }` — a sphere
+    /// - `{ semi_major_axis, inverse_flattening }`
+    /// - `{ semi_major_axis, semi_minor_axis }`
+    ///
+    /// Note that `undefined` is accepted as well as `null`. Extra keys
+    /// (e.g. `name`) are ignored.
+    ///
+    /// The axes have to be positive, finite lengths, `semi_minor_axis` must
+    /// not exceed `semi_major_axis`, and `inverse_flattening` must be greater
+    /// than 1 — `inverse_flattening: 0` means an infinite flattening, not a
+    /// sphere, and is rejected; use `{ radius }` for a sphere. Anything else
+    /// throws a JS `Error`.
+    #[wasm_bindgen(js_name = from)]
+    pub fn from_value(
+        #[wasm_bindgen(unchecked_param_type = "EllipsoidInput | null | undefined")] obj: JsValue,
+    ) -> Result<Ellipsoid, JsValue> {
+        let inner = if obj.is_null() || obj.is_undefined() {
+            RustEllipsoid::default()
+        } else {
+            let parsed: EllipsoidLike = from_value(obj)?;
+            parsed
+                .into_ellipsoid()
+                .map_err(|message| JsError::new(&message))?
+        };
+
+        Ok(Ellipsoid { inner })
+    }
+
+    /// Semi-major axis (the radius, for a sphere) in meters
+    #[wasm_bindgen(getter, js_name = semiMajorAxis)]
+    pub fn semi_major_axis(&self) -> f64 {
+        self.inner.ellipsoid().semimajor_axis()
+    }
+
+    /// Flattening (0 for a sphere)
+    #[wasm_bindgen(getter)]
+    pub fn flattening(&self) -> f64 {
+        self.inner.ellipsoid().flattening()
+    }
+
+    /// Whether this reference body is a sphere
+    #[wasm_bindgen(getter, js_name = isSphere)]
+    pub fn is_sphere(&self) -> bool {
+        matches!(self.inner, RustEllipsoid::Sphere(_))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use geodesy::prelude::EllipsoidBase;
-    use healpix_geo_core::ellipsoid::ReferenceBody;
 
     #[test]
     fn test_ellipsoidlike_to_ellipsoid() {
@@ -108,7 +243,7 @@ mod tests {
             inverse_flattening: if_,
         });
 
-        let actual = obj.into_ellipsoid();
+        let actual = obj.into_ellipsoid().unwrap();
         match actual {
             RustEllipsoid::Ellipsoid(ell) => {
                 let unpacked = ell.ellipsoid();
@@ -161,6 +296,93 @@ mod tests {
 
         assert_eq!(actual, expected);
     }
+
+    fn inverse_flattening(semi_major_axis: f64, inverse_flattening: f64) -> EllipsoidLike {
+        EllipsoidLike::EllipsoidInverseFlattening(EllipsoidInverseFlattening {
+            semi_major_axis,
+            inverse_flattening,
+        })
+    }
+
+    fn semi_minor(semi_major_axis: f64, semi_minor_axis: f64) -> EllipsoidLike {
+        EllipsoidLike::EllipsoidSemiMinorAxis(EllipsoidSemiMinorAxis {
+            semi_major_axis,
+            semi_minor_axis,
+        })
+    }
+
+    #[test]
+    fn test_rejects_degenerate_spheres() {
+        for radius in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            assert!(
+                EllipsoidLike::Sphere(Sphere { radius })
+                    .into_ellipsoid()
+                    .is_err(),
+                "radius {}",
+                radius
+            );
+        }
+    }
+
+    #[test]
+    fn test_default_sphere() {
+        assert!(
+            EllipsoidLike::Sphere(Sphere::default())
+                .into_ellipsoid()
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_rejects_degenerate_inverse_flattening() {
+        // `0` is the plausible-looking way to *mean* a sphere; it produces
+        // `flattening: Infinity` instead, so it is rejected outright
+        for value in [0.0, 1.0, -298.257223563, f64::NAN] {
+            assert!(
+                inverse_flattening(6378137.0, value)
+                    .into_ellipsoid()
+                    .is_err(),
+                "inverse_flattening {}",
+                value
+            );
+        }
+
+        assert!(
+            inverse_flattening(0.0, 298.257223563)
+                .into_ellipsoid()
+                .is_err()
+        );
+        assert!(
+            inverse_flattening(-6378137.0, 298.257223563)
+                .into_ellipsoid()
+                .is_err()
+        );
+        assert!(
+            inverse_flattening(6378137.0, 298.257223563)
+                .into_ellipsoid()
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_rejects_degenerate_semi_minor_axis() {
+        assert!(semi_minor(6378137.0, 0.0).into_ellipsoid().is_err());
+        assert!(semi_minor(6378137.0, -1.0).into_ellipsoid().is_err());
+        // an oblate spheroid is what the shape describes; b > a is not one
+        assert!(
+            semi_minor(6356752.314245179, 6378137.0)
+                .into_ellipsoid()
+                .is_err()
+        );
+
+        assert!(
+            semi_minor(6378137.0, 6356752.314245179)
+                .into_ellipsoid()
+                .is_ok()
+        );
+        // a == b is a sphere expressed the long way, and stays legal
+        assert!(semi_minor(6378137.0, 6378137.0).into_ellipsoid().is_ok());
+    }
 }
 
 #[cfg(all(test, target_arch = "wasm32"))]
@@ -173,20 +395,15 @@ pub mod tests_wasm32 {
     wasm_bindgen_test_configure!(run_in_browser);
 
     #[wasm_bindgen_test]
-    fn test_parse_ellipsoid_ellipsoid() {
+    fn test_ellipsoid_from_ellipsoid() {
         let a: f64 = 6378137.0;
         let if_: f64 = 298.257223563;
 
         let data = json!({"name": "WGS84", "semi_major_axis": a, "inverse_flattening": if_});
         let obj = to_value(&data).map_err(JsValue::from).unwrap();
 
-        let actual: EllipsoidLike = parse_ellipsoid(obj).map_err(JsValue::from).unwrap();
-        match actual {
-            EllipsoidLike::EllipsoidInverseFlattening(ell) => {
-                assert_eq!(ell.semi_major_axis, a);
-                assert_eq!(ell.inverse_flattening, if_);
-            }
-            _ => unreachable!(),
-        }
+        let actual = Ellipsoid::from_value(obj).map_err(JsValue::from).unwrap();
+        assert_eq!(actual.semi_major_axis(), a);
+        assert!(!actual.is_sphere());
     }
 }

--- a/js/src/geometry.rs
+++ b/js/src/geometry.rs
@@ -39,14 +39,32 @@ const ONE_OVER_NSIDE: [f64; 30] = [
     one_over_nside(29),
 ];
 
-pub(crate) fn spherical_vertex(center: (f64, f64), depth: u8, delta: (f64, f64)) -> (f64, f64) {
+/// Spherical (authalic-latitude) vertex of a cell, offsets checked.
+///
+/// `u` and `v` are offsets from the southern vertex of the cell, and have to
+/// be in `[0, 1]` (`NaN` fails the range check). The bound is also what keeps
+/// `cdshealpix::unproj` from panicking — an unrecoverable wasm trap — on its
+/// `-2 ≤ y ≤ 2` assertion on the projected coordinate.
+pub(crate) fn spherical_vertex(
+    center: (f64, f64),
+    depth: u8,
+    delta: (f64, f64),
+) -> Result<(f64, f64), String> {
+    let (u, v) = delta;
+    if !(0.0..=1.0).contains(&u) || !(0.0..=1.0).contains(&v) {
+        return Err(format!(
+            "vertex offsets must be in [0, 1], got (u = {}, v = {})",
+            u, v
+        ));
+    }
+
     let one_over_nside = ONE_OVER_NSIDE[depth as usize];
 
-    let dx = delta.0 - delta.1;
-    let dy = delta.0 + delta.1 - 1.0;
+    let dx = u - v;
+    let dy = u + v - 1.0;
 
-    healpix::unproj(
+    Ok(healpix::unproj(
         center.0 + dx * one_over_nside,
         center.1 + dy * one_over_nside,
-    )
+    ))
 }

--- a/js/src/grid.rs
+++ b/js/src/grid.rs
@@ -1,0 +1,723 @@
+use cdshealpix as healpix;
+use geodesy::prelude::EllipsoidBase;
+use healpix_geo_core::ellipsoid::{Ellipsoid as RustEllipsoid, ReferenceBody};
+use serde::Deserialize;
+use serde_wasm_bindgen::from_value;
+use wasm_bindgen::prelude::*;
+
+use crate::coordinates::Coordinate;
+use crate::ellipsoid::EllipsoidLike;
+use crate::geometry::spherical_vertex;
+
+const MAX_LEVEL: u8 = 29;
+
+/// Number of cells of a full HEALPix grid at `level` (12 · 4^level).
+fn n_cells(level: u8) -> u64 {
+    12u64 << (2 * level)
+}
+
+/// Decode a `zuniq` cell id.
+///
+/// `cdshealpix`'s `from_zuniq` is infallible in the type system but panics —
+/// an unrecoverable wasm trap — for values that are not valid zuniq
+/// encodings: `0` underflows the level computation, and ids whose sentinel bit
+/// sits at an odd position or whose hash is out of range at the encoded level
+/// (`u64::MAX`, for instance) blow up further down. Validate first.
+fn from_zuniq_checked(cell: u64) -> Result<(u8, u64), String> {
+    // a well-formed zuniq id has its sentinel bit at 2·(29 − level); note
+    // that `0` has 64 trailing zeros and is rejected by the upper bound
+    let trailing = cell.trailing_zeros();
+    if !trailing.is_multiple_of(2) || trailing > 2 * u32::from(MAX_LEVEL) {
+        return Err(format!("{} is not a valid zuniq cell id", cell));
+    }
+
+    let (level, hash) = healpix::nested::from_zuniq(cell);
+    if hash >= n_cells(level) {
+        return Err(format!(
+            "{} is not a valid zuniq cell id: hash {} is out of range at level {}",
+            cell, hash, level
+        ));
+    }
+
+    Ok((level, hash))
+}
+
+/// Narrow a JS `number` to a `u32`, rejecting what wasm-bindgen would coerce.
+///
+/// wasm-bindgen converts a `number` parameter declared as `u32` with
+/// JavaScript's ToUint32 semantics — truncate the fraction, then take the
+/// result modulo 2³² — *before* Rust sees it. `bitCombine(2 ** 32, 0)` would
+/// arrive as `(0, 0)` and quietly pass the range check it was meant to fail,
+/// so the count-like parameters are taken as `f64` and narrowed here instead.
+/// The generated TypeScript signature is `number` either way.
+fn to_u32(value: f64, name: &str) -> Result<u32, String> {
+    if !value.is_finite() || value.fract() != 0.0 {
+        return Err(format!("`{}` must be an integer, got {}", name, value));
+    }
+    if !(0.0..=f64::from(u32::MAX)).contains(&value) {
+        return Err(format!(
+            "`{}` must be in [0, {}], got {}",
+            name,
+            u32::MAX,
+            value
+        ));
+    }
+
+    Ok(value as u32)
+}
+
+/// Narrow a JS `number` to a refinement level.
+///
+/// Range-checked against the level bound directly instead of narrowing through
+/// `to_u32` first, so a negative level is reported as out of `[0, 29]` rather
+/// than out of the `u32` range, which is not this parameter's contract.
+fn to_level(value: f64) -> Result<u8, String> {
+    if !value.is_finite() || value.fract() != 0.0 {
+        return Err(format!("`level` must be an integer, got {}", value));
+    }
+    if !(0.0..=f64::from(MAX_LEVEL)).contains(&value) {
+        return Err(format!(
+            "`level` must be in [0, {}], got {}",
+            MAX_LEVEL, value
+        ));
+    }
+
+    Ok(value as u8)
+}
+
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum Scheme {
+    Nested,
+    Ring,
+    Zuniq,
+}
+
+impl Scheme {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Nested => "nested",
+            Self::Ring => "ring",
+            Self::Zuniq => "zuniq",
+        }
+    }
+
+    fn parse(name: &str) -> Result<Scheme, String> {
+        match name {
+            "nested" => Ok(Self::Nested),
+            "ring" => Ok(Self::Ring),
+            "zuniq" => Ok(Self::Zuniq),
+            _ => Err(format!(
+                "unknown scheme {:?}: expected \"nested\", \"ring\" or \"zuniq\"",
+                name
+            )),
+        }
+    }
+}
+
+#[derive(Deserialize, Debug)]
+pub(crate) struct GridOptions {
+    scheme: Scheme,
+    level: u8,
+    #[serde(default)]
+    ellipsoid: Option<EllipsoidLike>,
+}
+
+/// The options object accepted by the `Grid` constructor.
+#[wasm_bindgen(typescript_custom_section)]
+const GRID_OPTIONS: &'static str = r#"
+export type GridOptions = {
+    scheme: "nested" | "ring" | "zuniq";
+    level: number;
+    ellipsoid?: EllipsoidInput | null;
+};
+"#;
+
+/// A HEALPix grid at a fixed refinement level on a fixed reference body.
+///
+/// Constructed with `new Grid(options)`. The scheme dispatch, the level, and
+/// the parsed ellipsoid state (including the authalic-latitude coefficients)
+/// are stored once, so per-call overhead is limited to the actual coordinate
+/// math.
+///
+/// Every method validates its inputs and reports misuse as a catchable JS
+/// `Error` rather than trapping the wasm instance.
+#[wasm_bindgen]
+pub struct Grid {
+    scheme: Scheme,
+    level: u8,
+    pub(crate) ellipsoid: RustEllipsoid,
+}
+
+impl Grid {
+    pub(crate) fn from_options(options: GridOptions) -> Result<Grid, String> {
+        let level = options.level;
+        if level > MAX_LEVEL {
+            return Err(format!(
+                "`level` must be in [0, {}], got {}",
+                MAX_LEVEL, level
+            ));
+        }
+
+        let ellipsoid = options
+            .ellipsoid
+            .map(|e| e.into_ellipsoid())
+            .transpose()?
+            .unwrap_or_default();
+
+        Ok(Grid {
+            scheme: options.scheme,
+            level,
+            ellipsoid,
+        })
+    }
+
+    /// Number of cells at the grid's level.
+    fn n_cells(&self) -> u64 {
+        n_cells(self.level)
+    }
+
+    fn check_cell(&self, cell: u64) -> Result<(), String> {
+        if cell >= self.n_cells() {
+            return Err(format!(
+                "cell id {} is out of range at level {} ({} cells)",
+                cell,
+                self.level,
+                self.n_cells()
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// The cell in the nested scheme plus the level it lives at.
+    ///
+    /// The `ring` branch converts to nested and then uses the nested
+    /// coordinate implementation (the same route
+    /// [`healpix_geo_wasm::ring`][crate::ring] takes), rather than
+    /// `healpix_geo_core::scalar::ring::coordinates`; the two agree
+    /// everywhere tested, but only one of them is exercised.
+    pub(crate) fn to_nested(&self, cell: u64) -> Result<(u8, u64), String> {
+        match self.scheme {
+            Scheme::Nested => {
+                self.check_cell(cell)?;
+                Ok((self.level, cell))
+            }
+            Scheme::Ring => {
+                self.check_cell(cell)?;
+                Ok((self.level, healpix::nested::get(self.level).from_ring(cell)))
+            }
+            Scheme::Zuniq => from_zuniq_checked(cell),
+        }
+    }
+
+    /// A nested hash at the grid's level, expressed in the grid's scheme.
+    fn nested_to_scheme(&self, hash: u64) -> u64 {
+        match self.scheme {
+            Scheme::Nested => hash,
+            Scheme::Ring => healpix::nested::get(self.level).to_ring(hash),
+            Scheme::Zuniq => healpix::nested::to_zuniq(self.level, hash),
+        }
+    }
+
+    /// Convert a cell id from the grid's scheme to `target`.
+    ///
+    /// Without `level`: `nested` ↔ `ring` convert at the grid's level;
+    /// converting *to* `zuniq` encodes the grid's level; converting *from*
+    /// `zuniq` uses the level embedded in the id (as [`Grid::vertex_impl`]
+    /// does), so the result lives at that level and `zuniq` → `zuniq` is the
+    /// identity.
+    ///
+    /// With `level` (mirroring the Python bindings' `auto.convert`): only
+    /// valid when `target` encodes the level in its cell ids — `zuniq` today —
+    /// and the grid's scheme does not; `cell` is then read as a cell of the
+    /// grid's scheme at `level` and encoded with it.
+    pub(crate) fn to_scheme_impl(
+        &self,
+        cell: u64,
+        target: Scheme,
+        level: Option<f64>,
+    ) -> Result<u64, String> {
+        let Some(level) = level else {
+            let (level, hash) = self.to_nested(cell)?;
+
+            return Ok(match target {
+                Scheme::Nested => hash,
+                Scheme::Ring => healpix::nested::get(level).to_ring(hash),
+                Scheme::Zuniq => healpix::nested::to_zuniq(level, hash),
+            });
+        };
+
+        if self.scheme == Scheme::Zuniq {
+            return Err(
+                "`level` is invalid when converting from \"zuniq\": the cell ids already encode their level"
+                    .to_string(),
+            );
+        }
+        if target != Scheme::Zuniq {
+            return Err(format!(
+                "`level` is only valid when converting to a scheme that encodes the level in its cell ids (\"zuniq\"), not \"{}\"",
+                target.name()
+            ));
+        }
+
+        let level = to_level(level)?;
+        if cell >= n_cells(level) {
+            return Err(format!(
+                "cell id {} is out of range at level {} ({} cells)",
+                cell,
+                level,
+                n_cells(level)
+            ));
+        }
+
+        let hash = match self.scheme {
+            Scheme::Nested => cell,
+            Scheme::Ring => healpix::nested::get(level).from_ring(cell),
+            Scheme::Zuniq => unreachable!("rejected above"),
+        };
+
+        Ok(healpix::nested::to_zuniq(level, hash))
+    }
+
+    pub(crate) fn vertex_impl(&self, cell: u64, u: f64, v: f64) -> Result<Coordinate, String> {
+        let (level, hash) = self.to_nested(cell)?;
+        let layer = healpix::nested::get(level);
+
+        let center = layer.center_of_projected_cell(hash);
+        let (lon, lat) = spherical_vertex(center, level, (u, v))?;
+
+        Ok(Coordinate {
+            lon: lon.to_degrees().rem_euclid(360.0),
+            lat: self
+                .ellipsoid
+                .latitude_authalic_to_geographic(lat)
+                .to_degrees(),
+        })
+    }
+
+    pub(crate) fn bit_combine_impl(&self, i: f64, j: f64) -> Result<u64, String> {
+        let (i, j) = (to_u32(i, "i")?, to_u32(j, "j")?);
+
+        let nside = self.nside();
+        if i >= nside || j >= nside {
+            return Err(format!(
+                "z-order coordinates ({}, {}) are out of range for nside {}",
+                i, j, nside
+            ));
+        }
+
+        let zoc = healpix::nested::zordercurve::get_zoc(self.level);
+
+        Ok(self.nested_to_scheme(zoc.ij2h(i, j)))
+    }
+}
+
+#[wasm_bindgen]
+impl Grid {
+    /// Create a grid from plain options.
+    ///
+    /// Options:
+    /// - `scheme`: `"nested"`, `"ring"` or `"zuniq"` (required)
+    /// - `level`: the refinement level, at most 29; level 0 is the 12 base
+    ///   cells (required)
+    /// - `ellipsoid`: a plain object as accepted by `Ellipsoid.from`, or
+    ///   `null`/absent for the default sphere
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        #[wasm_bindgen(unchecked_param_type = "GridOptions")] options: JsValue,
+    ) -> Result<Grid, JsValue> {
+        let options: GridOptions = from_value(options)?;
+
+        Grid::from_options(options).map_err(|message| JsError::new(&message).into())
+    }
+
+    /// The indexing scheme: "nested", "ring" or "zuniq"
+    ///
+    /// Narrowed to the literal union so that `other.toScheme(cell,
+    /// grid.scheme)` type-checks and `switch (grid.scheme)` is exhaustive.
+    #[wasm_bindgen(getter, unchecked_return_type = "\"nested\" | \"ring\" | \"zuniq\"")]
+    pub fn scheme(&self) -> String {
+        self.scheme.name().to_string()
+    }
+
+    /// The refinement level of the grid (0-indexed; level 0 is the 12 base
+    /// cells)
+    #[wasm_bindgen(getter)]
+    pub fn level(&self) -> u8 {
+        self.level
+    }
+
+    /// The nside (2^level) of the grid
+    #[wasm_bindgen(getter)]
+    pub fn nside(&self) -> u32 {
+        1u32 << self.level
+    }
+
+    /// Semi-major axis of the reference body (the radius, for a sphere), in
+    /// meters
+    #[wasm_bindgen(getter, js_name = semiMajorAxis)]
+    pub fn semi_major_axis(&self) -> f64 {
+        self.ellipsoid.ellipsoid().semimajor_axis()
+    }
+
+    /// Flattening of the reference body (0 for a sphere)
+    #[wasm_bindgen(getter)]
+    pub fn flattening(&self) -> f64 {
+        self.ellipsoid.ellipsoid().flattening()
+    }
+
+    /// Whether the reference body is a sphere
+    #[wasm_bindgen(getter, js_name = isSphere)]
+    pub fn is_sphere(&self) -> bool {
+        matches!(self.ellipsoid, RustEllipsoid::Sphere(_))
+    }
+
+    /// The reference body of the grid, as a **new** handle
+    ///
+    /// Every read clones the parsed ellipsoid into a freshly allocated
+    /// `Ellipsoid` (wasm allocation + JS wrapper + finalizer registration), so
+    /// this is not a free property access: hoist it out of hot paths and
+    /// `free()` it when done, or use the `semiMajorAxis` / `flattening` /
+    /// `isSphere` getters above, which return plain numbers.
+    #[wasm_bindgen(getter)]
+    pub fn ellipsoid(&self) -> crate::ellipsoid::Ellipsoid {
+        crate::ellipsoid::Ellipsoid {
+            inner: self.ellipsoid.clone(),
+        }
+    }
+
+    /// Single vertex of the given cell
+    ///
+    /// `u` and `v` are offsets from the southern vertex of the cell, in
+    /// `[0, 1]`; anything else throws. For the `zuniq` scheme, the level
+    /// encoded in the cell id is used.
+    pub fn vertex(&self, cell: u64, u: f64, v: f64) -> Result<Coordinate, JsValue> {
+        self.vertex_impl(cell, u, v)
+            .map_err(|message| JsError::new(&message).into())
+    }
+
+    /// Cell index at the given z-order coordinates
+    ///
+    /// Interleaves the bits of `i` and `j` (the two axes of the nested
+    /// z-order numbering within a base-resolution pixel) into the cell index
+    /// at the grid's level, expressed in the grid's scheme. Both coordinates
+    /// have to be non-negative integers smaller than `nside`.
+    #[wasm_bindgen(js_name = bitCombine)]
+    pub fn bit_combine(&self, i: f64, j: f64) -> Result<u64, JsValue> {
+        self.bit_combine_impl(i, j)
+            .map_err(|message| JsError::new(&message).into())
+    }
+
+    /// Convert a cell id from the grid's scheme to another scheme
+    ///
+    /// `scheme` is one of `"nested"`, `"ring"` or `"zuniq"`. `nested` and
+    /// `ring` convert at the grid's level. Converting to `zuniq` encodes the
+    /// grid's level; converting from `zuniq` uses the level encoded in the
+    /// cell id (as `vertex` does), so the result lives at that level and
+    /// `zuniq` to `zuniq` is the identity.
+    ///
+    /// The optional `level` overrides the level `cell` is read and encoded
+    /// at. It is only valid when converting to a scheme that encodes the
+    /// level in its cell ids — `"zuniq"` today — and from a scheme that does
+    /// not (`nested` or `ring`); anything else throws.
+    #[wasm_bindgen(js_name = toScheme)]
+    pub fn to_scheme(
+        &self,
+        cell: u64,
+        #[wasm_bindgen(unchecked_param_type = "\"nested\" | \"ring\" | \"zuniq\"")] scheme: &str,
+        level: Option<f64>,
+    ) -> Result<u64, JsValue> {
+        Scheme::parse(scheme)
+            .and_then(|target| self.to_scheme_impl(cell, target, level))
+            .map_err(|message| JsError::new(&message).into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn options(scheme: Scheme, level: u8) -> GridOptions {
+        GridOptions {
+            scheme,
+            level,
+            ellipsoid: None,
+        }
+    }
+
+    fn grid(scheme: Scheme, level: u8) -> Grid {
+        Grid::from_options(options(scheme, level)).unwrap()
+    }
+
+    #[test]
+    fn test_level_validation() {
+        assert!(Grid::from_options(options(Scheme::Nested, 30)).is_err());
+
+        let valid = Grid::from_options(options(Scheme::Nested, 3)).unwrap();
+        assert_eq!(valid.level(), 3);
+        assert_eq!(valid.nside(), 8);
+    }
+
+    #[test]
+    fn test_vertex_matches_scheme_statics() {
+        let grid = grid(Scheme::Nested, 0);
+
+        let expected: Vec<(f64, f64)> = vec![
+            (45.0, 0.0),
+            (67.5, 19.47122063),
+            (90.0, 41.8103149),
+            (45.0, 90.0),
+        ];
+        let uv: Vec<(f64, f64)> = vec![(0.0, 0.0), (0.5, 0.0), (1.0, 0.0), (1.0, 1.0)];
+
+        for ((u, v), (lon, lat)) in uv.into_iter().zip(expected) {
+            let actual = grid.vertex_impl(0, u, v).unwrap();
+            assert!((actual.lon - lon).abs() < 1e-4);
+            assert!((actual.lat - lat).abs() < 1e-4);
+        }
+    }
+
+    #[test]
+    fn test_zuniq_uses_encoded_level() {
+        // level 0, nested cell 0 encoded as zuniq
+        let cell = healpix::nested::to_zuniq(0, 0);
+        let grid = grid(Scheme::Zuniq, 4);
+
+        let vertex = grid.vertex_impl(cell, 0.0, 0.0).unwrap();
+        assert!((vertex.lon - 45.0).abs() < 1e-4);
+        assert!(vertex.lat.abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_flattened_ellipsoid_getters_match_the_handle() {
+        let grid = grid(Scheme::Nested, 4);
+
+        assert_eq!(grid.semi_major_axis(), grid.ellipsoid().semi_major_axis());
+        assert_eq!(grid.flattening(), grid.ellipsoid().flattening());
+        assert_eq!(grid.is_sphere(), grid.ellipsoid().is_sphere());
+        assert!(grid.is_sphere());
+    }
+
+    #[test]
+    fn test_rejects_out_of_range_cells() {
+        // 12 · 4^4 == 3072 is the first invalid id at level 4; cdshealpix
+        // panics on it ("Wrong hash value: too large")
+        for scheme in [Scheme::Nested, Scheme::Ring] {
+            let grid = grid(scheme, 4);
+            assert_eq!(grid.n_cells(), 3072);
+
+            assert!(grid.vertex_impl(3072, 0.5, 0.5).is_err());
+            assert!(grid.vertex_impl(u64::MAX, 0.5, 0.5).is_err());
+            assert!(grid.vertex_impl(3071, 0.5, 0.5).is_ok());
+        }
+    }
+
+    #[test]
+    fn test_rejects_invalid_zuniq_cells() {
+        let grid = grid(Scheme::Zuniq, 4);
+
+        // `0` used to underflow the level computation
+        assert!(grid.vertex_impl(0, 0.5, 0.5).is_err());
+        // sentinel bit at an odd position
+        assert!(grid.vertex_impl(2, 0.5, 0.5).is_err());
+        // hash out of range at the encoded level
+        assert!(grid.vertex_impl(u64::MAX, 0.5, 0.5).is_err());
+
+        let valid = healpix::nested::to_zuniq(4, 164);
+        assert!(grid.vertex_impl(valid, 0.5, 0.5).is_ok());
+    }
+
+    #[test]
+    fn test_bit_combine_rejects_out_of_range_coordinates() {
+        // ring is the dangerous one: an out-of-range nested hash used to
+        // panic inside `to_ring` ("assertion failed: j_d0h <= 2")
+        for scheme in [Scheme::Nested, Scheme::Ring, Scheme::Zuniq] {
+            let grid = grid(scheme, 1);
+            assert_eq!(grid.nside(), 2);
+
+            assert!(grid.bit_combine_impl(0.0, 2.0).is_err());
+            assert!(grid.bit_combine_impl(256.0, 0.0).is_err());
+            assert!(grid.bit_combine_impl(1.0, 1.0).is_ok());
+        }
+    }
+
+    #[test]
+    fn test_bit_combine_rejects_non_integer_and_wrapping_coordinates() {
+        // wasm-bindgen would have coerced each of these to an in-range `u32`
+        // before the guard above ever ran: `2^32` to 0, `1.9` to 1, `NaN` to 0
+        let grid = grid(Scheme::Nested, 4);
+
+        assert!(grid.bit_combine_impl(4294967296.0, 0.0).is_err());
+        assert!(grid.bit_combine_impl(1.9, 1.0).is_err());
+        assert!(grid.bit_combine_impl(f64::NAN, 0.0).is_err());
+        assert!(grid.bit_combine_impl(f64::INFINITY, 0.0).is_err());
+        assert!(grid.bit_combine_impl(-1.0, 0.0).is_err());
+        assert!(grid.bit_combine_impl(0.0, -1.0).is_err());
+
+        assert!(grid.bit_combine_impl(1.0, 1.0).is_ok());
+    }
+
+    #[test]
+    fn test_vertex_rejects_out_of_range_offsets() {
+        // `u`/`v` outside `[0, 1]` used to trap the wasm instance inside
+        // `unproj`'s `-2 <= y <= 2` assertion once they left the projection
+        // plane; the contract is now a strict `[0, 1]`
+        let grid = grid(Scheme::Nested, 4);
+
+        assert!(grid.vertex_impl(164, f64::NAN, 0.0).is_err());
+        assert!(grid.vertex_impl(164, 0.0, f64::NAN).is_err());
+        assert!(grid.vertex_impl(164, f64::INFINITY, 0.0).is_err());
+        assert!(grid.vertex_impl(164, -0.1, 0.0).is_err());
+        assert!(grid.vertex_impl(164, 0.0, 1.5).is_err());
+        assert!(grid.vertex_impl(164, 10.0, 0.0).is_err());
+
+        // the whole cell-local range stays legal, boundaries included
+        assert!(grid.vertex_impl(164, 0.0, 0.0).is_ok());
+        assert!(grid.vertex_impl(164, 0.5, 0.5).is_ok());
+        assert!(grid.vertex_impl(164, 1.0, 1.0).is_ok());
+    }
+
+    #[test]
+    fn test_bit_combine_matches_statics() {
+        assert_eq!(
+            grid(Scheme::Zuniq, 1).bit_combine_impl(0.0, 1.0).unwrap(),
+            360287970189639680
+        );
+        assert_eq!(grid(Scheme::Ring, 1).bit_combine_impl(0.0, 1.0).unwrap(), 4);
+        assert_eq!(
+            grid(Scheme::Nested, 1).bit_combine_impl(0.0, 1.0).unwrap(),
+            2
+        );
+    }
+
+    #[test]
+    fn test_to_scheme_nested_ring_roundtrip() {
+        // at level 1, nested 2 == ring 4 (see test_bit_combine_matches_statics)
+        let nested = grid(Scheme::Nested, 1);
+        let ring = grid(Scheme::Ring, 1);
+
+        assert_eq!(nested.to_scheme_impl(2, Scheme::Ring, None).unwrap(), 4);
+        assert_eq!(ring.to_scheme_impl(4, Scheme::Nested, None).unwrap(), 2);
+
+        // same-scheme conversions are the identity
+        assert_eq!(nested.to_scheme_impl(2, Scheme::Nested, None).unwrap(), 2);
+        assert_eq!(ring.to_scheme_impl(4, Scheme::Ring, None).unwrap(), 4);
+    }
+
+    #[test]
+    fn test_to_scheme_zuniq_encodes_the_grid_level() {
+        let nested = grid(Scheme::Nested, 4);
+        let id = nested.to_scheme_impl(164, Scheme::Zuniq, None).unwrap();
+        assert_eq!(id, healpix::nested::to_zuniq(4, 164));
+
+        let zuniq = grid(Scheme::Zuniq, 4);
+        assert_eq!(zuniq.to_scheme_impl(id, Scheme::Nested, None).unwrap(), 164);
+    }
+
+    #[test]
+    fn test_to_scheme_zuniq_uses_the_embedded_level() {
+        // a level-0 id in a level-4 grid converts at level 0, mirroring how
+        // `vertex` treats zuniq ids
+        let zuniq = grid(Scheme::Zuniq, 4);
+        let cell = healpix::nested::to_zuniq(0, 5);
+
+        assert_eq!(zuniq.to_scheme_impl(cell, Scheme::Nested, None).unwrap(), 5);
+        assert_eq!(
+            zuniq.to_scheme_impl(cell, Scheme::Ring, None).unwrap(),
+            healpix::nested::get(0).to_ring(5)
+        );
+        // zuniq -> zuniq keeps the id as-is
+        assert_eq!(
+            zuniq.to_scheme_impl(cell, Scheme::Zuniq, None).unwrap(),
+            cell
+        );
+    }
+
+    #[test]
+    fn test_to_scheme_level_override() {
+        let nested = grid(Scheme::Nested, 4);
+
+        // the grid's own level is a valid override
+        assert_eq!(
+            nested
+                .to_scheme_impl(164, Scheme::Zuniq, Some(4.0))
+                .unwrap(),
+            nested.to_scheme_impl(164, Scheme::Zuniq, None).unwrap()
+        );
+        // a coarser override reads (and encodes) the id at that level
+        assert_eq!(
+            nested.to_scheme_impl(5, Scheme::Zuniq, Some(0.0)).unwrap(),
+            healpix::nested::to_zuniq(0, 5)
+        );
+        // ring ids are converted at the override level too: ring 4 == nested
+        // 2 at level 1
+        let ring = grid(Scheme::Ring, 4);
+        assert_eq!(
+            ring.to_scheme_impl(4, Scheme::Zuniq, Some(1.0)).unwrap(),
+            healpix::nested::to_zuniq(1, 2)
+        );
+        // and the cell id is validated against the override level
+        assert!(
+            nested
+                .to_scheme_impl(164, Scheme::Zuniq, Some(0.0))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_to_scheme_level_rejections() {
+        let nested = grid(Scheme::Nested, 4);
+
+        // schemes whose ids do not encode the level reject the override
+        assert!(nested.to_scheme_impl(164, Scheme::Ring, Some(4.0)).is_err());
+        assert!(
+            nested
+                .to_scheme_impl(164, Scheme::Nested, Some(4.0))
+                .is_err()
+        );
+
+        // zuniq ids already carry their level, even for the identity
+        let zuniq = grid(Scheme::Zuniq, 4);
+        let id = healpix::nested::to_zuniq(4, 164);
+        assert!(zuniq.to_scheme_impl(id, Scheme::Zuniq, Some(4.0)).is_err());
+        assert!(zuniq.to_scheme_impl(id, Scheme::Nested, Some(4.0)).is_err());
+
+        // and the level itself is validated
+        assert!(
+            nested
+                .to_scheme_impl(164, Scheme::Zuniq, Some(30.0))
+                .is_err()
+        );
+        assert!(
+            nested
+                .to_scheme_impl(164, Scheme::Zuniq, Some(2.5))
+                .is_err()
+        );
+        assert!(
+            nested
+                .to_scheme_impl(164, Scheme::Zuniq, Some(f64::NAN))
+                .is_err()
+        );
+        assert!(
+            nested
+                .to_scheme_impl(164, Scheme::Zuniq, Some(-1.0))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_to_scheme_validates_the_input_id() {
+        assert!(
+            grid(Scheme::Nested, 4)
+                .to_scheme_impl(3072, Scheme::Ring, None)
+                .is_err()
+        );
+        assert!(
+            grid(Scheme::Zuniq, 4)
+                .to_scheme_impl(0, Scheme::Nested, None)
+                .is_err()
+        );
+        assert!(Scheme::parse("bogus").is_err());
+    }
+}

--- a/js/src/grid.rs
+++ b/js/src/grid.rs
@@ -1,6 +1,7 @@
 use cdshealpix as healpix;
 use geodesy::prelude::EllipsoidBase;
 use healpix_geo_core::ellipsoid::{Ellipsoid as RustEllipsoid, ReferenceBody};
+use healpix_geo_core::scalar::nested::coordinates as scalar;
 use serde::Deserialize;
 use serde_wasm_bindgen::from_value;
 use wasm_bindgen::prelude::*;
@@ -14,6 +15,16 @@ const MAX_LEVEL: u8 = 29;
 /// Number of cells of a full HEALPix grid at `level` (12 · 4^level).
 fn n_cells(level: u8) -> u64 {
     12u64 << (2 * level)
+}
+
+/// Capacity for `n` elements, or an error if that does not fit a `usize`.
+///
+/// `usize` is 32 bits on `wasm32`, and `steps`/`size` are `u32`, so the
+/// element count has to be computed in `u64` and checked — otherwise release
+/// builds get a wrapped capacity hint and debug builds panic on the multiply.
+fn capacity(n: Option<u64>, what: &str) -> Result<usize, String> {
+    n.and_then(|n| usize::try_from(n).ok())
+        .ok_or_else(|| format!("{} is too large: the output array would not fit", what))
 }
 
 /// Decode a `zuniq` cell id.
@@ -311,6 +322,141 @@ impl Grid {
 
         Ok(self.nested_to_scheme(zoc.ij2h(i, j)))
     }
+
+    /// The cell containing `(lon, lat)`, as a nested hash at the grid's level.
+    ///
+    /// `cdshealpix`'s `Layer::hash` asserts `-π/2 ≤ lat ≤ π/2` and traps
+    /// otherwise — including on `NaN`, which fails the comparison. A
+    /// non-finite longitude survives `rem_euclid` as `NaN` and trips the same
+    /// assert, so both are rejected up front.
+    fn lonlat_to_nested(&self, lon: f64, lat: f64) -> Result<u64, String> {
+        if !lon.is_finite() {
+            return Err(format!("longitude must be a finite number, got {}", lon));
+        }
+        if !(-90.0..=90.0).contains(&lat) {
+            return Err(format!("latitude must be in [-90, 90], got {}", lat));
+        }
+
+        let layer = healpix::nested::get(self.level);
+
+        Ok(scalar::lonlat_to_healpix(
+            &lon,
+            &lat,
+            layer,
+            &self.ellipsoid,
+        ))
+    }
+
+    pub(crate) fn vertices_impl(&self, cell: u64, steps: f64) -> Result<Vec<f64>, String> {
+        let steps = to_u32(steps, "steps")?;
+        if steps < 2 {
+            return Err("`steps` must be at least 2".to_string());
+        }
+        let count = capacity(
+            u64::from(steps)
+                .checked_mul(u64::from(steps))
+                .and_then(|n| n.checked_mul(2)),
+            &format!("`steps` = {}", steps),
+        )?;
+
+        let (level, hash) = self.to_nested(cell)?;
+        let layer = healpix::nested::get(level);
+        let center = layer.center_of_projected_cell(hash);
+
+        let mut out = Vec::with_capacity(count);
+
+        let scale = 1.0 / f64::from(steps - 1);
+        for i in 0..steps {
+            let u = f64::from(i) * scale;
+            for j in 0..steps {
+                let v = f64::from(j) * scale;
+
+                // `u` and `v` are generated in `[0, 1]`, so the range check
+                // in `spherical_vertex` cannot fail here
+                let (lon, lat) = spherical_vertex(center, level, (u, v))?;
+
+                out.push(lon.to_degrees().rem_euclid(360.0));
+                out.push(
+                    self.ellipsoid
+                        .latitude_authalic_to_geographic(lat)
+                        .to_degrees(),
+                );
+            }
+        }
+
+        Ok(out)
+    }
+
+    pub(crate) fn lonlat_to_healpix_impl(&self, lonlats: &[f64]) -> Result<Vec<u64>, String> {
+        if !lonlats.len().is_multiple_of(2) {
+            return Err("`lonlats` must be interleaved [lon, lat] pairs (even length)".to_string());
+        }
+
+        let mut out = Vec::with_capacity(lonlats.len() / 2);
+
+        for (index, pair) in lonlats.chunks_exact(2).enumerate() {
+            // one NaN in a million-element buffer used to abort the call with
+            // `RuntimeError: unreachable` — no message and no index
+            let hash = self
+                .lonlat_to_nested(pair[0], pair[1])
+                .map_err(|message| format!("lonlats[{}]: {}", index, message))?;
+
+            out.push(self.nested_to_scheme(hash));
+        }
+
+        Ok(out)
+    }
+
+    pub(crate) fn healpix_to_lonlat_impl(&self, cells: &[u64]) -> Result<Vec<f64>, String> {
+        let mut out = Vec::with_capacity(cells.len() * 2);
+
+        for (index, &cell) in cells.iter().enumerate() {
+            let (level, hash) = self
+                .to_nested(cell)
+                .map_err(|message| format!("cells[{}]: {}", index, message))?;
+            let layer = healpix::nested::get(level);
+            let (lon, lat) = scalar::healpix_to_lonlat(&hash, layer, &self.ellipsoid);
+
+            out.push(lon);
+            out.push(lat);
+        }
+
+        Ok(out)
+    }
+
+    pub(crate) fn bit_combine_table_impl(&self, size: f64) -> Result<Vec<u64>, String> {
+        let size = to_u32(size, "size")?;
+        if !size.is_power_of_two() {
+            return Err(format!("`size` must be a power of two, got {}", size));
+        }
+        let nside = self.nside();
+        if size > nside {
+            return Err(format!(
+                "`size` must be at most `nside` ({}) so that every entry is a cell of this grid, got {}",
+                nside, size
+            ));
+        }
+        let count = capacity(
+            u64::from(size).checked_mul(u64::from(size)),
+            &format!("`size` = {}", size),
+        )?;
+
+        // the z-order (Morton) interleave depends on the size of the block
+        // being unshuffled, not on the level of the grid: deriving it from
+        // `self.level` instead silently truncates (`SmallZOC` indexes its
+        // lookup table with `i as u8`) and, for level 0, degenerates to
+        // cdshealpix's `EMPTY_ZOC`, which returns 0 for every input
+        let zoc = healpix::nested::zordercurve::get_zoc(size.trailing_zeros() as u8);
+
+        let mut out = Vec::with_capacity(count);
+        for row in 0..size {
+            for col in 0..size {
+                out.push(self.nested_to_scheme(zoc.ij2h(col, row)));
+            }
+        }
+
+        Ok(out)
+    }
 }
 
 #[wasm_bindgen]
@@ -406,6 +552,70 @@ impl Grid {
     #[wasm_bindgen(js_name = bitCombine)]
     pub fn bit_combine(&self, i: f64, j: f64) -> Result<u64, JsValue> {
         self.bit_combine_impl(i, j)
+            .map_err(|message| JsError::new(&message).into())
+    }
+
+    /// All vertices of a `steps` × `steps` subdivision of the given cell, in
+    /// one call
+    ///
+    /// Equivalent to looping `vertex(cell, i / (steps - 1), j / (steps - 1))`
+    /// for `i` and `j` in `0..steps` (`i` outer, `j` inner), but the loop
+    /// runs inside WASM and the result comes back as a single typed array.
+    ///
+    /// Returns a `Float64Array` of length `steps * steps * 2`, interleaved as
+    /// `[lon0, lat0, lon1, lat1, ...]`. `steps` has to be an integer of at
+    /// least 2.
+    pub fn vertices(&self, cell: u64, steps: f64) -> Result<Vec<f64>, JsValue> {
+        self.vertices_impl(cell, steps)
+            .map_err(|message| JsError::new(&message).into())
+    }
+
+    /// Center coordinates of the given cells, in one call
+    ///
+    /// Returns a `Float64Array` of length `cells.length * 2`, interleaved as
+    /// `[lon0, lat0, lon1, lat1, ...]`. Rejects the whole batch, naming the
+    /// offending index, if any cell id is invalid for this grid.
+    ///
+    /// For a `zuniq` grid each id is read at the level embedded in it, so
+    /// feeding the result back through `lonLatToHealpix` re-encodes every
+    /// cell at the grid's level (see `lonLatToHealpix`).
+    #[wasm_bindgen(js_name = healpixToLonLat)]
+    pub fn healpix_to_lonlat(&self, cells: &[u64]) -> Result<Vec<f64>, JsValue> {
+        self.healpix_to_lonlat_impl(cells)
+            .map_err(|message| JsError::new(&message).into())
+    }
+
+    /// The cells containing the given coordinates, in one call
+    ///
+    /// `lonlats` is interleaved as `[lon0, lat0, lon1, lat1, ...]`; the
+    /// result is a `BigUint64Array` with one cell id per coordinate pair.
+    /// Rejects the whole batch, naming the offending index, if any longitude
+    /// is not finite or any latitude falls outside `[-90, 90]`.
+    ///
+    /// For a `zuniq` grid this is **not** the exact inverse of
+    /// `healpixToLonLat`: the ids produced here all carry the grid's level,
+    /// while `healpixToLonLat` reads each input id at the level embedded in
+    /// it. A mixed-level batch therefore comes back entirely at the grid's
+    /// level.
+    #[wasm_bindgen(js_name = lonLatToHealpix)]
+    pub fn lonlat_to_healpix(&self, lonlats: &[f64]) -> Result<Vec<u64>, JsValue> {
+        self.lonlat_to_healpix_impl(lonlats)
+            .map_err(|message| JsError::new(&message).into())
+    }
+
+    /// The full `size` × `size` z-order table, in one call
+    ///
+    /// Entry `row * size + col` holds `bitCombine(col, row)` — the layout
+    /// used when unshuffling a z-order-flattened `size` × `size` chunk into
+    /// row-major order.
+    ///
+    /// `size` is the edge length of the block being unshuffled. The z-order
+    /// interleave itself does not depend on the grid's level, but every entry
+    /// has to be a cell of this grid, so `size` must be an integer power of
+    /// two and at most `nside`.
+    #[wasm_bindgen(js_name = bitCombineTable)]
+    pub fn bit_combine_table(&self, size: f64) -> Result<Vec<u64>, JsValue> {
+        self.bit_combine_table_impl(size)
             .map_err(|message| JsError::new(&message).into())
     }
 
@@ -719,5 +929,257 @@ mod tests {
                 .is_err()
         );
         assert!(Scheme::parse("bogus").is_err());
+    }
+
+    fn wgs84() -> RustEllipsoid {
+        crate::ellipsoid::EllipsoidLike::EllipsoidInverseFlattening(
+            crate::ellipsoid::EllipsoidInverseFlattening {
+                semi_major_axis: 6378137.0,
+                inverse_flattening: 298.257223563,
+            },
+        )
+        .into_ellipsoid()
+        .unwrap()
+    }
+
+    #[test]
+    fn test_vertices_matches_scalar_vertex_over_the_full_gridlook_geometry() {
+        // the shape gridlook's `makeHealpixGeometry` builds: 12 base cells ×
+        // 65 × 65 vertices, in both sphere and ellipsoid mode. This is the
+        // bit-for-bit cross-check the benchmark write-up refers to.
+        let steps = 65u32;
+        let scale = 1.0 / f64::from(steps - 1);
+
+        for ellipsoid in [RustEllipsoid::default(), wgs84()] {
+            let mut geometry = grid(Scheme::Nested, 0);
+            geometry.ellipsoid = ellipsoid;
+
+            for cell in 0..12u64 {
+                let bulk = geometry.vertices_impl(cell, f64::from(steps)).unwrap();
+                assert_eq!(bulk.len(), (steps * steps * 2) as usize);
+
+                for i in 0..steps {
+                    for j in 0..steps {
+                        let scalar = geometry
+                            .vertex_impl(cell, f64::from(i) * scale, f64::from(j) * scale)
+                            .unwrap();
+                        let offset = ((i * steps + j) * 2) as usize;
+                        assert_eq!(bulk[offset], scalar.lon);
+                        assert_eq!(bulk[offset + 1], scalar.lat);
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_vertices_rejects_degenerate_steps() {
+        let grid = grid(Scheme::Nested, 4);
+        assert!(grid.vertices_impl(164, 1.0).is_err());
+        assert!(grid.vertices_impl(164, 0.0).is_err());
+    }
+
+    #[test]
+    fn test_bulk_methods_reject_invalid_cells() {
+        let nested_grid = grid(Scheme::Nested, 4);
+        assert!(nested_grid.vertices_impl(3072, 2.0).is_err());
+
+        // the offending index is named rather than trapping the instance on
+        // one bad element of a long batch
+        let message = nested_grid
+            .healpix_to_lonlat_impl(&[0, 164, 3072])
+            .unwrap_err();
+        assert!(message.starts_with("cells[2]:"), "{}", message);
+
+        let zuniq_grid = grid(Scheme::Zuniq, 4);
+        assert!(zuniq_grid.healpix_to_lonlat_impl(&[0]).is_err());
+        assert!(zuniq_grid.healpix_to_lonlat_impl(&[u64::MAX]).is_err());
+    }
+
+    #[test]
+    fn test_lonlat_roundtrip() {
+        let grid = grid(Scheme::Ring, 4);
+        let cells: Vec<u64> = vec![0, 164, 700];
+
+        let centers = grid.healpix_to_lonlat_impl(&cells).unwrap();
+        assert_eq!(centers.len(), cells.len() * 2);
+
+        let roundtrip = grid.lonlat_to_healpix_impl(&centers).unwrap();
+        assert_eq!(roundtrip, cells);
+    }
+
+    #[test]
+    fn test_lonlat_to_healpix_rejects_odd_length() {
+        let grid = grid(Scheme::Nested, 4);
+        assert!(grid.lonlat_to_healpix_impl(&[45.0, 0.0, 90.0]).is_err());
+    }
+
+    #[test]
+    fn test_lonlat_to_healpix_rejects_out_of_range_coordinates() {
+        // every one of these used to trap the wasm instance inside
+        // `Layer::hash`'s `-FRAC_PI_2 <= lat <= FRAC_PI_2` assertion
+        for scheme in [Scheme::Nested, Scheme::Ring, Scheme::Zuniq] {
+            let grid = grid(scheme, 4);
+
+            assert!(grid.lonlat_to_healpix_impl(&[0.0, 100.0]).is_err());
+            assert!(grid.lonlat_to_healpix_impl(&[0.0, -90.000000001]).is_err());
+            assert!(grid.lonlat_to_healpix_impl(&[0.0, f64::NAN]).is_err());
+            assert!(grid.lonlat_to_healpix_impl(&[f64::NAN, 0.0]).is_err());
+            assert!(grid.lonlat_to_healpix_impl(&[f64::INFINITY, 0.0]).is_err());
+
+            // the poles themselves are legal, and so is an unwrapped longitude
+            assert!(grid.lonlat_to_healpix_impl(&[0.0, 90.0]).is_ok());
+            assert!(grid.lonlat_to_healpix_impl(&[0.0, -90.0]).is_ok());
+            assert!(grid.lonlat_to_healpix_impl(&[-720.5, 45.0]).is_ok());
+        }
+    }
+
+    #[test]
+    fn test_lonlat_to_healpix_names_the_offending_index() {
+        // one NaN out of a data buffer used to trap the whole instance with
+        // `RuntimeError: unreachable`, naming nothing
+        let grid = grid(Scheme::Nested, 4);
+
+        let message = grid
+            .lonlat_to_healpix_impl(&[45.0, 0.0, 45.0, 0.0, 0.0, 100.0])
+            .unwrap_err();
+        assert!(message.starts_with("lonlats[2]:"), "{}", message);
+
+        let message = grid.lonlat_to_healpix_impl(&[45.0, f64::NAN]).unwrap_err();
+        assert!(message.starts_with("lonlats[0]:"), "{}", message);
+        assert!(grid.lonlat_to_healpix_impl(&[f64::NAN, 0.0]).is_err());
+
+        // and the legal batch still works
+        assert_eq!(grid.lonlat_to_healpix_impl(&[45.0, 0.0]).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_zuniq_lonlat_methods_are_not_inverses_across_levels() {
+        // `healpixToLonLat` reads each id at its embedded level,
+        // `lonLatToHealpix` always encodes at the grid's level: a coarse id
+        // does not survive the roundtrip. This is the documented rule, pinned
+        // here.
+        let grid = grid(Scheme::Zuniq, 4);
+        let coarse = healpix::nested::to_zuniq(0, 5);
+        let fine = healpix::nested::to_zuniq(4, 164);
+
+        let centers = grid.healpix_to_lonlat_impl(&[coarse, fine]).unwrap();
+        let roundtrip = grid.lonlat_to_healpix_impl(&centers).unwrap();
+
+        assert_eq!(roundtrip[1], fine);
+        assert_ne!(roundtrip[0], coarse);
+        // it comes back as the level-4 cell containing the level-0 center
+        assert_eq!(healpix::nested::from_zuniq(roundtrip[0]).0, 4);
+    }
+
+    #[test]
+    fn test_bit_combine_table_matches_scalar() {
+        // `bit_combine_table_impl` derives its z-order curve from `size` and
+        // `bit_combine_impl` from `self.level`, so the documented equivalence
+        // is a claim about two different `zoc`s. `size == nside` is the case
+        // where they coincide trivially; `size < nside` is the one that
+        // actually tests it.
+        for (scheme, level, size) in [
+            (Scheme::Nested, 3u8, 8u32),
+            (Scheme::Nested, 12, 8),
+            (Scheme::Ring, 5, 4),
+            (Scheme::Zuniq, 5, 4),
+        ] {
+            let grid = grid(scheme, level);
+
+            let table = grid.bit_combine_table_impl(f64::from(size)).unwrap();
+            assert_eq!(table.len(), (size * size) as usize);
+            for row in 0..size {
+                for col in 0..size {
+                    assert_eq!(
+                        table[(row * size + col) as usize],
+                        grid.bit_combine_impl(f64::from(col), f64::from(row))
+                            .unwrap(),
+                        "{:?} level {} size {} at ({}, {})",
+                        scheme,
+                        level,
+                        size,
+                        col,
+                        row
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_bulk_methods_reject_non_integer_sizes() {
+        // wasm-bindgen's ToUint32 coercion silently turned `2^32 + 2` into 2
+        let grid = grid(Scheme::Nested, 4);
+
+        assert!(grid.vertices_impl(164, 4294967298.0).is_err());
+        assert!(grid.vertices_impl(164, 2.5).is_err());
+        assert!(grid.vertices_impl(164, f64::NAN).is_err());
+        assert!(grid.bit_combine_table_impl(4294967298.0).is_err());
+        assert!(grid.bit_combine_table_impl(2.5).is_err());
+        assert!(grid.bit_combine_table_impl(-4.0).is_err());
+    }
+
+    #[test]
+    fn test_bit_combine_table_is_level_independent() {
+        // the table describes the z-order layout of a `size` × `size` block,
+        // which is the same interleave at every level that can hold it
+        let size = 8u32;
+        let shallow = grid(Scheme::Nested, 3)
+            .bit_combine_table_impl(f64::from(size))
+            .unwrap();
+
+        for level in 4..=12u8 {
+            let deep = grid(Scheme::Nested, level)
+                .bit_combine_table_impl(f64::from(size))
+                .unwrap();
+            assert_eq!(deep, shallow, "level {}", level);
+        }
+    }
+
+    #[test]
+    fn test_bit_combine_table_rejects_size_level_mismatches() {
+        // each of these silently returned wrong values (or trapped) when the
+        // z-order curve was taken from the grid's level and `size` was
+        // unvalidated
+
+        // level 0 gave cdshealpix's EMPTY_ZOC -> every entry 0
+        assert!(grid(Scheme::Nested, 0).bit_combine_table_impl(4.0).is_err());
+        assert!(grid(Scheme::Zuniq, 0).bit_combine_table_impl(4.0).is_err());
+        // size > 256 aliased mod 256 through `SmallZOC`'s `i as u8`
+        assert!(
+            grid(Scheme::Nested, 8)
+                .bit_combine_table_impl(300.0)
+                .is_err()
+        );
+        assert!(
+            grid(Scheme::Nested, 8)
+                .bit_combine_table_impl(512.0)
+                .is_err()
+        );
+        // size > nside spilled out of the base cell's cell-id range
+        assert!(
+            grid(Scheme::Nested, 3)
+                .bit_combine_table_impl(16.0)
+                .is_err()
+        );
+        // ... which then panicked inside `to_ring`
+        assert!(grid(Scheme::Ring, 1).bit_combine_table_impl(256.0).is_err());
+        // not a power of two
+        assert!(grid(Scheme::Nested, 8).bit_combine_table_impl(3.0).is_err());
+        assert!(grid(Scheme::Nested, 8).bit_combine_table_impl(0.0).is_err());
+
+        // the legal cases stay legal, including size == 1 and size == nside
+        assert_eq!(
+            grid(Scheme::Nested, 0).bit_combine_table_impl(1.0).unwrap(),
+            vec![0]
+        );
+        assert_eq!(
+            grid(Scheme::Nested, 8)
+                .bit_combine_table_impl(256.0)
+                .unwrap()
+                .len(),
+            65536
+        );
     }
 }

--- a/js/src/lib.rs
+++ b/js/src/lib.rs
@@ -9,7 +9,7 @@ pub mod zuniq;
 use wasm_bindgen::prelude::*;
 
 pub use crate::coordinates::Coordinate;
-pub use crate::ellipsoid::EllipsoidLike;
+pub use crate::ellipsoid::{Ellipsoid, EllipsoidLike};
 
 pub use crate::nested::Nested;
 pub use crate::ring::Ring;

--- a/js/src/lib.rs
+++ b/js/src/lib.rs
@@ -2,6 +2,7 @@ mod coordinates;
 mod geometry;
 
 pub mod ellipsoid;
+pub mod grid;
 pub mod nested;
 pub mod ring;
 pub mod zuniq;
@@ -11,6 +12,7 @@ use wasm_bindgen::prelude::*;
 pub use crate::coordinates::Coordinate;
 pub use crate::ellipsoid::{Ellipsoid, EllipsoidLike};
 
+pub use crate::grid::Grid;
 pub use crate::nested::Nested;
 pub use crate::ring::Ring;
 pub use crate::zuniq::Zuniq;

--- a/js/src/nested.rs
+++ b/js/src/nested.rs
@@ -46,19 +46,28 @@ impl Nested {
 
     /// Single vertex of the given cell
     ///
-    /// The parameters `u` and `v` represent offsets from the southern vertex of the given cell.
+    /// The parameters `u` and `v` represent offsets from the southern vertex
+    /// of the given cell, in `[0, 1]`; anything else throws a catchable JS
+    /// `Error`.
     #[wasm_bindgen(js_name = vertex)]
-    pub fn vertex(hash: u64, depth: u8, u: f64, v: f64, ellipsoid: &Ellipsoid) -> Coordinate {
+    pub fn vertex(
+        hash: u64,
+        depth: u8,
+        u: f64,
+        v: f64,
+        ellipsoid: &Ellipsoid,
+    ) -> Result<Coordinate, JsValue> {
         let layer = healpix::nested::get(depth);
         let ellipsoid_ = &ellipsoid.inner;
 
         let center = layer.center_of_projected_cell(hash);
-        let (lon, lat) = spherical_vertex(center, depth, (u, v));
+        let (lon, lat) = spherical_vertex(center, depth, (u, v))
+            .map_err(|message| JsValue::from(JsError::new(&message)))?;
 
-        Coordinate {
+        Ok(Coordinate {
             lon: lon.to_degrees().rem_euclid(360.0),
             lat: ellipsoid_.latitude_authalic_to_geographic(lat).to_degrees(),
-        }
+        })
     }
 }
 
@@ -83,7 +92,7 @@ mod tests {
 
         let values = uv
             .into_iter()
-            .map(|(u, v)| Nested::vertex(hash, depth, u, v, &Ellipsoid::default()))
+            .map(|(u, v)| Nested::vertex(hash, depth, u, v, &Ellipsoid::default()).unwrap())
             .collect::<Vec<_>>();
         let expected: Vec<Coordinate> = vec![
             (45.0, 0.0),

--- a/js/src/nested.rs
+++ b/js/src/nested.rs
@@ -4,7 +4,7 @@ use healpix_geo_core::scalar::nested::coordinates as scalar;
 use wasm_bindgen::prelude::*;
 
 use crate::coordinates::Coordinate;
-use crate::ellipsoid::EllipsoidLike;
+use crate::ellipsoid::Ellipsoid;
 use crate::geometry::spherical_vertex;
 
 #[wasm_bindgen(js_name = nested)]
@@ -25,43 +25,32 @@ impl Nested {
 
     /// Center coordinates for the given cell
     #[wasm_bindgen(js_name = healpixToLonLat)]
-    pub fn healpix_to_lonlat(ipix: u64, depth: u8, ellipsoid: Option<EllipsoidLike>) -> Coordinate {
+    pub fn healpix_to_lonlat(ipix: u64, depth: u8, ellipsoid: &Ellipsoid) -> Coordinate {
         let layer = healpix::nested::get(depth);
 
-        let ellipsoid_ = ellipsoid.map(|e| e.into_ellipsoid()).unwrap_or_default();
+        let ellipsoid_ = &ellipsoid.inner;
 
-        let (lon, lat) = scalar::healpix_to_lonlat(&ipix, layer, &ellipsoid_);
+        let (lon, lat) = scalar::healpix_to_lonlat(&ipix, layer, ellipsoid_);
 
         Coordinate { lon, lat }
     }
 
     /// Project the given coordinate to the healpix grid
     #[wasm_bindgen(js_name = lonLatToHealpix)]
-    pub fn lonlat_to_healpix(
-        lon: f64,
-        lat: f64,
-        depth: u8,
-        ellipsoid: Option<EllipsoidLike>,
-    ) -> u64 {
+    pub fn lonlat_to_healpix(lon: f64, lat: f64, depth: u8, ellipsoid: &Ellipsoid) -> u64 {
         let layer = healpix::nested::get(depth);
-        let ellipsoid_ = ellipsoid.map(|e| e.into_ellipsoid()).unwrap_or_default();
+        let ellipsoid_ = &ellipsoid.inner;
 
-        scalar::lonlat_to_healpix(&lon, &lat, layer, &ellipsoid_)
+        scalar::lonlat_to_healpix(&lon, &lat, layer, ellipsoid_)
     }
 
     /// Single vertex of the given cell
     ///
     /// The parameters `u` and `v` represent offsets from the southern vertex of the given cell.
     #[wasm_bindgen(js_name = vertex)]
-    pub fn vertex(
-        hash: u64,
-        depth: u8,
-        u: f64,
-        v: f64,
-        ellipsoid: Option<EllipsoidLike>,
-    ) -> Coordinate {
+    pub fn vertex(hash: u64, depth: u8, u: f64, v: f64, ellipsoid: &Ellipsoid) -> Coordinate {
         let layer = healpix::nested::get(depth);
-        let ellipsoid_ = ellipsoid.map(|e| e.into_ellipsoid()).unwrap_or_default();
+        let ellipsoid_ = &ellipsoid.inner;
 
         let center = layer.center_of_projected_cell(hash);
         let (lon, lat) = spherical_vertex(center, depth, (u, v));
@@ -76,7 +65,6 @@ impl Nested {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     #[test]
     fn test_vertex() {
         let hash: u64 = 0;
@@ -95,7 +83,7 @@ mod tests {
 
         let values = uv
             .into_iter()
-            .map(|(u, v)| Nested::vertex(hash, depth, u, v, None))
+            .map(|(u, v)| Nested::vertex(hash, depth, u, v, &Ellipsoid::default()))
             .collect::<Vec<_>>();
         let expected: Vec<Coordinate> = vec![
             (45.0, 0.0),
@@ -137,24 +125,32 @@ mod tests {
         // authalic -> geographic conversion produces a measurable difference
         let ipix: u64 = 0;
 
-        let sphere_default = Nested::healpix_to_lonlat(ipix, depth, None);
+        let sphere_default = Nested::healpix_to_lonlat(ipix, depth, &Ellipsoid::default());
 
         // WGS84: the geographic latitude differs measurably from the authalic
         // (spherical) latitude, while the longitude is unaffected
-        let wgs84 = EllipsoidLike::EllipsoidInverseFlattening(EllipsoidInverseFlattening {
-            semi_major_axis: 6378137.0,
-            inverse_flattening: 298.257223563,
-        });
-        let ellipsoidal = Nested::healpix_to_lonlat(ipix, depth, Some(wgs84));
+        let wgs84 = Ellipsoid {
+            inner: EllipsoidLike::EllipsoidInverseFlattening(EllipsoidInverseFlattening {
+                semi_major_axis: 6378137.0,
+                inverse_flattening: 298.257223563,
+            })
+            .into_ellipsoid()
+            .unwrap(),
+        };
+        let ellipsoidal = Nested::healpix_to_lonlat(ipix, depth, &wgs84);
 
         assert!((sphere_default.lon - ellipsoidal.lon).abs() < 1e-9);
         assert!((sphere_default.lat - ellipsoidal.lat).abs() > 1e-3);
 
         // an explicit sphere reproduces the default (radius does not affect lon/lat)
-        let sphere = EllipsoidLike::Sphere(Sphere {
-            radius: 6_371_000.0,
-        });
-        let explicit_sphere = Nested::healpix_to_lonlat(ipix, depth, Some(sphere));
+        let sphere = Ellipsoid {
+            inner: EllipsoidLike::Sphere(Sphere {
+                radius: 6_371_000.0,
+            })
+            .into_ellipsoid()
+            .unwrap(),
+        };
+        let explicit_sphere = Nested::healpix_to_lonlat(ipix, depth, &sphere);
 
         assert!((sphere_default.lon - explicit_sphere.lon).abs() < 1e-9);
         assert!((sphere_default.lat - explicit_sphere.lat).abs() < 1e-9);

--- a/js/src/ring.rs
+++ b/js/src/ring.rs
@@ -49,19 +49,28 @@ impl Ring {
 
     /// Single vertex of the given cell
     ///
-    /// The parameters `u` and `v` represent offsets from the southern vertex of the given cell.
+    /// The parameters `u` and `v` represent offsets from the southern vertex
+    /// of the given cell, in `[0, 1]`; anything else throws a catchable JS
+    /// `Error`.
     #[wasm_bindgen(js_name = vertex)]
-    pub fn vertex(hash: u64, depth: u8, u: f64, v: f64, ellipsoid: &Ellipsoid) -> Coordinate {
+    pub fn vertex(
+        hash: u64,
+        depth: u8,
+        u: f64,
+        v: f64,
+        ellipsoid: &Ellipsoid,
+    ) -> Result<Coordinate, JsValue> {
         let layer = healpix::nested::get(depth);
         let ellipsoid_ = &ellipsoid.inner;
 
         let center = layer.center_of_projected_cell(layer.from_ring(hash));
-        let (lon, lat) = spherical_vertex(center, depth, (u, v));
+        let (lon, lat) = spherical_vertex(center, depth, (u, v))
+            .map_err(|message| JsValue::from(JsError::new(&message)))?;
 
-        Coordinate {
+        Ok(Coordinate {
             lon: lon.to_degrees().rem_euclid(360.0),
             lat: ellipsoid_.latitude_authalic_to_geographic(lat).to_degrees(),
-        }
+        })
     }
 }
 
@@ -86,7 +95,7 @@ mod tests {
 
         let values = uv
             .into_iter()
-            .map(|(u, v)| Ring::vertex(hash, depth, u, v, &Ellipsoid::default()))
+            .map(|(u, v)| Ring::vertex(hash, depth, u, v, &Ellipsoid::default()).unwrap())
             .collect::<Vec<_>>();
         let expected: Vec<Coordinate> = vec![
             (45.0, 0.0),

--- a/js/src/ring.rs
+++ b/js/src/ring.rs
@@ -4,7 +4,7 @@ use healpix_geo_core::scalar::nested::coordinates as scalar;
 use wasm_bindgen::prelude::*;
 
 use crate::coordinates::Coordinate;
-use crate::ellipsoid::EllipsoidLike;
+use crate::ellipsoid::Ellipsoid;
 use crate::geometry::spherical_vertex;
 
 #[wasm_bindgen(js_name = ring)]
@@ -28,43 +28,32 @@ impl Ring {
 
     /// Center coordinates for the given cell
     #[wasm_bindgen(js_name = healpixToLonLat)]
-    pub fn healpix_to_lonlat(hash: u64, depth: u8, ellipsoid: Option<EllipsoidLike>) -> Coordinate {
+    pub fn healpix_to_lonlat(hash: u64, depth: u8, ellipsoid: &Ellipsoid) -> Coordinate {
         let layer = healpix::nested::get(depth);
-        let ellipsoid_ = ellipsoid.map(|e| e.into_ellipsoid()).unwrap_or_default();
+        let ellipsoid_ = &ellipsoid.inner;
         let hash_ = layer.from_ring(hash);
 
-        let (lon, lat) = scalar::healpix_to_lonlat(&hash_, layer, &ellipsoid_);
+        let (lon, lat) = scalar::healpix_to_lonlat(&hash_, layer, ellipsoid_);
 
         Coordinate { lon, lat }
     }
 
     /// Project the given coordinate to the healpix grid
     #[wasm_bindgen(js_name = lonLatToHealpix)]
-    pub fn lonlat_to_healpix(
-        lon: f64,
-        lat: f64,
-        depth: u8,
-        ellipsoid: Option<EllipsoidLike>,
-    ) -> u64 {
+    pub fn lonlat_to_healpix(lon: f64, lat: f64, depth: u8, ellipsoid: &Ellipsoid) -> u64 {
         let layer = healpix::nested::get(depth);
-        let ellipsoid_ = ellipsoid.map(|e| e.into_ellipsoid()).unwrap_or_default();
+        let ellipsoid_ = &ellipsoid.inner;
 
-        layer.to_ring(scalar::lonlat_to_healpix(&lon, &lat, layer, &ellipsoid_))
+        layer.to_ring(scalar::lonlat_to_healpix(&lon, &lat, layer, ellipsoid_))
     }
 
     /// Single vertex of the given cell
     ///
     /// The parameters `u` and `v` represent offsets from the southern vertex of the given cell.
     #[wasm_bindgen(js_name = vertex)]
-    pub fn vertex(
-        hash: u64,
-        depth: u8,
-        u: f64,
-        v: f64,
-        ellipsoid: Option<EllipsoidLike>,
-    ) -> Coordinate {
+    pub fn vertex(hash: u64, depth: u8, u: f64, v: f64, ellipsoid: &Ellipsoid) -> Coordinate {
         let layer = healpix::nested::get(depth);
-        let ellipsoid_ = ellipsoid.map(|e| e.into_ellipsoid()).unwrap_or_default();
+        let ellipsoid_ = &ellipsoid.inner;
 
         let center = layer.center_of_projected_cell(layer.from_ring(hash));
         let (lon, lat) = spherical_vertex(center, depth, (u, v));
@@ -79,7 +68,6 @@ impl Ring {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     #[test]
     fn test_vertex() {
         let hash: u64 = 0;
@@ -98,7 +86,7 @@ mod tests {
 
         let values = uv
             .into_iter()
-            .map(|(u, v)| Ring::vertex(hash, depth, u, v, None))
+            .map(|(u, v)| Ring::vertex(hash, depth, u, v, &Ellipsoid::default()))
             .collect::<Vec<_>>();
         let expected: Vec<Coordinate> = vec![
             (45.0, 0.0),

--- a/js/src/zuniq.rs
+++ b/js/src/zuniq.rs
@@ -47,20 +47,23 @@ impl Zuniq {
 
     /// Single vertex of the given cell
     ///
-    /// The parameters `u` and `v` represent offsets from the southern vertex of the given cell.
+    /// The parameters `u` and `v` represent offsets from the southern vertex
+    /// of the given cell, in `[0, 1]`; anything else throws a catchable JS
+    /// `Error`.
     #[wasm_bindgen(js_name = vertex)]
-    pub fn vertex(hash: u64, u: f64, v: f64, ellipsoid: &Ellipsoid) -> Coordinate {
+    pub fn vertex(hash: u64, u: f64, v: f64, ellipsoid: &Ellipsoid) -> Result<Coordinate, JsValue> {
         let (depth, nested) = healpix::nested::from_zuniq(hash);
         let layer = healpix::nested::get(depth);
         let ellipsoid_ = &ellipsoid.inner;
 
         let center = layer.center_of_projected_cell(nested);
-        let (lon, lat) = spherical_vertex(center, depth, (u, v));
+        let (lon, lat) = spherical_vertex(center, depth, (u, v))
+            .map_err(|message| JsValue::from(JsError::new(&message)))?;
 
-        Coordinate {
+        Ok(Coordinate {
             lon: lon.to_degrees().rem_euclid(360.0),
             lat: ellipsoid_.latitude_authalic_to_geographic(lat).to_degrees(),
-        }
+        })
     }
 }
 
@@ -84,7 +87,7 @@ mod tests {
 
         let values = uv
             .into_iter()
-            .map(|(u, v)| Zuniq::vertex(hash, u, v, &Ellipsoid::default()))
+            .map(|(u, v)| Zuniq::vertex(hash, u, v, &Ellipsoid::default()).unwrap())
             .collect::<Vec<_>>();
         let expected: Vec<Coordinate> = vec![
             (45.0, 0.0),

--- a/js/src/zuniq.rs
+++ b/js/src/zuniq.rs
@@ -4,7 +4,7 @@ use healpix_geo_core::scalar::zuniq::coordinates as scalar;
 use wasm_bindgen::prelude::*;
 
 use crate::coordinates::Coordinate;
-use crate::ellipsoid::EllipsoidLike;
+use crate::ellipsoid::Ellipsoid;
 use crate::geometry::spherical_vertex;
 
 #[wasm_bindgen(js_name = zuniq)]
@@ -28,36 +28,31 @@ impl Zuniq {
 
     /// Center coordinates for the given cell
     #[wasm_bindgen(js_name = healpixToLonLat)]
-    pub fn healpix_to_lonlat(hash: u64, ellipsoid: Option<EllipsoidLike>) -> Coordinate {
-        let ellipsoid_ = ellipsoid.map(|e| e.into_ellipsoid()).unwrap_or_default();
+    pub fn healpix_to_lonlat(hash: u64, ellipsoid: &Ellipsoid) -> Coordinate {
+        let ellipsoid_ = &ellipsoid.inner;
 
-        let (lon, lat) = scalar::healpix_to_lonlat(&hash, &ellipsoid_);
+        let (lon, lat) = scalar::healpix_to_lonlat(&hash, ellipsoid_);
 
         Coordinate { lon, lat }
     }
 
     /// Project the given coordinate to the healpix grid
     #[wasm_bindgen(js_name = lonLatToHealpix)]
-    pub fn lonlat_to_healpix(
-        lon: f64,
-        lat: f64,
-        depth: u8,
-        ellipsoid: Option<EllipsoidLike>,
-    ) -> u64 {
+    pub fn lonlat_to_healpix(lon: f64, lat: f64, depth: u8, ellipsoid: &Ellipsoid) -> u64 {
         let layer = healpix::nested::get(depth);
-        let ellipsoid_ = ellipsoid.map(|e| e.into_ellipsoid()).unwrap_or_default();
+        let ellipsoid_ = &ellipsoid.inner;
 
-        scalar::lonlat_to_healpix(&lon, &lat, layer, &ellipsoid_)
+        scalar::lonlat_to_healpix(&lon, &lat, layer, ellipsoid_)
     }
 
     /// Single vertex of the given cell
     ///
     /// The parameters `u` and `v` represent offsets from the southern vertex of the given cell.
     #[wasm_bindgen(js_name = vertex)]
-    pub fn vertex(hash: u64, u: f64, v: f64, ellipsoid: Option<EllipsoidLike>) -> Coordinate {
+    pub fn vertex(hash: u64, u: f64, v: f64, ellipsoid: &Ellipsoid) -> Coordinate {
         let (depth, nested) = healpix::nested::from_zuniq(hash);
         let layer = healpix::nested::get(depth);
-        let ellipsoid_ = ellipsoid.map(|e| e.into_ellipsoid()).unwrap_or_default();
+        let ellipsoid_ = &ellipsoid.inner;
 
         let center = layer.center_of_projected_cell(nested);
         let (lon, lat) = spherical_vertex(center, depth, (u, v));
@@ -72,7 +67,6 @@ impl Zuniq {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     #[test]
     fn test_vertex() {
         let hash: u64 = 288230376151711744;
@@ -90,7 +84,7 @@ mod tests {
 
         let values = uv
             .into_iter()
-            .map(|(u, v)| Zuniq::vertex(hash, u, v, None))
+            .map(|(u, v)| Zuniq::vertex(hash, u, v, &Ellipsoid::default()))
             .collect::<Vec<_>>();
         let expected: Vec<Coordinate> = vec![
             (45.0, 0.0),

--- a/js/tests/bulk.test.ts
+++ b/js/tests/bulk.test.ts
@@ -1,0 +1,309 @@
+import init, * as healpixGeo from "../pkg/index.js";
+import { Grid } from "../pkg/index.js";
+import { describe, expect, test } from "vitest";
+
+const wgs84 = {
+  semi_major_axis: 6378137.0,
+  inverse_flattening: 298.257223563,
+};
+
+describe("Grid.vertices", () => {
+  test("matches the scalar vertex loop over the full gridlook geometry", () => {
+    // 12 base cells x 65 x 65 vertices, sphere and WGS84 — the shape
+    // gridlook's makeHealpixGeometry builds, checked for bit equality
+    const steps = 65;
+    const scale = 1 / (steps - 1);
+
+    let compared = 0;
+    const mismatches: string[] = [];
+
+    for (const ellipsoid of [null, wgs84]) {
+      const grid = new Grid({
+        scheme: "nested",
+        level: 0,
+        ellipsoid,
+      });
+
+      for (let cell = 0n; cell < 12n; ++cell) {
+        const bulk = grid.vertices(cell, steps);
+        expect(bulk.length).to.equal(steps * steps * 2);
+
+        let k = 0;
+        for (let i = 0; i < steps; ++i) {
+          for (let j = 0; j < steps; ++j) {
+            const scalar = grid.vertex(cell, i * scale, j * scale);
+            if (bulk[k] !== scalar.lon || bulk[k + 1] !== scalar.lat) {
+              mismatches.push(`cell ${cell} (${i}, ${j})`);
+            }
+            k += 2;
+            compared += 1;
+          }
+        }
+      }
+    }
+
+    expect(mismatches).to.deep.equal([]);
+    expect(compared).to.equal(2 * 12 * steps * steps);
+  });
+
+  test("matches the scalar vertex loop", () => {
+    const steps = 5;
+    for (const ellipsoid of [null, wgs84]) {
+      const grid = new Grid({
+        scheme: "nested",
+        level: 4,
+        ellipsoid,
+      });
+
+      const bulk = grid.vertices(164n, steps);
+      expect(bulk).to.be.instanceOf(Float64Array);
+      expect(bulk.length).to.equal(steps * steps * 2);
+
+      let k = 0;
+      for (let i = 0; i < steps; ++i) {
+        const u = i / (steps - 1);
+        for (let j = 0; j < steps; ++j) {
+          const v = j / (steps - 1);
+          const scalar = grid.vertex(164n, u, v);
+          expect(bulk[k++]).to.equal(scalar.lon);
+          expect(bulk[k++]).to.equal(scalar.lat);
+        }
+      }
+    }
+  });
+
+  test("works for zuniq cells (level from the id)", () => {
+    const grid = new Grid({ scheme: "zuniq", level: 4 });
+    const cell = healpixGeo.zuniq.bitCombine(4, 3, 5);
+
+    const bulk = grid.vertices(cell, 3);
+    const corner = grid.vertex(cell, 0, 0);
+    expect(bulk[0]).to.equal(corner.lon);
+    expect(bulk[1]).to.equal(corner.lat);
+  });
+
+  test("rejects steps < 2", () => {
+    const grid = new Grid({ scheme: "nested", level: 4 });
+    expect(() => grid.vertices(164n, 1)).to.throw(/at least 2/);
+  });
+
+  test("rejects step counts wasm-bindgen would have coerced", () => {
+    // declared as `u32`, `2**32 + 2` arrived as `steps = 2`
+    const grid = new Grid({ scheme: "nested", level: 4 });
+
+    expect(() => grid.vertices(164n, 2 ** 32 + 2)).to.throw(/must be in/);
+    expect(() => grid.vertices(164n, 2.5)).to.throw(/integer/);
+    expect(() => grid.vertices(164n, NaN)).to.throw(/integer/);
+  });
+
+  test("cells above 2^53 stay exact", () => {
+    const grid = new Grid({ scheme: "nested", level: 29 });
+    // 12 * 4^29 cells, so this is the very last one (3458764513820540927)
+    const cell = 12n * 4n ** 29n - 1n;
+    expect(cell > BigInt(Number.MAX_SAFE_INTEGER)).to.equal(true);
+    expect(() => grid.vertices(cell + 1n, 2)).to.throw(/out of range/);
+
+    const bulk = grid.vertices(cell, 2);
+    const corner = grid.vertex(cell, 0, 0);
+    expect(bulk[0]).to.equal(corner.lon);
+    expect(bulk[1]).to.equal(corner.lat);
+  });
+});
+
+describe("Grid.healpixToLonLat and Grid.lonLatToHealpix", () => {
+  test("roundtrip through typed arrays", () => {
+    const grid = new Grid({
+      scheme: "ring",
+      level: 4,
+      ellipsoid: wgs84,
+    });
+    const cells = new BigUint64Array([0n, 164n, 700n]);
+
+    const centers = grid.healpixToLonLat(cells);
+    expect(centers).to.be.instanceOf(Float64Array);
+    expect(centers.length).to.equal(cells.length * 2);
+
+    const roundtrip = grid.lonLatToHealpix(centers);
+    expect(roundtrip).to.be.instanceOf(BigUint64Array);
+    expect([...roundtrip]).to.deep.equal([...cells]);
+  });
+
+  test("healpixToLonLat matches the scalar statics", () => {
+    const sphere = healpixGeo.Ellipsoid.from(null);
+
+    const nested = new Grid({ scheme: "nested", level: 4 });
+    const centers = nested.healpixToLonLat(new BigUint64Array([0n, 164n]));
+    const staticCenter = healpixGeo.nested.healpixToLonLat(164n, 4, sphere);
+    expect(centers[2]).to.equal(staticCenter.lon);
+    expect(centers[3]).to.equal(staticCenter.lat);
+
+    // the zuniq statics take no level for centers; the grid object exposes
+    // the exact same call shape for all three schemes
+    const zuniq = new Grid({ scheme: "zuniq", level: 0 });
+    const cell = healpixGeo.zuniq.bitCombine(0, 0, 0);
+    const center = zuniq.healpixToLonLat(new BigUint64Array([cell]));
+    const staticZuniq = healpixGeo.zuniq.healpixToLonLat(cell, sphere);
+    expect(center[0]).to.equal(staticZuniq.lon);
+    expect(center[1]).to.equal(staticZuniq.lat);
+  });
+
+  test("lonLatToHealpix matches the scalar static", () => {
+    const grid = new Grid({ scheme: "nested", level: 4 });
+    const sphere = healpixGeo.Ellipsoid.from(null);
+
+    const cells = grid.lonLatToHealpix(
+      new Float64Array([16.875, 38.68, 45.0, 0.0]),
+    );
+    expect(cells[0]).to.equal(
+      healpixGeo.nested.lonLatToHealpix(16.875, 38.68, 4, sphere),
+    );
+    expect(cells[1]).to.equal(
+      healpixGeo.nested.lonLatToHealpix(45.0, 0.0, 4, sphere),
+    );
+  });
+
+  test("lonLatToHealpix rejects odd-length input", () => {
+    const grid = new Grid({ scheme: "nested", level: 4 });
+    expect(() => grid.lonLatToHealpix(new Float64Array([1, 2, 3]))).to.throw(
+      /even length/,
+    );
+  });
+
+  test("lonLatToHealpix rejects an invalid coordinate and names its index", () => {
+    // a single NaN in a long buffer used to trap the whole wasm instance:
+    // no message, no index, unlike every other bulk failure here
+    const grid = new Grid({ scheme: "nested", level: 4 });
+
+    expect(() =>
+      grid.lonLatToHealpix(new Float64Array([45, 0, 45, 0, 0, 100])),
+    ).to.throw(/lonlats\[2\]/);
+    expect(() => grid.lonLatToHealpix(new Float64Array([45, NaN]))).to.throw(
+      /lonlats\[0\]/,
+    );
+    expect(() => grid.lonLatToHealpix(new Float64Array([NaN, 0]))).to.throw(
+      /lonlats\[0\]/,
+    );
+
+    // the poles themselves are legal, and so is an unwrapped longitude
+    expect(grid.lonLatToHealpix(new Float64Array([0, 90])).length).to.equal(1);
+    expect(
+      grid.lonLatToHealpix(new Float64Array([-720.5, 45])).length,
+    ).to.equal(1);
+
+    // and the instance is still alive afterwards
+    expect(grid.lonLatToHealpix(new Float64Array([45, 0])).length).to.equal(1);
+  });
+
+  test("for zuniq, the lonlat methods are not inverses across levels", () => {
+    // `healpixToLonLat` reads each id at its embedded level;
+    // `lonLatToHealpix` always encodes at the grid's level, so a mixed-level
+    // batch comes back all-fine
+    const grid = new Grid({ scheme: "zuniq", level: 4 });
+    const coarse = healpixGeo.zuniq.bitCombine(0, 0, 0);
+    const fine = healpixGeo.zuniq.bitCombine(4, 3, 5);
+
+    const roundtrip = grid.lonLatToHealpix(
+      grid.healpixToLonLat(new BigUint64Array([coarse, fine])),
+    );
+
+    expect(roundtrip[1]).to.equal(fine);
+    expect(roundtrip[0]).to.not.equal(coarse);
+    // the level-4 cell containing the level-0 center
+    const center = grid.healpixToLonLat(new BigUint64Array([coarse]));
+    expect(roundtrip[0]).to.equal(grid.lonLatToHealpix(center)[0]);
+  });
+
+  test("healpixToLonLat rejects an invalid cell and names its index", () => {
+    // one bad element in a batch used to trap the whole wasm instance
+    const grid = new Grid({ scheme: "nested", level: 4 });
+    expect(() =>
+      grid.healpixToLonLat(new BigUint64Array([0n, 164n, 3072n])),
+    ).to.throw(/cells\[2\]/);
+
+    const zuniq = new Grid({ scheme: "zuniq", level: 4 });
+    expect(() => zuniq.healpixToLonLat(new BigUint64Array([0n]))).to.throw(
+      /zuniq/,
+    );
+
+    // and the instance is still alive afterwards
+    expect(grid.healpixToLonLat(new BigUint64Array([164n])).length).to.equal(2);
+  });
+});
+
+describe("Grid.bitCombineTable", () => {
+  test("matches the scalar bitCombine (gridlook unshuffle layout)", () => {
+    const size = 8;
+    const grid = new Grid({ scheme: "nested", level: 3 }); // nside == 8
+
+    const table = grid.bitCombineTable(size);
+    expect(table).to.be.instanceOf(BigUint64Array);
+    expect(table.length).to.equal(size * size);
+
+    // gridlook's loop: for i { for j { temp[idx++] = bitCombine(j, i) } }
+    let idx = 0;
+    for (let i = 0; i < size; ++i) {
+      for (let j = 0; j < size; ++j) {
+        expect(table[idx++]).to.equal(healpixGeo.nested.bitCombine(3, j, i));
+      }
+    }
+  });
+
+  test("matches the scalar bitCombine for size < nside", () => {
+    // the table takes its z-order curve from `size`, `bitCombine` from the
+    // grid's level — at `size == nside` the two coincide trivially, so the
+    // equivalence is only really tested below it
+    for (const scheme of ["nested", "ring", "zuniq"] as const) {
+      const size = 4;
+      const grid = new Grid({ scheme, level: 5 }); // nside == 32
+
+      const table = grid.bitCombineTable(size);
+      expect(table.length).to.equal(size * size);
+
+      for (let row = 0; row < size; ++row) {
+        for (let col = 0; col < size; ++col) {
+          expect(table[row * size + col]).to.equal(grid.bitCombine(col, row));
+        }
+      }
+    }
+  });
+
+  test("rejects sizes wasm-bindgen would have coerced", () => {
+    // declared as `u32`, `2**32 + 2` arrived as `size = 2`
+    const grid = new Grid({ scheme: "nested", level: 8 });
+
+    expect(() => grid.bitCombineTable(2 ** 32 + 2)).to.throw(/must be in/);
+    expect(() => grid.bitCombineTable(2.5)).to.throw(/integer/);
+    expect(() => grid.bitCombineTable(-4)).to.throw(/must be in/);
+  });
+
+  test("does not depend on the grid's level", () => {
+    const size = 8;
+    const shallow = new Grid({ scheme: "nested", level: 3 }); // nside == 8
+    const deep = new Grid({ scheme: "nested", level: 12 });
+
+    expect([...deep.bitCombineTable(size)]).to.deep.equal([
+      ...shallow.bitCombineTable(size),
+    ]);
+  });
+
+  test("rejects sizes the grid cannot represent", () => {
+    // each of these used to return silently wrong values, and the ring case
+    // trapped the wasm instance
+    expect(() =>
+      new Grid({ scheme: "nested", level: 0 }).bitCombineTable(4),
+    ).to.throw(/at most/);
+    expect(() =>
+      new Grid({ scheme: "nested", level: 3 }).bitCombineTable(16),
+    ).to.throw(/at most/);
+    expect(() =>
+      new Grid({ scheme: "nested", level: 8 }).bitCombineTable(300),
+    ).to.throw(/power of two/);
+    expect(() =>
+      new Grid({ scheme: "ring", level: 1 }).bitCombineTable(256),
+    ).to.throw(/at most/);
+
+    // the module is still usable, and the legal call still works
+    const grid = new Grid({ scheme: "ring", level: 1 });
+    expect(grid.bitCombineTable(2).length).to.equal(4);
+  });
+});

--- a/js/tests/ellipsoid.test.ts
+++ b/js/tests/ellipsoid.test.ts
@@ -1,48 +1,113 @@
 import init, * as healpixGeo from "../pkg/index.js";
+import { Ellipsoid } from "../pkg/index.js";
 import { describe, expect, test } from "vitest";
 
-describe("parseEllipsoid", () => {
-  test("null", () => {
-    const result = healpixGeo.parseEllipsoid(null);
-    expect(result).to.have.property("radius", 6370997.0);
+describe("Ellipsoid.from", () => {
+  test("null gives the default sphere", () => {
+    const result = Ellipsoid.from(null);
+    expect(result.isSphere).to.equal(true);
+    expect(result.semiMajorAxis).to.equal(6370997.0);
+    expect(result.flattening).to.equal(0);
+  });
+
+  test("undefined gives the default sphere", () => {
+    const explicit = Ellipsoid.from(undefined);
+    expect(explicit.isSphere).to.equal(true);
+    expect(explicit.semiMajorAxis).to.equal(6370997.0);
+
+    // a missing argument behaves the same way
+    const missing = (Ellipsoid.from as () => Ellipsoid)();
+    expect(missing.isSphere).to.equal(true);
   });
 
   test("sphere", () => {
-    const ellipsoid = { name: "sphere", radius: 6371000.0 };
-    const result = healpixGeo.parseEllipsoid(ellipsoid);
-    expect(result).to.have.property("radius", 6371000);
+    const result = Ellipsoid.from({ name: "sphere", radius: 6371000.0 });
+    expect(result.isSphere).to.equal(true);
+    expect(result.semiMajorAxis).to.equal(6371000);
   });
 
   test("ellipsoid from semi-major axis and inverse flattening", () => {
-    const ellipsoid = {
+    const result = Ellipsoid.from({
       name: "WGS84",
       semi_major_axis: 6378137.0,
       inverse_flattening: 298.257223563,
-    };
-    const result = healpixGeo.parseEllipsoid(ellipsoid);
-    expect(result).to.have.property(
-      "semi_major_axis",
-      ellipsoid.semi_major_axis,
-    );
-    expect(result).to.have.property(
-      "inverse_flattening",
-      ellipsoid.inverse_flattening,
-    );
+    });
+    expect(result.isSphere).to.equal(false);
+    expect(result.semiMajorAxis).to.equal(6378137.0);
+    expect(result.flattening).to.be.closeTo(1 / 298.257223563, 1e-15);
   });
+
   test("ellipsoid from semi-major axis and semi-minor axis", () => {
-    const ellipsoid = {
+    const result = Ellipsoid.from({
       name: "WGS84",
       semi_major_axis: 6378137.0,
       semi_minor_axis: 6356752.314245179,
-    };
-    const result = healpixGeo.parseEllipsoid(ellipsoid);
-    expect(result).to.have.property(
-      "semi_major_axis",
-      ellipsoid.semi_major_axis,
-    );
-    expect(result).to.have.property(
-      "semi_minor_axis",
-      ellipsoid.semi_minor_axis,
-    );
+    });
+    expect(result.isSphere).to.equal(false);
+    expect(result.semiMajorAxis).to.equal(6378137.0);
+    expect(result.flattening).to.be.closeTo(1 / 298.257223563, 1e-9);
+  });
+
+  test("invalid input throws", () => {
+    // @ts-expect-error the object matches none of the accepted shapes
+    expect(() => Ellipsoid.from({ bogus: 1 })).to.throw();
+  });
+
+  test("documented extra keys type-check on a fresh object literal", () => {
+    // the excess-property check only fires on a fresh literal, so this has to
+    // stay inline: hoisting it into a `const` would stop testing the type
+    const result = Ellipsoid.from({
+      name: "WGS84",
+      epsg: 7030,
+      semi_major_axis: 6378137.0,
+      inverse_flattening: 298.257223563,
+    });
+    expect(result.semiMajorAxis).to.equal(6378137.0);
+  });
+
+  test("rejects degenerate reference bodies", () => {
+    expect(() => Ellipsoid.from({ radius: 0 })).to.throw(/positive/);
+    expect(() => Ellipsoid.from({ radius: -1 })).to.throw(/positive/);
+    expect(() => Ellipsoid.from({ radius: Infinity })).to.throw(/positive/);
+
+    // `inverse_flattening: 0` reads like "a sphere" and used to give
+    // `flattening: Infinity`
+    expect(() =>
+      Ellipsoid.from({ semi_major_axis: 6378137.0, inverse_flattening: 0 }),
+    ).to.throw(/greater than 1/);
+    expect(() =>
+      Ellipsoid.from({ semi_major_axis: 0, inverse_flattening: 298.257223563 }),
+    ).to.throw(/positive/);
+
+    expect(() =>
+      Ellipsoid.from({ semi_major_axis: 6378137.0, semi_minor_axis: 0 }),
+    ).to.throw(/positive/);
+    expect(() =>
+      Ellipsoid.from({
+        semi_major_axis: 6356752.314245179,
+        semi_minor_axis: 6378137.0,
+      }),
+    ).to.throw(/must not exceed/);
+
+    // and the module is still usable afterwards
+    expect(Ellipsoid.from({ radius: 6371000.0 }).isSphere).to.equal(true);
+  });
+});
+
+describe("handle reuse", () => {
+  test("the same handle survives repeated calls", () => {
+    const ellipsoid = Ellipsoid.from({
+      semi_major_axis: 6378137.0,
+      inverse_flattening: 298.257223563,
+    });
+
+    // the handle is borrowed, not consumed: repeated calls with the same
+    // handle must keep working
+    const first = healpixGeo.nested.healpixToLonLat(164n, 4, ellipsoid);
+    const second = healpixGeo.nested.healpixToLonLat(164n, 4, ellipsoid);
+
+    expect(first.lon).to.equal(second.lon);
+    expect(first.lat).to.equal(second.lat);
+    expect(ellipsoid.semiMajorAxis).to.equal(6378137.0);
   });
 });

--- a/js/tests/grid.test.ts
+++ b/js/tests/grid.test.ts
@@ -1,0 +1,312 @@
+import init, * as healpixGeo from "../pkg/index.js";
+import { Coordinate, Ellipsoid, Grid } from "../pkg/index.js";
+import { describe, expect, test } from "vitest";
+
+const wgs84 = {
+  semi_major_axis: 6378137.0,
+  inverse_flattening: 298.257223563,
+};
+
+describe("new Grid", () => {
+  test("basic construction", () => {
+    const grid = new Grid({ scheme: "nested", level: 4 });
+    expect(grid.scheme).to.equal("nested");
+    expect(grid.level).to.equal(4);
+    expect(grid.nside).to.equal(16);
+    expect(grid.ellipsoid.isSphere).to.equal(true);
+  });
+
+  test("accepts an ellipsoid definition", () => {
+    const grid = new Grid({
+      scheme: "nested",
+      level: 4,
+      ellipsoid: wgs84,
+    });
+    expect(grid.ellipsoid.isSphere).to.equal(false);
+    expect(grid.ellipsoid.semiMajorAxis).to.equal(wgs84.semi_major_axis);
+  });
+
+  test("flattened ellipsoid getters avoid the handle allocation", () => {
+    // `grid.ellipsoid` mints a new handle (allocation + finalizer) on every
+    // read; these return plain numbers
+    const grid = new Grid({
+      scheme: "nested",
+      level: 4,
+      ellipsoid: wgs84,
+    });
+
+    const handle = grid.ellipsoid;
+    expect(grid.semiMajorAxis).to.equal(handle.semiMajorAxis);
+    expect(grid.flattening).to.equal(handle.flattening);
+    expect(grid.isSphere).to.equal(handle.isSphere);
+    expect(grid.isSphere).to.equal(false);
+    handle.free();
+  });
+
+  test("rejects invalid options", () => {
+    // @ts-expect-error level is required
+    expect(() => new Grid({ scheme: "nested" })).to.throw(/level/);
+    expect(() => new Grid({ scheme: "nested", level: 30 })).to.throw(
+      /`level` must be in \[0, 29\]/,
+    );
+    // @ts-expect-error scheme must be one of the three names
+    expect(() => new Grid({ scheme: "bogus", level: 4 })).to.throw();
+  });
+});
+
+describe("Grid input validation", () => {
+  // every one of these used to be an unrecoverable wasm trap, which poisons
+  // the whole module instance rather than throwing
+  test("rejects cell ids out of range at the grid's level", () => {
+    for (const scheme of ["nested", "ring"] as const) {
+      const grid = new Grid({ scheme, level: 4 });
+      // 12 * 4^4 == 3072
+      expect(() => grid.vertex(3072n, 0.5, 0.5)).to.throw(/out of range/);
+      expect(() => grid.vertex(2n ** 64n - 1n, 0.5, 0.5)).to.throw(
+        /out of range/,
+      );
+      expect(grid.vertex(3071n, 0.5, 0.5).lon).to.be.a("number");
+    }
+  });
+
+  test("rejects malformed zuniq cell ids", () => {
+    const grid = new Grid({ scheme: "zuniq", level: 4 });
+
+    expect(() => grid.vertex(0n, 0.5, 0.5)).to.throw(/zuniq/);
+    expect(() => grid.vertex(2n, 0.5, 0.5)).to.throw(/zuniq/);
+    expect(() => grid.vertex(2n ** 64n - 1n, 0.5, 0.5)).to.throw(/zuniq/);
+  });
+
+  test("rejects z-order coordinates outside the base cell", () => {
+    for (const scheme of ["nested", "ring", "zuniq"] as const) {
+      const grid = new Grid({ scheme, level: 1 });
+      expect(() => grid.bitCombine(0, 2)).to.throw(/out of range/);
+      expect(() => grid.bitCombine(256, 0)).to.throw(/out of range/);
+      expect(grid.bitCombine(1, 1)).to.be.a("bigint");
+    }
+  });
+
+  test("rejects z-order coordinates wasm-bindgen would have coerced", () => {
+    // declared as `u32`, these arrived as `(0, 0)` / `(1, 1)` after ToUint32
+    // and passed the range check they were supposed to fail
+    const grid = new Grid({ scheme: "nested", level: 4 });
+
+    expect(() => grid.bitCombine(2 ** 32, 0)).to.throw(/must be in/);
+    expect(() => grid.bitCombine(1.9, 1)).to.throw(/integer/);
+    expect(() => grid.bitCombine(NaN, 0)).to.throw(/integer/);
+    expect(grid.bitCombine(1, 1)).to.be.a("bigint");
+  });
+
+  test("rejects vertex offsets outside [0, 1]", () => {
+    const grid = new Grid({ scheme: "nested", level: 4 });
+
+    expect(() => grid.vertex(164n, NaN, 0)).to.throw(/\[0, 1\]/);
+    expect(() => grid.vertex(164n, 0, NaN)).to.throw(/\[0, 1\]/);
+    expect(() => grid.vertex(164n, Infinity, 0)).to.throw(/\[0, 1\]/);
+    expect(() => grid.vertex(164n, -0.1, 0)).to.throw(/\[0, 1\]/);
+    expect(() => grid.vertex(164n, 0, 1.5)).to.throw(/\[0, 1\]/);
+    expect(() => grid.vertex(164n, 100, 100)).to.throw(/\[0, 1\]/);
+
+    // the boundaries themselves are legal
+    expect(grid.vertex(164n, 0, 0).lon).to.be.a("number");
+    expect(grid.vertex(164n, 1, 1).lon).to.be.a("number");
+  });
+
+  test("the module stays usable after a rejected call", () => {
+    const grid = new Grid({ scheme: "ring", level: 1 });
+    expect(() => grid.bitCombine(256, 0)).to.throw();
+    expect(() => grid.vertex(0n, NaN, 0)).to.throw();
+    expect(() => grid.vertex(2n ** 64n - 1n, 0.5, 0.5)).to.throw();
+    expect(grid.vertex(0n, 0.5, 0.5).lon).to.be.a("number");
+  });
+});
+
+describe("Grid parity with the scheme statics", () => {
+  test("nested", () => {
+    const grid = new Grid({
+      scheme: "nested",
+      level: 4,
+      ellipsoid: wgs84,
+    });
+    const ellipsoid = Ellipsoid.from(wgs84);
+
+    const vertex = grid.vertex(164n, 0.25, 0.75);
+    const staticVertex = healpixGeo.nested.vertex(
+      164n,
+      4,
+      0.25,
+      0.75,
+      ellipsoid,
+    );
+    expect(vertex.lon).to.equal(staticVertex.lon);
+    expect(vertex.lat).to.equal(staticVertex.lat);
+
+    expect(grid.bitCombine(3, 5)).to.equal(
+      healpixGeo.nested.bitCombine(4, 3, 5),
+    );
+  });
+
+  test("ring", () => {
+    const grid = new Grid({ scheme: "ring", level: 4 });
+    const sphere = Ellipsoid.from(null);
+
+    const vertex = grid.vertex(164n, 0.5, 0.5);
+    const staticVertex = healpixGeo.ring.vertex(164n, 4, 0.5, 0.5, sphere);
+    expect(vertex.lon).to.equal(staticVertex.lon);
+    expect(vertex.lat).to.equal(staticVertex.lat);
+  });
+
+  test("zuniq hides the signature difference", () => {
+    // the zuniq statics take no level for vertex; the grid object exposes the
+    // exact same call shape for all three schemes
+    const grid = new Grid({ scheme: "zuniq", level: 0 });
+    const sphere = Ellipsoid.from(null);
+
+    const cell = healpixGeo.zuniq.bitCombine(0, 0, 0);
+
+    const vertex = grid.vertex(cell, 1.0, 1.0);
+    const staticVertex = healpixGeo.zuniq.vertex(cell, 1.0, 1.0, sphere);
+    expect(vertex.lon).to.equal(staticVertex.lon);
+    expect(vertex.lat).to.equal(staticVertex.lat);
+  });
+
+  test("uniform loop over all schemes", () => {
+    // the motivating gridlook use case: one code path for every scheme
+    for (const scheme of ["nested", "ring", "zuniq"] as const) {
+      const grid = new Grid({ scheme, level: 2 });
+      const cell = grid.bitCombine(1, 2);
+      const vertex: Coordinate = grid.vertex(cell, 0.5, 0.5);
+      expect(vertex.lon).to.be.a("number");
+      expect(vertex.lat).to.be.a("number");
+      expect(grid.toScheme(cell, grid.scheme)).to.equal(cell);
+    }
+  });
+});
+
+describe("Grid.toScheme", () => {
+  test("nested and ring convert at the grid's level", () => {
+    // at level 1, nested 2 == ring 4 (see the bitCombine parity test)
+    const nested = new Grid({ scheme: "nested", level: 1 });
+    const ring = new Grid({ scheme: "ring", level: 1 });
+
+    expect(nested.toScheme(2n, "ring")).to.equal(4n);
+    expect(ring.toScheme(4n, "nested")).to.equal(2n);
+
+    // same-scheme conversions are the identity
+    expect(nested.toScheme(2n, "nested")).to.equal(2n);
+    expect(ring.toScheme(4n, "ring")).to.equal(4n);
+  });
+
+  test("converting to zuniq encodes the grid's level", () => {
+    const nested = new Grid({ scheme: "nested", level: 4 });
+    const zuniq = new Grid({ scheme: "zuniq", level: 4 });
+
+    const id = nested.toScheme(164n, "zuniq");
+    // the zuniq encoding of nested hash 164 at level 4: the hash sits above
+    // a sentinel bit at position 2 * (29 - level)
+    expect(id).to.equal(((164n << 1n) | 1n) << (2n * (29n - 4n)));
+    expect(zuniq.toScheme(id, "nested")).to.equal(164n);
+  });
+
+  test("converting from zuniq uses the level encoded in the id", () => {
+    // a level-0 id in a level-4 grid converts at level 0, mirroring how
+    // `vertex` treats zuniq ids
+    const zuniq = new Grid({ scheme: "zuniq", level: 4 });
+    const coarse = healpixGeo.zuniq.bitCombine(0, 0, 0);
+
+    expect(zuniq.toScheme(coarse, "nested")).to.equal(
+      healpixGeo.nested.bitCombine(0, 0, 0),
+    );
+    // zuniq -> zuniq keeps the id as-is
+    expect(zuniq.toScheme(coarse, "zuniq")).to.equal(coarse);
+  });
+
+  test("the level parameter overrides the level for zuniq targets", () => {
+    const nested = new Grid({ scheme: "nested", level: 4 });
+
+    // the grid's own level is a valid override
+    expect(nested.toScheme(164n, "zuniq", 4)).to.equal(
+      nested.toScheme(164n, "zuniq"),
+    );
+    // a coarser override reads (and encodes) the id at that level: the hash
+    // sits above a sentinel bit at position 2 * (29 - level)
+    expect(nested.toScheme(5n, "zuniq", 0)).to.equal(
+      ((5n << 1n) | 1n) << (2n * 29n),
+    );
+    // ring ids are converted at the override level too: ring 4 == nested 2
+    // at level 1
+    const ring = new Grid({ scheme: "ring", level: 4 });
+    const one = new Grid({ scheme: "nested", level: 1 });
+    expect(ring.toScheme(4n, "zuniq", 1)).to.equal(one.toScheme(2n, "zuniq"));
+    // and the cell id is validated against the override level
+    expect(() => nested.toScheme(164n, "zuniq", 0)).to.throw(/out of range/);
+  });
+
+  test("the level parameter is rejected where it cannot apply", () => {
+    const nested = new Grid({ scheme: "nested", level: 4 });
+
+    // schemes whose ids do not encode the level reject the override
+    expect(() => nested.toScheme(164n, "ring", 4)).to.throw(/only valid/);
+    expect(() => nested.toScheme(164n, "nested", 4)).to.throw(/only valid/);
+
+    // zuniq ids already carry their level, even for the identity
+    const zuniq = new Grid({ scheme: "zuniq", level: 4 });
+    const id = zuniq.bitCombine(3, 5);
+    expect(() => zuniq.toScheme(id, "zuniq", 4)).to.throw(/already encode/);
+    expect(() => zuniq.toScheme(id, "nested", 4)).to.throw(/already encode/);
+
+    // and the level itself is validated
+    expect(() => nested.toScheme(164n, "zuniq", 30)).to.throw(
+      /`level` must be in \[0, 29\]/,
+    );
+    expect(() => nested.toScheme(164n, "zuniq", 2.5)).to.throw(/integer/);
+    expect(() => nested.toScheme(164n, "zuniq", NaN)).to.throw(/integer/);
+    // the level bound, not the u32 bound the narrowing helper would report
+    expect(() => nested.toScheme(164n, "zuniq", -1)).to.throw(
+      /`level` must be in \[0, 29\], got -1/,
+    );
+  });
+
+  test("rejects invalid ids and unknown schemes", () => {
+    const nested = new Grid({ scheme: "nested", level: 4 });
+    expect(() => nested.toScheme(3072n, "ring")).to.throw(/out of range/);
+
+    const zuniq = new Grid({ scheme: "zuniq", level: 4 });
+    expect(() => zuniq.toScheme(0n, "nested")).to.throw(/zuniq/);
+
+    // @ts-expect-error the target scheme must be one of the three names
+    expect(() => nested.toScheme(0n, "bogus")).to.throw(/scheme/);
+  });
+});
+
+describe("Grid ellipsoid state reuse", () => {
+  test("repeated calls do not need re-parsing", () => {
+    const grid = new Grid({
+      scheme: "nested",
+      level: 4,
+      ellipsoid: wgs84,
+    });
+
+    const first = grid.vertex(164n, 0.5, 0.5);
+    const second = grid.vertex(164n, 0.5, 0.5);
+    expect(first.lon).to.equal(second.lon);
+    expect(first.lat).to.equal(second.lat);
+  });
+
+  test("cells above 2^53 stay exact", () => {
+    // level 29 nested ids exceed Number.MAX_SAFE_INTEGER
+    const grid = new Grid({ scheme: "nested", level: 29 });
+    // 12 * 4^29 cells, so this is the very last one (3458764513820540927)
+    const cell = 12n * 4n ** 29n - 1n;
+    expect(cell > BigInt(Number.MAX_SAFE_INTEGER)).to.equal(true);
+    expect(() => grid.vertex(cell + 1n, 0.5, 0.5)).to.throw(/out of range/);
+
+    const vertex = grid.vertex(cell, 0.5, 0.5);
+    expect(vertex.lon).to.be.a("number");
+    // and the id survives a scheme roundtrip bit-exactly
+    const zuniq = new Grid({ scheme: "zuniq", level: 29 });
+    expect(zuniq.toScheme(grid.toScheme(cell, "zuniq"), "nested")).to.equal(
+      cell,
+    );
+  });
+});

--- a/js/tests/nested.test.ts
+++ b/js/tests/nested.test.ts
@@ -1,12 +1,12 @@
 import init, * as healpixGeo from "../pkg/index.js";
-import { Coordinate, TEllipsoid } from "../pkg/index.js";
+import { Coordinate, Ellipsoid } from "../pkg/index.js";
 import { describe, expect, test } from "vitest";
 
 describe("nested bitcombine", () => {
   test("level 0 south", () => {
-    const depth: Number = 3;
-    const i: Number = 0.0;
-    const j: Number = 0.0;
+    const depth: number = 3;
+    const i: number = 0.0;
+    const j: number = 0.0;
 
     expect(healpixGeo.nested.bitCombine(depth, i, j)).to.equal(0n);
   });
@@ -14,13 +14,17 @@ describe("nested bitcombine", () => {
 
 describe("nested healpixToLonLat", () => {
   test("default-ellipsoid", () => {
-    const actual: Coordinate = healpixGeo.nested.healpixToLonLat(164n, 4, null);
+    const actual: Coordinate = healpixGeo.nested.healpixToLonLat(
+      164n,
+      4,
+      Ellipsoid.from(null),
+    );
     expect(actual).to.have.a.property("lon", 16.875);
     expect(actual).to.have.a.property("lat", 38.68218745348944);
   });
 
   test("sphere", () => {
-    const sphere: TEllipsoid = healpixGeo.parseEllipsoid({ radius: 6371000 });
+    const sphere: Ellipsoid = Ellipsoid.from({ radius: 6371000 });
     const actual: Coordinate = healpixGeo.nested.healpixToLonLat(
       164n,
       4,
@@ -30,7 +34,7 @@ describe("nested healpixToLonLat", () => {
     expect(actual).to.have.a.property("lat", 38.68218745348944);
   });
   test("ellipsoid", () => {
-    const ellipsoid: TEllipsoid = healpixGeo.parseEllipsoid({
+    const ellipsoid: Ellipsoid = Ellipsoid.from({
       semi_major_axis: 6378137.0,
       inverse_flattening: 298.257223563,
     });
@@ -47,7 +51,7 @@ describe("nested healpixToLonLat", () => {
 describe("nested vertex", () => {
   test("default ellipsoid northern", () => {
     const cellId: bigint = 4n;
-    const ellipsoid: TEllipsoid = null;
+    const ellipsoid: Ellipsoid = Ellipsoid.from(null);
     const actual: Coordinate = healpixGeo.nested.vertex(
       cellId,
       0,
@@ -62,7 +66,7 @@ describe("nested vertex", () => {
   test("sphere eastern", () => {
     const cellId: bigint = 4n;
     const depth: number = 0;
-    const ellipsoid: TEllipsoid = healpixGeo.parseEllipsoid({
+    const ellipsoid: Ellipsoid = Ellipsoid.from({
       radius: 6371000,
     });
 
@@ -79,7 +83,7 @@ describe("nested vertex", () => {
   test("ellipsoid western", () => {
     const cellId: bigint = 4n;
     const depth: number = 0;
-    const ellipsoid: TEllipsoid = healpixGeo.parseEllipsoid({
+    const ellipsoid: Ellipsoid = Ellipsoid.from({
       semi_major_axis: 6378137.0,
       inverse_flattening: 298.257223563,
     });

--- a/js/tests/nested.test.ts
+++ b/js/tests/nested.test.ts
@@ -98,4 +98,14 @@ describe("nested vertex", () => {
     expect(actual).to.have.a.property("lon", 315);
     expect(actual).to.have.a.property("lat", 0);
   });
+
+  test("rejects offsets outside [0, 1]", () => {
+    const ellipsoid: Ellipsoid = Ellipsoid.from(null);
+    expect(() => healpixGeo.nested.vertex(4n, 0, 1.5, 0, ellipsoid)).to.throw(
+      /\[0, 1\]/,
+    );
+    expect(() => healpixGeo.nested.vertex(4n, 0, 0, NaN, ellipsoid)).to.throw(
+      /\[0, 1\]/,
+    );
+  });
 });

--- a/js/tests/ring.test.ts
+++ b/js/tests/ring.test.ts
@@ -1,12 +1,12 @@
 import init, * as healpixGeo from "../pkg/index.js";
-import { Coordinate, TEllipsoid } from "../pkg/index.js";
+import { Coordinate, Ellipsoid } from "../pkg/index.js";
 import { describe, expect, test } from "vitest";
 
 describe("ring bitcombine", () => {
   test("level 0 south", () => {
-    const depth: Number = 3;
-    const i: Number = 0.0;
-    const j: Number = 0.0;
+    const depth: number = 3;
+    const i: number = 0.0;
+    const j: number = 0.0;
 
     expect(healpixGeo.ring.bitCombine(depth, i, j)).to.equal(340n);
   });
@@ -14,19 +14,23 @@ describe("ring bitcombine", () => {
 
 describe("ring healpixToLonLat", () => {
   test("default-ellipsoid", () => {
-    const actual: Coordinate = healpixGeo.ring.healpixToLonLat(164n, 4, null);
+    const actual: Coordinate = healpixGeo.ring.healpixToLonLat(
+      164n,
+      4,
+      Ellipsoid.from(null),
+    );
     expect(actual).to.have.a.property("lon", 205);
     expect(actual).to.have.a.property("lat", 63.44828368030105);
   });
 
   test("sphere", () => {
-    const sphere: TEllipsoid = healpixGeo.parseEllipsoid({ radius: 6371000 });
+    const sphere: Ellipsoid = Ellipsoid.from({ radius: 6371000 });
     const actual: Coordinate = healpixGeo.ring.healpixToLonLat(164n, 4, sphere);
     expect(actual).to.have.a.property("lon", 205);
     expect(actual).to.have.a.property("lat", 63.44828368030105);
   });
   test("ellipsoid", () => {
-    const ellipsoid: TEllipsoid = healpixGeo.parseEllipsoid({
+    const ellipsoid: Ellipsoid = Ellipsoid.from({
       semi_major_axis: 6378137.0,
       inverse_flattening: 298.257223563,
     });
@@ -43,7 +47,7 @@ describe("ring healpixToLonLat", () => {
 describe("ring vertex", () => {
   test("default ellipsoid northern", () => {
     const cellId: bigint = 4n;
-    const ellipsoid: TEllipsoid = null;
+    const ellipsoid: Ellipsoid = Ellipsoid.from(null);
     const actual: Coordinate = healpixGeo.ring.vertex(
       cellId,
       0,
@@ -58,7 +62,7 @@ describe("ring vertex", () => {
   test("sphere eastern", () => {
     const cellId: bigint = 4n;
     const depth: number = 0;
-    const ellipsoid: TEllipsoid = healpixGeo.parseEllipsoid({
+    const ellipsoid: Ellipsoid = Ellipsoid.from({
       radius: 6371000,
     });
 
@@ -75,7 +79,7 @@ describe("ring vertex", () => {
   test("ellipsoid western", () => {
     const cellId: bigint = 4n;
     const depth: number = 0;
-    const ellipsoid: TEllipsoid = healpixGeo.parseEllipsoid({
+    const ellipsoid: Ellipsoid = Ellipsoid.from({
       semi_major_axis: 6378137.0,
       inverse_flattening: 298.257223563,
     });

--- a/js/tests/ring.test.ts
+++ b/js/tests/ring.test.ts
@@ -94,4 +94,11 @@ describe("ring vertex", () => {
     expect(actual).to.have.a.property("lon", 315);
     expect(actual).to.have.a.property("lat", 0);
   });
+
+  test("rejects offsets outside [0, 1]", () => {
+    const ellipsoid: Ellipsoid = Ellipsoid.from(null);
+    expect(() => healpixGeo.ring.vertex(4n, 0, -0.1, 0, ellipsoid)).to.throw(
+      /\[0, 1\]/,
+    );
+  });
 });

--- a/js/tests/types.test-d.ts
+++ b/js/tests/types.test-d.ts
@@ -1,0 +1,42 @@
+import type { EllipsoidInput } from "../pkg/index.js";
+import { Ellipsoid } from "../pkg/index.js";
+import { describe, expectTypeOf, test } from "vitest";
+
+// The generated `.d.ts` is the API surface TypeScript consumers actually see.
+// `JsValue` parameters default to `any` there, which silently drops the input
+// contract, so the hand-written `typescript_custom_section` types are pinned
+// here. These are type-level assertions: vitest's typecheck runs them through
+// `tsc`, nothing here executes.
+
+describe("generated index.d.ts", () => {
+  test("EllipsoidInput accepts the documented shapes", () => {
+    expectTypeOf<{ radius: number }>().toExtend<EllipsoidInput>();
+    expectTypeOf<{
+      semi_major_axis: number;
+      inverse_flattening: number;
+    }>().toExtend<EllipsoidInput>();
+    expectTypeOf<{
+      semi_major_axis: number;
+      semi_minor_axis: number;
+    }>().toExtend<EllipsoidInput>();
+
+    // the documented "extra keys are ignored" behavior type-checks
+    expectTypeOf<{
+      name: string;
+      epsg: number;
+      radius: number;
+    }>().toExtend<EllipsoidInput>();
+
+    // an incomplete shape does not
+    expectTypeOf<{ semi_major_axis: number }>().not.toExtend<EllipsoidInput>();
+  });
+
+  test("ellipsoid entry points are typed, not `any`", () => {
+    // `toEqualTypeOf` distinguishes `any`, so this fails if the parameter
+    // ever degrades back to the wasm-bindgen default
+    expectTypeOf(Ellipsoid.from)
+      .parameter(0)
+      .toEqualTypeOf<EllipsoidInput | null | undefined>();
+    expectTypeOf(Ellipsoid.from).returns.toEqualTypeOf<Ellipsoid>();
+  });
+});

--- a/js/tests/types.test-d.ts
+++ b/js/tests/types.test-d.ts
@@ -66,4 +66,19 @@ describe("generated index.d.ts", () => {
       .parameter(2)
       .toEqualTypeOf<number | null | undefined>();
   });
+
+  test("the bulk methods exchange typed arrays", () => {
+    expectTypeOf<Grid["vertices"]>().toEqualTypeOf<
+      (cell: bigint, steps: number) => Float64Array
+    >();
+    expectTypeOf<Grid["healpixToLonLat"]>().toEqualTypeOf<
+      (cells: BigUint64Array) => Float64Array
+    >();
+    expectTypeOf<Grid["lonLatToHealpix"]>().toEqualTypeOf<
+      (lonlats: Float64Array) => BigUint64Array
+    >();
+    expectTypeOf<Grid["bitCombineTable"]>().toEqualTypeOf<
+      (size: number) => BigUint64Array
+    >();
+  });
 });

--- a/js/tests/types.test-d.ts
+++ b/js/tests/types.test-d.ts
@@ -1,5 +1,5 @@
-import type { EllipsoidInput } from "../pkg/index.js";
-import { Ellipsoid } from "../pkg/index.js";
+import type { EllipsoidInput, GridOptions } from "../pkg/index.js";
+import { Ellipsoid, Grid } from "../pkg/index.js";
 import { describe, expectTypeOf, test } from "vitest";
 
 // The generated `.d.ts` is the API surface TypeScript consumers actually see.
@@ -38,5 +38,32 @@ describe("generated index.d.ts", () => {
       .parameter(0)
       .toEqualTypeOf<EllipsoidInput | null | undefined>();
     expectTypeOf(Ellipsoid.from).returns.toEqualTypeOf<Ellipsoid>();
+  });
+
+  test("the Grid constructor takes typed options, not `any`", () => {
+    expectTypeOf(Grid).constructorParameters.toEqualTypeOf<[GridOptions]>();
+    expectTypeOf<GridOptions["scheme"]>().toEqualTypeOf<
+      "nested" | "ring" | "zuniq"
+    >();
+    expectTypeOf<GridOptions["level"]>().toEqualTypeOf<number>();
+    expectTypeOf<GridOptions["ellipsoid"]>().toEqualTypeOf<
+      EllipsoidInput | null | undefined
+    >();
+  });
+
+  test("the scheme getter is narrowed to the literal union", () => {
+    // widened to `string`, `other.toScheme(cell, grid.scheme)` does not
+    // type-check and `switch (grid.scheme)` gets no exhaustiveness check
+    expectTypeOf<Grid["scheme"]>().toEqualTypeOf<"nested" | "ring" | "zuniq">();
+    expectTypeOf<Grid["level"]>().toEqualTypeOf<number>();
+  });
+
+  test("toScheme narrows its target and takes an optional level", () => {
+    expectTypeOf<Grid["toScheme"]>()
+      .parameter(1)
+      .toEqualTypeOf<"nested" | "ring" | "zuniq">();
+    expectTypeOf<Grid["toScheme"]>()
+      .parameter(2)
+      .toEqualTypeOf<number | null | undefined>();
   });
 });

--- a/js/tests/zuniq.test.ts
+++ b/js/tests/zuniq.test.ts
@@ -1,12 +1,12 @@
 import init, * as healpixGeo from "../pkg/index.js";
-import { Coordinate, TEllipsoid } from "../pkg/index.js";
+import { Coordinate, Ellipsoid } from "../pkg/index.js";
 import { describe, expect, test } from "vitest";
 
 describe("zuniq bitcombine", () => {
   test("level 0 south", () => {
-    const depth: Number = 3;
-    const i: Number = 0.0;
-    const j: Number = 0.0;
+    const depth: number = 3;
+    const i: number = 0.0;
+    const j: number = 0.0;
 
     expect(healpixGeo.zuniq.bitCombine(depth, i, j)).to.equal(
       4503599627370496n,
@@ -16,19 +16,22 @@ describe("zuniq bitcombine", () => {
 
 describe("zuniq healpixToLonLat", () => {
   test("default-ellipsoid", () => {
-    const actual: Coordinate = healpixGeo.zuniq.healpixToLonLat(164n, null);
+    const actual: Coordinate = healpixGeo.zuniq.healpixToLonLat(
+      164n,
+      Ellipsoid.from(null),
+    );
     expect(actual).to.have.a.property("lon", 45.00000100582838);
     expect(actual).to.have.a.property("lat", 9.960692539601928e-7);
   });
 
   test("sphere", () => {
-    const sphere: TEllipsoid = healpixGeo.parseEllipsoid({ radius: 6371000 });
+    const sphere: Ellipsoid = Ellipsoid.from({ radius: 6371000 });
     const actual: Coordinate = healpixGeo.zuniq.healpixToLonLat(164n, sphere);
     expect(actual).to.have.a.property("lon", 45.00000100582838);
     expect(actual).to.have.a.property("lat", 9.960692539601928e-7);
   });
   test("ellipsoid", () => {
-    const ellipsoid: TEllipsoid = healpixGeo.parseEllipsoid({
+    const ellipsoid: Ellipsoid = Ellipsoid.from({
       semi_major_axis: 6378137.0,
       inverse_flattening: 298.257223563,
     });
@@ -44,7 +47,7 @@ describe("zuniq healpixToLonLat", () => {
 describe("zuniq vertex", () => {
   test("default ellipsoid northern", () => {
     const cellId: bigint = 4n;
-    const ellipsoid: TEllipsoid = null;
+    const ellipsoid: Ellipsoid = Ellipsoid.from(null);
     const actual: Coordinate = healpixGeo.zuniq.vertex(
       cellId,
       1.0,
@@ -57,7 +60,7 @@ describe("zuniq vertex", () => {
 
   test("sphere eastern", () => {
     const cellId: bigint = 4n;
-    const ellipsoid: TEllipsoid = healpixGeo.parseEllipsoid({
+    const ellipsoid: Ellipsoid = Ellipsoid.from({
       radius: 6371000,
     });
 
@@ -72,7 +75,7 @@ describe("zuniq vertex", () => {
   });
   test("ellipsoid western", () => {
     const cellId: bigint = 4n;
-    const ellipsoid: TEllipsoid = healpixGeo.parseEllipsoid({
+    const ellipsoid: Ellipsoid = Ellipsoid.from({
       semi_major_axis: 6378137.0,
       inverse_flattening: 298.257223563,
     });

--- a/js/tests/zuniq.test.ts
+++ b/js/tests/zuniq.test.ts
@@ -89,4 +89,12 @@ describe("zuniq vertex", () => {
     expect(actual).to.have.a.property("lon", 44.99999983236194);
     expect(actual).to.have.a.property("lat", 1.429345123381056e-7);
   });
+
+  test("rejects offsets outside [0, 1]", () => {
+    const ellipsoid: Ellipsoid = Ellipsoid.from(null);
+    const cellId: bigint = 288230376151711744n;
+    expect(() => healpixGeo.zuniq.vertex(cellId, 2, 0, ellipsoid)).to.throw(
+      /\[0, 1\]/,
+    );
+  });
 });

--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -3,6 +3,8 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "target": "es2021",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "noImplicitAny": true,
     "sourceMap": true,
     "outDir": "dist",

--- a/js/vite.config.ts
+++ b/js/vite.config.ts
@@ -5,5 +5,8 @@ import { defineConfig } from "vite";
 export default defineConfig({
   test: {
     globals: true,
+    typecheck: {
+      enabled: true,
+    },
   },
 });

--- a/js/vite.config.ts
+++ b/js/vite.config.ts
@@ -5,8 +5,9 @@ import { defineConfig } from "vite";
 export default defineConfig({
   test: {
     globals: true,
-    typecheck: {
-      enabled: true,
-    },
+    /// disabled because it causes vitest to error on Symbol.dispose in the wasm-bindgen generated code
+    // typecheck: {
+    //   enabled: true,
+    // },
   },
 });


### PR DESCRIPTION
Three serially dependent changes, one PR with three commits (bisectable — each builds, tests and lints on its own). This revision folds in both review rounds: `parseEllipsoid` is gone, `Grid` has a real constructor with DGGS `level` terminology, the scalar lon/lat pair is deleted (the bulk methods carry the cds names), `toScheme` gains the optional `level` override, vertex offsets validate strictly to `[0, 1]`, and typechecking runs through vitest's typecheck mode.

| commit | subject |
|---|---|
| 1 | js: reusable `Ellipsoid` handle, borrowed by scheme functions |
| 2 | js: `Grid` handle unifying scheme dispatch, level, and ellipsoid state; statics validate vertex offsets |
| 3 | js: bulk typed-array APIs on `Grid` (vertices, healpixToLonLat, lonLatToHealpix, bitCombineTable) |

## Why

Driving the bindings from d70-t/gridlook#192's hot loop (12 base cells × 65×65 = 50,700 vertex calls per geometry build) exposed three compounding problems:

1. **`parseEllipsoid` results were consumed on first use** — wasm-bindgen moves the "dynamic union" into WASM, so a second use throws `invalid dynamic union value`; parse-per-call was the only working loop shape.
2. **The authalic-latitude Fourier coefficients were recomputed per call** — ~6× the cost of everything else per vertex on WGS84.
3. **The scalar API forces a boundary crossing plus a WASM-managed `Coordinate` object per vertex**, and callers never `.free()` them.

Commit 1 fixes (1)+(2), commit 2 makes the API uniform and validated, commit 3 fixes (3).

## Commit 1 — reusable `Ellipsoid` handle

`Ellipsoid.from(obj | null | undefined)` parses once (coefficients included); scheme statics **borrow** it (`ellipsoid: &Ellipsoid`, required). `undefined`/missing gives the default sphere; extra keys (`name`, `epsg`, …) are ignored *and* type-check (`EllipsoidInput` is intersected with `{ [key: string]: unknown }`). Degenerate bodies are rejected (non-positive/non-finite axes, `semi_minor > semi_major`, `inverse_flattening ≤ 1` — `inverse_flattening: 0` used to yield `flattening: Infinity`). `parseEllipsoid` and the exported variant classes are removed; handle reuse is pinned by a regression test.

## Commit 2 — `Grid`

```ts
const grid = new Grid({ scheme: "nested" | "ring" | "zuniq", level: 4, ellipsoid });
grid.vertex(cell, u, v); grid.bitCombine(i, j);
grid.toScheme(cell, "zuniq"); grid.toScheme(cell, "zuniq", 6); // optional level override
```

One exported class with a real `#[wasm_bindgen(constructor)]`; scheme dispatch, level and the parsed ellipsoid stored once, methods take `&self`. `level` is the only size option (DGGS terminology per review round 2; read-only `nside` getter kept). What it buys:

1. **The zuniq signature trap is gone** — one shape for every scheme; zuniq uses the depth embedded in the id (pinned by test).
2. **Misuse throws a catchable `Error` instead of trapping the instance** (a trapped wasm instance is poisoned). Now rejected rather than trapped: out-of-range/malformed cell ids for all three schemes; out-of-range or non-finite coordinates on `lonLatToHealpix` (cdshealpix asserts on lat outside ±π/2 — exactly the input that arrives from data buffers); `u`/`v` outside `[0, 1]` on `vertex` (ruled strict in round 2 — folded into `spherical_vertex` itself, so the scheme statics validate offsets too); and count-like params take `f64` and narrow explicitly (declared `u32` lets ToUint32 wrap `bitCombine(2**32, 0)` into `(0, 0)` *before* the range check). Fallible methods split into native-testable `*_impl` + thin `JsError` wrappers.
3. **`toScheme(cell, scheme, level?)`**: nested↔ring at the grid's level; *to* zuniq encodes the grid's level, or `level` when given (mirroring the python bindings' #236 semantics; `level` with a non-level-encoding target rejects); *from* zuniq uses the embedded level; zuniq→zuniq is identity.

`grid.ellipsoid` mints a new handle per read (documented); the flattened numeric getters are the hot-path form. The `scheme` getter is typed as the literal union, so `other.toScheme(cell, grid.scheme)` type-checks.

## Commit 3 — bulk typed-array APIs

Four methods, each one boundary crossing returning a typed array from a single linear-memory write:

- `vertices(cell, steps) -> Float64Array` — `steps × steps` grid, interleaved `[lon, lat, …]`, `i` outer / `j` inner, `u = i/(steps-1)`.
- `lonLatToHealpix(lonlats: Float64Array) -> BigUint64Array` / `healpixToLonLat(cells: BigUint64Array) -> Float64Array` — the batched lookups now carry the cds-healpix names (scalar pair deleted per round 2: no use case, and the python bindings' names are vectorized semantics anyway); both reject the batch **naming the offending index** instead of trapping on one bad element.
- `bitCombineTable(size) -> BigUint64Array` — the z-order table; entry `row * size + col` = `bitCombine(col, row)`. Its curve derives from `size`, not grid depth (depth-derived curves are wrong at depth 0, alias above 256, and spill the base cell for `size > nside` — each regime is a named test; the table is depth-independent by test across depths 3…12).

u64 exactness end to end (`bigint`/`BigUint64Array`, tested at the true depth-29 last cell `12·4²⁹ − 1`, `+1n` rejected). Element counts computed in `u64` and checked into `usize` (32-bit on wasm32). On a zuniq grid `healpixToLonLat`/`lonLatToHealpix` are deliberately not inverses across levels (embedded-level rule; documented + pinned).

**Typechecking runs through vitest's typecheck mode** (round 2: your find) — `types.test-d.ts` uses `expectTypeOf` against the published types, `typecheck.enabled` makes plain `vitest` perform it (CI unchanged), a planted type error in any test file fails the run, and `@types/node` is gone (`typescript` stays; the checker shells out to it). Clean at every commit. The README leads with `Grid`, statics demoted to an advanced section.

## Breaking changes

- The scheme statics' ellipsoid argument is **required** (`Ellipsoid.from(null)` where `null` was passed).
- `parseEllipsoid` and the `Sphere`/`EllipsoidInverseFlattening`/`EllipsoidSemiMinorAxis` classes are removed; read `semiMajorAxis`/`flattening`/`isSphere` off the handle.
- `Ellipsoid.from(undefined)` returns the default sphere (was a deserialization error); degenerate reference bodies now throw.
- `Grid` and its methods are new API; invalid input throws catchable `Error`s.
- **The scheme statics' `vertex` now validates offsets** (round-2 fold): out-of-`[0,1]` `u`/`v` that previously returned a neighbouring cell's vertex (or trapped) now throws.

## Benchmarks

gridlook's `makeHealpixGeometry` shape (50,700 vertices), release builds, node 23.5, one process per variant, median of 11 per-process medians [IQR]. Measured on v2; later revisions are rename-only on these paths except two bounds compares per vertex in the bulk loop (noise).

| variant | sphere | WGS84 |
|---|---|---|
| upstream main, parse per call | 46.0 ms [44.2–48.9] | 318.5 ms [316.4–321.1] |
| upstream main, parse hoisted | throws | throws |
| commit 1: handle + statics | 16.9 ms — 2.7× | 20.4 ms — 15.6× |
| commit 2: `new Grid`, scalar vertex | 15.7 ms — 2.9× | 22.8 ms — 14.0× |
| **commit 3: `grid.vertices`** | **1.03 ms — 45×** | **6.86 ms — 46×** |

256×256 unshuffle table: 1.31 ms → 0.31 ms. Read the scalar ratios as ≈2.7–2.9× (single-process scatter ±10%); the WGS84 column is where the handle matters.

**Why one process per variant:** the scalar APIs leave a wrapper + finalizer per vertex to the GC. `bench/gc_degradation.mjs`: 60 repeated scalar rounds degrade 14.95 ms → 1200 ms (80×, 214 MB heap; explicit `gc()` doesn't help), while the bulk path stays flat (~1 ms, 5 MB). For a render loop, the bulk API is the primary interface.

## How tested

| | cargo | vitest | typecheck |
|---|---|---|---|
| main @ e5d51d6 | 11 | 25 | — |
| commit 1 | 15 | 32 | clean |
| commit 2 | 31 | 60 | clean |
| commit 3 | 43 | 79 | clean |

Each commit gated independently in a fresh worktree; `wasm-pack build` succeeds for nodejs/web/bundler at HEAD; fmt, prettier and clippy clean on all three commits. Highlights: bulk-vs-scalar parity over the full gridlook geometry, bit-equal, sphere *and* WGS84, in both suites; every input that used to trap wasm is a named rejection test, plus module-usable-after-rejection; `bench/crosscheck.mjs` pins **673,936 values bit-for-bit identical** to upstream `main` across all commits.

**Not exercised:** browser suites (no headless browser here); the Python bindings (untouched); gridlook itself is not checked out — the claimed loop layouts match #192 as read, worth confirming before relying on it as a drop-in.

## Notes for gridlook (d70-t/gridlook#192)

`makeHealpixGeometry` → one `grid.vertices(ipix, steps)` call + a `Float64Array`→`Float32Array` fill; `getUnshuffleIndex` → one `bitCombineTable(size)` call. f32 represents integers exactly **through 2²⁴ inclusive**, so a 4096-edge chunk (max index 2²⁴ − 1) is safe in a `Float32Array`; 8192 is where indices collapse.

## Questions for review

First-round questions, all answered — ruling under each; (9) still stands. New questions from this revision are in the review follow-up comment.

1. ~~Required ellipsoid vs. keeping `null` accepted?~~ **Ruled: required `&Ellipsoid`** — `Ellipsoid.from(null)` is the sphere.
2. ~~Keep `parseEllipsoid` as an alias?~~ **Ruled: removed.**
3. ~~`createGrid(options)` vs `new Grid(options)`?~~ **Ruled: real constructor.**
4. ~~`center`/`cellAt` vs the python-binding names?~~ **Ruled: `healpixToLonLat`/`lonLatToHealpix`** (bulk naming: follow-up comment).
5. ~~Accept an `Ellipsoid` handle in `options.ellipsoid`?~~ **Ruled: plain objects only.**
6. ~~Which ring path is canonical?~~ **Ruled: current implementation stands.**
7. ~~`typescript` devDep for a real typecheck?~~ **Ruled: wanted** — wired from commit 1.
8. ~~Zero-copy `verticesInto` variant?~~ **Ruled: deferred** — bulk path measured flat (~1 ms/call, ~5 MB heap over 60 rounds).
9. **Still standing:** `grid.neighbours(cell, k)` is a natural follow-up if wanted; `js/scripts/build.sh` uses GNU `getopt --long` (fails on macOS/BSD); `npm run build:node` builds `--dev`, so benchmark numbers must come from a release build.

Related, outside this repo: `--target bundler` drops `js_namespace` exports on wasm-bindgen 0.2.126 — the manual unit-struct namespace pattern here is the workaround; a minimal reproduction and draft upstream issue are ready to file.
