### PR TITLE
functions to convert between indexing schemes

### DIFF
--- a/python/healpix-geo/docs/api/auto.rst
+++ b/python/healpix-geo/docs/api/auto.rst
@@ -23,6 +23,14 @@ Coordinate Conversions
    cartesian_to_healpix
    vertices
 
+Indexing Scheme Conversions
+---------------------------
+
+.. autosummary::
+   :toctree: ../generated/
+
+   convert
+
 Interpolation
 -------------
 Interpolation from HEALPix to geographic coordinates.

--- a/python/healpix-geo/docs/api/nested.rst
+++ b/python/healpix-geo/docs/api/nested.rst
@@ -22,6 +22,17 @@ Conversions between geographic coordinates and HEALPix indices.
 .. seealso::
    Tutorial complete : :doc:`../tutorials/coordinate_conversion`
 
+Indexing Scheme Conversions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: ../generated/
+
+   from_ring
+   from_zuniq
+   to_ring
+   to_zuniq
+
 Interpolation
 ~~~~~~~~~~~~~
 

--- a/python/healpix-geo/docs/api/nested.rst
+++ b/python/healpix-geo/docs/api/nested.rst
@@ -28,8 +28,6 @@ Indexing Scheme Conversions
 .. autosummary::
    :toctree: ../generated/
 
-   from_ring
-   from_zuniq
    to_ring
    to_zuniq
 

--- a/python/healpix-geo/docs/api/nested.rst
+++ b/python/healpix-geo/docs/api/nested.rst
@@ -5,8 +5,8 @@ The module `healpix_geo.nested` gives functions for the nested indexing scheme.
 
 .. currentmodule:: healpix_geo.nested
 
-Coordinates Conversions
-~~~~~~~~~~~~~~~~~~~~~~~~
+Coordinate Conversions
+~~~~~~~~~~~~~~~~~~~~~~
 
 Conversions between geographic coordinates and HEALPix indices.
 

--- a/python/healpix-geo/docs/api/ring.rst
+++ b/python/healpix-geo/docs/api/ring.rst
@@ -8,8 +8,8 @@ The module `healpix_geo.ring` gives for the ring indexation scheme.
 .. note::
    The ring scheme is principally given for **compatibility**. For new applications, prefer `healpix_geo.nested`.
 
-Coordinates Conversions
-~~~~~~~~~~~~~~~~~~~~~~~~~
+Coordinate Conversions
+~~~~~~~~~~~~~~~~~~~~~~
 
 .. autosummary::
    :toctree: ../generated/

--- a/python/healpix-geo/docs/api/ring.rst
+++ b/python/healpix-geo/docs/api/ring.rst
@@ -26,8 +26,6 @@ Indexing Scheme Conversions
 .. autosummary::
    :toctree: ../generated/
 
-   from_nested
-   from_zuniq
    to_nested
    to_zuniq
 

--- a/python/healpix-geo/docs/api/ring.rst
+++ b/python/healpix-geo/docs/api/ring.rst
@@ -20,6 +20,17 @@ Coordinates Conversions
    cartesian_to_healpix
    vertices
 
+Indexing Scheme Conversions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: ../generated/
+
+   from_nested
+   from_zuniq
+   to_nested
+   to_zuniq
+
 Interpolation
 ~~~~~~~~~~~~~
 

--- a/python/healpix-geo/docs/api/zuniq.rst
+++ b/python/healpix-geo/docs/api/zuniq.rst
@@ -38,8 +38,6 @@ Indexing Scheme Conversions
 .. autosummary::
    :toctree: ../generated/
 
-   from_ring
-   from_nested
    to_ring
    to_nested
 

--- a/python/healpix-geo/docs/api/zuniq.rst
+++ b/python/healpix-geo/docs/api/zuniq.rst
@@ -5,23 +5,8 @@ The module `healpix_geo.zuniq` gives functions for the zuniq scheme, utilised fo
 
 .. currentmodule:: healpix_geo.zuniq
 
-Conversions
-~~~~~~~~~~~
-
-Conversions between schemes nested et zuniq.
-
-.. autosummary::
-   :toctree: ../generated/
-
-   from_nested
-   to_nested
-
-.. seealso::
-   Complete tutorial : :doc:`../tutorials/coordinate_conversion`
-
-
-Coordinates Conversions
-~~~~~~~~~~~~~~~~~~~~~~~~
+Coordinate Conversions
+~~~~~~~~~~~~~~~~~~~~~~
 
 .. autosummary::
    :toctree: ../generated/
@@ -31,6 +16,9 @@ Coordinates Conversions
    healpix_to_cartesian
    cartesian_to_healpix
    vertices
+
+.. seealso::
+   Complete tutorial : :doc:`../tutorials/coordinate_conversion`
 
 Indexing Scheme Conversions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/python/healpix-geo/docs/api/zuniq.rst
+++ b/python/healpix-geo/docs/api/zuniq.rst
@@ -32,6 +32,17 @@ Coordinates Conversions
    cartesian_to_healpix
    vertices
 
+Indexing Scheme Conversions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: ../generated/
+
+   from_ring
+   from_nested
+   to_ring
+   to_nested
+
 Interpolation
 ~~~~~~~~~~~~~
 

--- a/python/healpix-geo/docs/tutorials/coordinate_conversion.md
+++ b/python/healpix-geo/docs/tutorials/coordinate_conversion.md
@@ -49,18 +49,18 @@ The nested and ring indices **are not interchangeable**. The same point has diff
 ### Nested and Zuniq
 
 ```{code-cell} python
-from healpix_geo.zuniq import from_nested, to_nested
+import healpix_geo
 import numpy as np
 
 # Nested → Zuniq
 ipix_nested = 349440
 depth = 8
-zuniq_id = from_nested(ipix_nested, depth)
+zuniq_id = healpix_geo.nested.to_zuniq(ipix_nested, depth)
 
 print(f"Nested (depth={depth}, ipix={ipix_nested}) → Zuniq: {zuniq_id}")
 
 # Zuniq → Nested
-ipix_back, depth_back = to_nested(zuniq_id)
+ipix_back, depth_back = healpix_geo.zuniq.to_nested(zuniq_id)
 print(f"Zuniq {zuniq_id} → Nested (depth={depth_back}, ipix={ipix_back})")
 ```
 

--- a/python/healpix-geo/docs/tutorials/working_with_moc.md
+++ b/python/healpix-geo/docs/tutorials/working_with_moc.md
@@ -7,19 +7,19 @@ This tutorial explains how to use Multi-Order Coverage maps (MOC) to represent e
 The MOC is using the **zuniq** scheme which encode depth + ipix in one integer 64-bit.
 
 ```python
-from healpix_geo.zuniq import from_nested, to_nested
+import healpix_geo
 import numpy as np
 
 # Cells nested
 ipix_nested = np.array([100, 200, 300])
 depth = 8
 
-# Convert in zuniq
-zuniq_ids = from_nested(ipix_nested, depth)
+# Convert to zuniq
+zuniq_ids = healpix_geo.nested.to_zuniq(ipix_nested, depth)
 print(f"Zuniq IDs: {zuniq_ids}")
 
 # Convert return in nested
-ipix_back, depth_back = to_nested(zuniq_ids)
+ipix_back, depth_back = healpix_geo.zuniq.to_nested(zuniq_ids)
 print(f"Nested: depth={depth_back}, ipix={ipix_back}")
 ```
 

--- a/python/healpix-geo/python/healpix_geo/auto.py
+++ b/python/healpix-geo/python/healpix_geo/auto.py
@@ -27,12 +27,15 @@ def _dispatch_module(indexing_scheme: str) -> ModuleType:
     return module
 
 
+SchemeType = Literal["nested", "ring", "zuniq"]
+
+
 @dataclass(frozen=True)
 class Grid:
     level: int | None
     """The refinement level of the grid."""
 
-    indexing_scheme: Literal["nested", "ring", "zuniq"] = "nested"
+    indexing_scheme: SchemeType = "nested"
     """The indexing scheme of the grid."""
 
     ellipsoid: EllipsoidLike = "sphere"
@@ -44,6 +47,68 @@ class Grid:
             params["depth"] = self.level
 
         return params
+
+
+def convert(
+    ipix: npt.NDArray[np.uint64],
+    grid: Grid,
+    *,
+    to: SchemeType,
+    level: npt.NDArray[np.uint8] | None = None,
+    num_threads: int = 0,
+) -> tuple[npt.NDArray[np.uint64], int | npt.NDArray[np.uint8]]:
+    """Convert the cell ids to a different indexing scheme
+
+    Parameters
+    ----------
+    ipix : `numpy.ndarray`
+        The HEALPix cell indexes given as a `np.uint64` numpy array.
+    grid : Grid
+        The definition of the HEALPix grid.
+    to : {"nested", "ring", "zuniq"}
+        The indexing scheme to convert to. If equal to the grid object's
+        indexing scheme the input cell ids will be returned unmodified.
+    level : `numpy.ndarray`, optional
+        The levels in case the cells have a different sizes.
+    num_threads : int, optional
+        Specifies the number of threads to use for the computation. Default to 0 means
+        it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
+        or the number of logical CPUs (otherwise)
+
+    Returns
+    -------
+    converted : `numpy.ndarray`
+        The converted cell indexes as a `np.uint64` numpy array.
+    levels : int or `numpy.ndarray`
+        The refinement level of the cell indexes. If the input scheme was
+        ``"nested"`` or ``"ring"`` and `level` was not passed this will be the
+        grid object's refinement level, otherwise an array of refinement levels.
+    """
+    base_indexing_schemes = {"nested", "ring"}
+    if grid.indexing_scheme == to:
+        return ipix
+
+    params = {"num_threads": num_threads}
+    if grid.indexing_scheme not in base_indexing_schemes and level is not None:
+        raise ValueError(
+            f"indexing scheme {grid.indexing_scheme} already contains"
+            " the refinement level in the cell indexes"
+        )
+    elif grid.indexing_scheme in base_indexing_schemes:
+        if level is None:
+            level = grid.level
+        params["depth"] = level
+
+    module = _dispatch_module(grid.indexing_scheme)
+    converter = getattr(module, f"to_{to}", None)
+    if converter is None:
+        raise ValueError(f"unknown indexing scheme: {to!r}")
+
+    result = converter(ipix, **params)
+    if grid.indexing_scheme not in {"nested", "ring"} and to in {"nested", "ring"}:
+        return result
+    else:
+        return result, level
 
 
 def healpix_to_lonlat(

--- a/python/healpix-geo/python/healpix_geo/nested.py
+++ b/python/healpix-geo/python/healpix_geo/nested.py
@@ -21,49 +21,6 @@ def create_empty(depth):
     return RangeMOCIndex.empty(depth)
 
 
-def from_ring(
-    ipix: npt.NDArray[np.uint64], depth: DepthType, num_threads: int = 0
-) -> npt.NDArray[np.uint64]:
-    """Convert from ring to nested
-
-    Parameters
-    ----------
-    ipix : `numpy.ndarray`
-        The HEALPix cell indexes in the ring scheme given as a `np.uint64` numpy array.
-    depth : int or array-like of int
-        The HEALPix cell depth given as scalar or a `np.uint8` numpy array.
-    num_threads : int, optional
-        Specifies the number of threads to use for the computation. Default to 0 means
-        it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
-        or the number of logical CPUs (otherwise)
-
-    Returns
-    -------
-    nested : array-like of int
-        The cell ids in the nested scheme.
-
-    Examples
-    --------
-    >>> import healpix_geo.nested
-    >>> import numpy as np
-    >>> ipix_ring = np.array([32, 125, 45, 91], dtype="uint64")
-    >>> depth = np.array([1, 3, 2, 4], dtype="uint8")
-    >>> ipix_nested = healpix_geo.nested.from_ring(ipix_ring, depth)
-    >>> ipix_nested
-    array([ 24,  89,  24, 491], dtype=uint64)
-    """
-    _check_depth(depth)
-
-    ipix = np.atleast_1d(ipix)
-    _check_ipixels(data=ipix, depth=depth)
-    ipix = ipix.astype(np.uint64)
-
-    depth = depth if isinstance(depth, int) else depth.astype("uint8")
-    num_threads = np.uint16(num_threads)
-
-    return healpix_geo.nested.from_ring(ipix, depth, num_threads)
-
-
 def to_ring(
     ipix: npt.NDArray[np.uint64], depth: DepthType, num_threads: int = 0
 ) -> npt.NDArray[np.uint64]:
@@ -106,53 +63,6 @@ def to_ring(
     num_threads = np.uint16(num_threads)
 
     return healpix_geo.nested.to_ring(ipix, depth, num_threads)
-
-
-def from_zuniq(
-    ipix: npt.NDArray[np.uint64], num_threads: int = 0
-) -> tuple[npt.NDArray[np.uint64], DepthType]:
-    """Convert from zuniq to nested
-
-    Parameters
-    ----------
-    ipix : `numpy.ndarray`
-        The HEALPix cell indexes in the zuniq scheme given as a `np.uint64` numpy array.
-    num_threads : int, optional
-        Specifies the number of threads to use for the computation. Default to 0 means
-        it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
-        or the number of logical CPUs (otherwise)
-
-    Returns
-    -------
-    nested : array-like of int
-        The cell ids in the nested scheme.
-    depth : array-like of int
-        The HEALPix cell depth of the given cells as a `np.uint8` numpy array.
-
-    Examples
-    --------
-    >>> import healpix_geo.nested
-    >>> import numpy as np
-    >>> ipix_zuniq = np.array(
-    ...     [
-    ...         4683743612465315840,
-    ...         1130403506469994496,
-    ...         1639310264362860544,
-    ...         206039682952200192,
-    ...     ],
-    ...     dtype="uint64",
-    ... )
-    >>> ipix_nested, depth = healpix_geo.nested.from_zuniq(ipix_zuniq)
-    >>> ipix_nested
-    array([ 32, 125,  45,  91], dtype=uint64)
-    >>> depth
-    array([1, 3, 2, 4], dtype=uint8)
-    """
-    ipix = np.atleast_1d(ipix).astype(np.uint64)
-
-    num_threads = np.uint16(num_threads)
-
-    return healpix_geo.nested.from_zuniq(ipix, num_threads)
 
 
 def to_zuniq(

--- a/python/healpix-geo/python/healpix_geo/nested.py
+++ b/python/healpix-geo/python/healpix_geo/nested.py
@@ -11,6 +11,8 @@ from healpix_geo.utils import _check_depth, _check_ipixels, _check_ring
 if TYPE_CHECKING:
     import numpy.typing as npt
 
+    from healpix_geo.typing import DepthType
+
 RangeMOCIndex = healpix_geo.nested.RangeMOCIndex
 internal_boundary = healpix_geo.nested.internal_boundary
 
@@ -19,7 +21,9 @@ def create_empty(depth):
     return RangeMOCIndex.empty(depth)
 
 
-def from_ring(ipix, depth, num_threads=0):
+def from_ring(
+    ipix: npt.NDArray[np.uint64], depth: DepthType, num_threads: int = 0
+) -> npt.NDArray[np.uint64]:
     """Convert from ring to nested
 
     Parameters
@@ -60,7 +64,9 @@ def from_ring(ipix, depth, num_threads=0):
     return healpix_geo.nested.from_ring(ipix, depth, num_threads)
 
 
-def to_ring(ipix, depth, num_threads=0):
+def to_ring(
+    ipix: npt.NDArray[np.uint64], depth: DepthType, num_threads: int = 0
+) -> npt.NDArray[np.uint64]:
     """Convert from nested to ring
 
     Parameters
@@ -102,7 +108,9 @@ def to_ring(ipix, depth, num_threads=0):
     return healpix_geo.nested.to_ring(ipix, depth, num_threads)
 
 
-def from_zuniq(ipix, num_threads=0):
+def from_zuniq(
+    ipix: npt.NDArray[np.uint64], num_threads: int = 0
+) -> tuple[npt.NDArray[np.uint64], DepthType]:
     """Convert from zuniq to nested
 
     Parameters
@@ -147,7 +155,9 @@ def from_zuniq(ipix, num_threads=0):
     return healpix_geo.nested.from_zuniq(ipix, num_threads)
 
 
-def to_zuniq(ipix, depth, num_threads=0):
+def to_zuniq(
+    ipix: npt.NDArray[np.uint64], depth: DepthType, num_threads: int = 0
+) -> npt.NDArray[np.uint64]:
     """Convert from nested to zuniq
 
     Parameters

--- a/python/healpix-geo/python/healpix_geo/nested.py
+++ b/python/healpix-geo/python/healpix_geo/nested.py
@@ -19,6 +19,177 @@ def create_empty(depth):
     return RangeMOCIndex.empty(depth)
 
 
+def from_ring(ipix, depth, num_threads=0):
+    """Convert from ring to nested
+
+    Parameters
+    ----------
+    ipix : `numpy.ndarray`
+        The HEALPix cell indexes in the ring scheme given as a `np.uint64` numpy array.
+    depth : int or array-like of int
+        The HEALPix cell depth given as scalar or a `np.uint8` numpy array.
+    num_threads : int, optional
+        Specifies the number of threads to use for the computation. Default to 0 means
+        it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
+        or the number of logical CPUs (otherwise)
+
+    Returns
+    -------
+    nested : array-like of int
+        The cell ids in the nested scheme.
+
+    Examples
+    --------
+    >>> import healpix_geo.nested
+    >>> import numpy as np
+    >>> ipix_ring = np.array([32, 125, 45, 91], dtype="uint64")
+    >>> depth = np.array([1, 3, 2, 4], dtype="uint8")
+    >>> ipix_nested = healpix_geo.nested.from_ring(ipix_ring, depth)
+    >>> ipix_nested
+    array([ 24,  89,  24, 491], dtype=uint64)
+    """
+    _check_depth(depth)
+
+    ipix = np.atleast_1d(ipix)
+    _check_ipixels(data=ipix, depth=depth)
+    ipix = ipix.astype(np.uint64)
+
+    depth = depth if isinstance(depth, int) else depth.astype("uint8")
+    num_threads = np.uint16(num_threads)
+
+    return healpix_geo.nested.from_ring(ipix, depth, num_threads)
+
+
+def to_ring(ipix, depth, num_threads=0):
+    """Convert from nested to ring
+
+    Parameters
+    ----------
+    ipix : `numpy.ndarray`
+        The HEALPix cell indexes in the nested scheme given as a `np.uint64` numpy array.
+    depth : int or array-like of int
+        The HEALPix cell depth given as scalar or a `np.uint8` numpy array.
+    num_threads : int, optional
+        Specifies the number of threads to use for the computation. Default to 0 means
+        it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
+        or the number of logical CPUs (otherwise)
+
+    Returns
+    -------
+    ring : array-like of int
+        The cell ids in the ring scheme.
+
+    Examples
+    --------
+    >>> import healpix_geo.nested
+    >>> import numpy as np
+    >>> ipix_nested = np.array([32, 125, 45, 91], dtype="uint64")
+    >>> depth = np.array([1, 3, 2, 4], dtype="uint8")
+    >>> ipix_ring = healpix_geo.nested.to_ring(ipix_nested, depth)
+    >>> ipix_ring
+    array([ 44,   7,   9, 432], dtype=uint64)
+    """
+    _check_depth(depth)
+
+    ipix = np.atleast_1d(ipix)
+    _check_ipixels(data=ipix, depth=depth)
+    ipix = ipix.astype(np.uint64)
+
+    ipix = np.atleast_1d(ipix).astype(np.uint64)
+
+    num_threads = np.uint16(num_threads)
+
+    return healpix_geo.nested.to_ring(ipix, depth, num_threads)
+
+
+def from_zuniq(ipix, num_threads=0):
+    """Convert from zuniq to nested
+
+    Parameters
+    ----------
+    ipix : `numpy.ndarray`
+        The HEALPix cell indexes in the zuniq scheme given as a `np.uint64` numpy array.
+    num_threads : int, optional
+        Specifies the number of threads to use for the computation. Default to 0 means
+        it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
+        or the number of logical CPUs (otherwise)
+
+    Returns
+    -------
+    nested : array-like of int
+        The cell ids in the nested scheme.
+    depth : array-like of int
+        The HEALPix cell depth of the given cells as a `np.uint8` numpy array.
+
+    Examples
+    --------
+    >>> import healpix_geo.nested
+    >>> import numpy as np
+    >>> ipix_zuniq = np.array(
+    ...     [
+    ...         4683743612465315840,
+    ...         1130403506469994496,
+    ...         1639310264362860544,
+    ...         206039682952200192,
+    ...     ],
+    ...     dtype="uint64",
+    ... )
+    >>> ipix_nested, depth = healpix_geo.nested.from_zuniq(ipix_zuniq)
+    >>> ipix_nested
+    array([ 32, 125,  45,  91], dtype=uint64)
+    >>> depth
+    array([1, 3, 2, 4], dtype=uint8)
+    """
+    ipix = np.atleast_1d(ipix).astype(np.uint64)
+
+    num_threads = np.uint16(num_threads)
+
+    return healpix_geo.nested.from_zuniq(ipix, num_threads)
+
+
+def to_zuniq(ipix, depth, num_threads=0):
+    """Convert from nested to zuniq
+
+    Parameters
+    ----------
+    ipix : `numpy.ndarray`
+        The HEALPix cell indexes in the nested scheme given as a `np.uint64` numpy array.
+    depth : int or array-like of int
+        The HEALPix cell depth given as scalar or a `np.uint8` numpy array.
+    num_threads : int, optional
+        Specifies the number of threads to use for the computation. Default to 0 means
+        it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
+        or the number of logical CPUs (otherwise)
+
+    Returns
+    -------
+    nested : array-like of int
+        The cell ids in the nested scheme.
+
+    Examples
+    --------
+    >>> import healpix_geo.nested
+    >>> import numpy as np
+    >>> ipix_nested = np.array([32, 125, 45, 91], dtype="uint64")
+    >>> depth = np.array([1, 3, 2, 4], dtype="uint8")
+    >>> ipix_zuniq = healpix_geo.nested.to_zuniq(ipix_nested, depth)
+    >>> ipix_zuniq
+    array([4683743612465315840, 1130403506469994496, 1639310264362860544,
+            206039682952200192], dtype=uint64)
+    """
+    _check_depth(depth)
+
+    ipix = np.atleast_1d(ipix)
+    _check_ipixels(data=ipix, depth=depth)
+    ipix = ipix.astype(np.uint64)
+
+    depth = depth if isinstance(depth, int) else depth.astype("uint8")
+
+    num_threads = np.uint16(num_threads)
+
+    return healpix_geo.nested.to_zuniq(ipix, depth, num_threads)
+
+
 def healpix_to_lonlat(ipix, depth, ellipsoid="sphere", num_threads=0):
     r"""Get the longitudes and latitudes of the center of some HEALPix cells.
 

--- a/python/healpix-geo/python/healpix_geo/ring.py
+++ b/python/healpix-geo/python/healpix_geo/ring.py
@@ -11,8 +11,12 @@ from healpix_geo.utils import _check_depth, _check_ipixels, _check_ring
 if TYPE_CHECKING:
     import numpy.typing as npt
 
+    from healpix_geo.typing import DepthType
 
-def from_nested(ipix, depth, num_threads=0):
+
+def from_nested(
+    ipix: npt.NDArray[np.uint64], depth: DepthType, num_threads: int = 0
+) -> npt.NDArray[np.uint64]:
     """Convert from nested to ring
 
     Parameters
@@ -63,7 +67,9 @@ def from_nested(ipix, depth, num_threads=0):
     return healpix_geo.ring.from_nested(ipix, depth, num_threads)
 
 
-def to_nested(ipix, depth, num_threads=0):
+def to_nested(
+    ipix: npt.NDArray[np.uint64], depth: DepthType, num_threads: int = 0
+) -> npt.NDArray[np.uint64]:
     """Convert from ring to nested
 
     Parameters
@@ -116,7 +122,9 @@ def to_nested(ipix, depth, num_threads=0):
     return healpix_geo.ring.to_nested(ipix, depth, num_threads)
 
 
-def from_zuniq(ipix, num_threads=0):
+def from_zuniq(
+    ipix: npt.NDArray[np.uint64], num_threads: int = 0
+) -> tuple[npt.NDArray[np.uint64], DepthType]:
     """Convert from zuniq to nested
 
     Parameters
@@ -161,7 +169,9 @@ def from_zuniq(ipix, num_threads=0):
     return healpix_geo.ring.from_zuniq(ipix, num_threads)
 
 
-def to_zuniq(ipix, depth, num_threads=0):
+def to_zuniq(
+    ipix: npt.NDArray[np.uint64], depth: DepthType, num_threads: int = 0
+) -> npt.NDArray[np.uint64]:
     """Convert from nested to zuniq
 
     Parameters

--- a/python/healpix-geo/python/healpix_geo/ring.py
+++ b/python/healpix-geo/python/healpix_geo/ring.py
@@ -12,6 +12,198 @@ if TYPE_CHECKING:
     import numpy.typing as npt
 
 
+def from_nested(ipix, depth, num_threads=0):
+    """Convert from nested to ring
+
+    Parameters
+    ----------
+    ipix : `numpy.ndarray`
+        The HEALPix cell indexes in the nested scheme given as a `np.uint64` numpy array.
+    depth : int or array-like of int
+        The HEALPix cell depth given as scalar or a `np.uint8` numpy array.
+    num_threads : int, optional
+        Specifies the number of threads to use for the computation. Default to 0 means
+        it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
+        or the number of logical CPUs (otherwise)
+
+    Returns
+    -------
+    ring : array-like of int
+        The cell ids in the ring scheme.
+
+    Examples
+    --------
+    >>> import healpix_geo
+    >>> import numpy as np
+
+    Scalar depth:
+
+    >>> ipix_nested = np.array([32, 125, 45, 91], dtype="uint64")
+    >>> depth = 4
+    >>> ipix_ring = healpix_geo.ring.from_nested(ipix_nested, depth)
+    >>> ipix_ring
+    array([1190,  189,  870,  432], dtype=uint64)
+
+    Array depth:
+
+    >>> depth = np.array([1, 3, 2, 4], dtype="uint8")
+    >>> ipix_ring = healpix_geo.ring.from_nested(ipix_nested, depth)
+    >>> ipix_ring
+    array([ 44,   7,   9, 432], dtype=uint64)
+    """
+    _check_depth(depth)
+
+    ipix = np.atleast_1d(ipix)
+    _check_ipixels(data=ipix, depth=depth)
+    ipix = ipix.astype(np.uint64)
+
+    depth = depth if isinstance(depth, int) else depth.astype("uint8")
+    num_threads = np.uint16(num_threads)
+
+    return healpix_geo.ring.from_nested(ipix, depth, num_threads)
+
+
+def to_nested(ipix, depth, num_threads=0):
+    """Convert from ring to nested
+
+    Parameters
+    ----------
+    ipix : `numpy.ndarray`
+        The HEALPix cell indexes in the ring scheme given as a `np.uint64` numpy array.
+    depth : int or array-like of int
+        The HEALPix cell depth given as scalar or a `np.uint8` numpy array.
+    num_threads : int, optional
+        Specifies the number of threads to use for the computation. Default to 0 means
+        it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
+        or the number of logical CPUs (otherwise)
+
+    Returns
+    -------
+    nested : array-like of int
+        The cell ids in the nested scheme.
+
+    Examples
+    --------
+    >>> import healpix_geo
+    >>> import numpy as np
+
+    Scalar depth:
+
+    >>> ipix_ring = np.array([1190, 189, 870, 432], dtype="uint64")
+    >>> depth = 4
+    >>> ipix_nested = healpix_geo.ring.to_nested(ipix_ring, depth)
+    >>> ipix_nested
+    array([ 32, 125,  45,  91], dtype=uint64)
+
+    Array depth:
+
+    >>> ipix_ring = np.array([44, 7, 9, 432], dtype="uint64")
+    >>> depth = np.array([1, 3, 2, 4], dtype="uint8")
+    >>> ipix_nested = healpix_geo.ring.to_nested(ipix_ring, depth)
+    >>> ipix_nested
+    array([ 32, 125,  45,  91], dtype=uint64)
+    """
+    _check_depth(depth)
+
+    ipix = np.atleast_1d(ipix)
+    _check_ipixels(data=ipix, depth=depth)
+    ipix = ipix.astype(np.uint64)
+
+    ipix = np.atleast_1d(ipix).astype(np.uint64)
+
+    num_threads = np.uint16(num_threads)
+
+    return healpix_geo.ring.to_nested(ipix, depth, num_threads)
+
+
+def from_zuniq(ipix, num_threads=0):
+    """Convert from zuniq to nested
+
+    Parameters
+    ----------
+    ipix : `numpy.ndarray`
+        The HEALPix cell indexes in the zuniq scheme given as a `np.uint64` numpy array.
+    num_threads : int, optional
+        Specifies the number of threads to use for the computation. Default to 0 means
+        it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
+        or the number of logical CPUs (otherwise)
+
+    Returns
+    -------
+    nested : array-like of int
+        The cell ids in the nested scheme.
+    depth : array-like of int
+        The HEALPix cell depth of the given cells as a `np.uint8` numpy array.
+
+    Examples
+    --------
+    >>> import healpix_geo.nested
+    >>> import numpy as np
+    >>> ipix_zuniq = np.array(
+    ...     [
+    ...         4683743612465315840,
+    ...         1130403506469994496,
+    ...         1639310264362860544,
+    ...         206039682952200192,
+    ...     ],
+    ...     dtype="uint64",
+    ... )
+    >>> ipix_ring, depth = healpix_geo.ring.from_zuniq(ipix_zuniq)
+    >>> ipix_ring
+    array([ 44,   7,   9, 432], dtype=uint64)
+    >>> depth
+    array([1, 3, 2, 4], dtype=uint8)
+    """
+    ipix = np.atleast_1d(ipix).astype(np.uint64)
+
+    num_threads = np.uint16(num_threads)
+
+    return healpix_geo.ring.from_zuniq(ipix, num_threads)
+
+
+def to_zuniq(ipix, depth, num_threads=0):
+    """Convert from nested to zuniq
+
+    Parameters
+    ----------
+    ipix : `numpy.ndarray`
+        The HEALPix cell indexes in the nested scheme given as a `np.uint64` numpy array.
+    depth : int or array-like of int
+        The HEALPix cell depth given as scalar or a `np.uint8` numpy array.
+    num_threads : int, optional
+        Specifies the number of threads to use for the computation. Default to 0 means
+        it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
+        or the number of logical CPUs (otherwise)
+
+    Returns
+    -------
+    nested : array-like of int
+        The cell ids in the nested scheme.
+
+    Examples
+    --------
+    >>> import healpix_geo.nested
+    >>> import numpy as np
+    >>> ipix_ring = np.array([32, 125, 45, 91], dtype="uint64")
+    >>> depth = np.array([1, 3, 2, 4], dtype="uint8")
+    >>> ipix_zuniq = healpix_geo.ring.to_zuniq(ipix_ring, depth)
+    >>> ipix_zuniq
+    array([3530822107858468864,  806144333299318784,  882705526964617216,
+           1106759608426299392], dtype=uint64)
+    """
+    _check_depth(depth)
+
+    ipix = np.atleast_1d(ipix)
+    _check_ipixels(data=ipix, depth=depth)
+    ipix = ipix.astype(np.uint64)
+
+    depth = depth if isinstance(depth, int) else depth.astype("uint8")
+
+    num_threads = np.uint16(num_threads)
+
+    return healpix_geo.ring.to_zuniq(ipix, depth, num_threads)
+
+
 def healpix_to_lonlat(ipix, depth, ellipsoid="sphere", num_threads=0):
     r"""Get the longitudes and latitudes of the center of some HEALPix cells.
 

--- a/python/healpix-geo/python/healpix_geo/ring.py
+++ b/python/healpix-geo/python/healpix_geo/ring.py
@@ -14,59 +14,6 @@ if TYPE_CHECKING:
     from healpix_geo.typing import DepthType
 
 
-def from_nested(
-    ipix: npt.NDArray[np.uint64], depth: DepthType, num_threads: int = 0
-) -> npt.NDArray[np.uint64]:
-    """Convert from nested to ring
-
-    Parameters
-    ----------
-    ipix : `numpy.ndarray`
-        The HEALPix cell indexes in the nested scheme given as a `np.uint64` numpy array.
-    depth : int or array-like of int
-        The HEALPix cell depth given as scalar or a `np.uint8` numpy array.
-    num_threads : int, optional
-        Specifies the number of threads to use for the computation. Default to 0 means
-        it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
-        or the number of logical CPUs (otherwise)
-
-    Returns
-    -------
-    ring : array-like of int
-        The cell ids in the ring scheme.
-
-    Examples
-    --------
-    >>> import healpix_geo
-    >>> import numpy as np
-
-    Scalar depth:
-
-    >>> ipix_nested = np.array([32, 125, 45, 91], dtype="uint64")
-    >>> depth = 4
-    >>> ipix_ring = healpix_geo.ring.from_nested(ipix_nested, depth)
-    >>> ipix_ring
-    array([1190,  189,  870,  432], dtype=uint64)
-
-    Array depth:
-
-    >>> depth = np.array([1, 3, 2, 4], dtype="uint8")
-    >>> ipix_ring = healpix_geo.ring.from_nested(ipix_nested, depth)
-    >>> ipix_ring
-    array([ 44,   7,   9, 432], dtype=uint64)
-    """
-    _check_depth(depth)
-
-    ipix = np.atleast_1d(ipix)
-    _check_ipixels(data=ipix, depth=depth)
-    ipix = ipix.astype(np.uint64)
-
-    depth = depth if isinstance(depth, int) else depth.astype("uint8")
-    num_threads = np.uint16(num_threads)
-
-    return healpix_geo.ring.from_nested(ipix, depth, num_threads)
-
-
 def to_nested(
     ipix: npt.NDArray[np.uint64], depth: DepthType, num_threads: int = 0
 ) -> npt.NDArray[np.uint64]:
@@ -120,53 +67,6 @@ def to_nested(
     num_threads = np.uint16(num_threads)
 
     return healpix_geo.ring.to_nested(ipix, depth, num_threads)
-
-
-def from_zuniq(
-    ipix: npt.NDArray[np.uint64], num_threads: int = 0
-) -> tuple[npt.NDArray[np.uint64], DepthType]:
-    """Convert from zuniq to nested
-
-    Parameters
-    ----------
-    ipix : `numpy.ndarray`
-        The HEALPix cell indexes in the zuniq scheme given as a `np.uint64` numpy array.
-    num_threads : int, optional
-        Specifies the number of threads to use for the computation. Default to 0 means
-        it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
-        or the number of logical CPUs (otherwise)
-
-    Returns
-    -------
-    nested : array-like of int
-        The cell ids in the nested scheme.
-    depth : array-like of int
-        The HEALPix cell depth of the given cells as a `np.uint8` numpy array.
-
-    Examples
-    --------
-    >>> import healpix_geo.nested
-    >>> import numpy as np
-    >>> ipix_zuniq = np.array(
-    ...     [
-    ...         4683743612465315840,
-    ...         1130403506469994496,
-    ...         1639310264362860544,
-    ...         206039682952200192,
-    ...     ],
-    ...     dtype="uint64",
-    ... )
-    >>> ipix_ring, depth = healpix_geo.ring.from_zuniq(ipix_zuniq)
-    >>> ipix_ring
-    array([ 44,   7,   9, 432], dtype=uint64)
-    >>> depth
-    array([1, 3, 2, 4], dtype=uint8)
-    """
-    ipix = np.atleast_1d(ipix).astype(np.uint64)
-
-    num_threads = np.uint16(num_threads)
-
-    return healpix_geo.ring.from_zuniq(ipix, num_threads)
 
 
 def to_zuniq(

--- a/python/healpix-geo/python/healpix_geo/tests/test_auto.py
+++ b/python/healpix-geo/python/healpix_geo/tests/test_auto.py
@@ -32,6 +32,96 @@ def test_dispatch_module_failing(scheme):
 
 
 @pytest.mark.parametrize(
+    ["grid", "cell_ids", "levels", "scheme", "expected", "expected_levels"],
+    (
+        pytest.param(
+            auto.Grid(level=4, indexing_scheme="nested", ellipsoid="sphere"),
+            np.array([48, 312]),
+            None,
+            "ring",
+            np.array([936, 823]),
+            4,
+            id="nested-ring",
+        ),
+        pytest.param(
+            auto.Grid(level=7, indexing_scheme="nested", ellipsoid="sphere"),
+            np.array([956, 761, 3278]),
+            np.array([6, 7, 10]),
+            "zuniq",
+            np.array([134615407611871232, 26792899345645568, 1802374435831808]),
+            np.array([6, 7, 10]),
+            id="nested-zuniq",
+        ),
+        pytest.param(
+            auto.Grid(level=4, indexing_scheme="ring", ellipsoid="sphere"),
+            np.array([72, 81, 64, 15]),
+            None,
+            "nested",
+            np.array([750, 1009, 222, 507]),
+            4,
+            id="ring-nested",
+        ),
+        pytest.param(
+            auto.Grid(level=4, indexing_scheme="ring", ellipsoid="sphere"),
+            np.array([72, 81, 64, 15]),
+            None,
+            "zuniq",
+            np.array(
+                [
+                    1689975760170778624,
+                    2273191911915257856,
+                    501025458544967680,
+                    1142788405445263360,
+                ]
+            ),
+            4,
+            id="ring-zuniq",
+        ),
+        pytest.param(
+            auto.Grid(level=4, indexing_scheme="zuniq", ellipsoid="sphere"),
+            np.array(
+                [
+                    6825768185233408,
+                    47358164831567872,
+                    58617163899994112,
+                    40602765390512128,
+                ]
+            ),
+            None,
+            "nested",
+            np.array([48, 336, 416, 288]),
+            np.array([6, 6, 6, 6]),
+            id="zuniq-nested",
+        ),
+        pytest.param(
+            auto.Grid(level=4, indexing_scheme="zuniq", ellipsoid="sphere"),
+            np.array(
+                [
+                    6825768185233408,
+                    47358164831567872,
+                    58617163899994112,
+                    40602765390512128,
+                ]
+            ),
+            None,
+            "ring",
+            np.array([22176, 17070, 17058, 19110]),
+            np.array([6, 6, 6, 6]),
+            id="zuniq-ring",
+        ),
+    ),
+)
+def test_convert(grid, cell_ids, levels, scheme, expected, expected_levels):
+    params = {}
+    if levels is not None:
+        params["level"] = levels
+    actual, levels = auto.convert(cell_ids, grid, to=scheme, **params)
+
+    np.testing.assert_equal(actual, expected)
+    np.testing.assert_equal(levels, expected_levels)
+
+
+@pytest.mark.parametrize(
     ["grid", "expected"],
     (
         (

--- a/python/healpix-geo/python/healpix_geo/tests/test_conversion.py
+++ b/python/healpix-geo/python/healpix_geo/tests/test_conversion.py
@@ -345,3 +345,158 @@ class TestNested:
         actual = healpix_geo.nested.to_zuniq(cell_ids, depths)
 
         np.testing.assert_equal(actual, expected)
+
+
+class TestRing:
+    @pytest.mark.parametrize(
+        ["cell_ids", "depths", "expected"],
+        (
+            (
+                np.array([3, 12, 48]),
+                np.array([0, 1, 2]),
+                np.array([3, 19, 86], dtype="uint64"),
+            ),
+            (
+                np.array([215, 230, 245]),
+                4,
+                np.array([90, 114, 27], dtype="uint64"),
+            ),
+            (
+                np.array([[3], [12], [48]]),
+                np.array([[0], [1], [2]]),
+                np.array([[3], [19], [86]], dtype="uint64"),
+            ),
+            (
+                np.array([[[215, 230, 245]]]),
+                np.array([[[4, 4, 4]]]),
+                np.array([[[90, 114, 27]]], dtype="uint64"),
+            ),
+        ),
+    )
+    def test_from_nested(self, cell_ids, depths, expected):
+        actual = healpix_geo.ring.from_nested(cell_ids, depths)
+
+        np.testing.assert_equal(actual, expected)
+
+    @pytest.mark.parametrize(
+        ["cell_ids", "depths", "expected_cell_ids"],
+        (
+            (
+                np.array([3, 19, 86], dtype="uint64"),
+                np.array([0, 1, 2], dtype="uint8"),
+                np.array([3, 12, 48]),
+            ),
+            (
+                np.array([90, 114, 27], dtype="uint64"),
+                4,
+                np.array([215, 230, 245]),
+            ),
+            (
+                np.array([[3], [19], [86]], dtype="uint64"),
+                np.array([[0], [1], [2]], dtype="uint8"),
+                np.array([[3], [12], [48]]),
+            ),
+            (
+                np.array([[[90, 114, 27]]], dtype="uint64"),
+                np.array([[[4, 4, 4]]], dtype="uint8"),
+                np.array([[[215, 230, 245]]]),
+            ),
+        ),
+    )
+    def test_to_nested(self, cell_ids, depths, expected_cell_ids):
+        actual_cell_ids = healpix_geo.ring.to_nested(cell_ids, depths)
+
+        np.testing.assert_equal(actual_cell_ids, expected_cell_ids)
+
+    @pytest.mark.parametrize(
+        ["cell_ids", "expected_cell_ids", "expected_depths"],
+        (
+            (
+                np.array(
+                    [2017612633061982208, 1801439850948198400, 1747396655419752448],
+                    dtype="uint64",
+                ),
+                np.array([3, 19, 86]),
+                np.array([0, 1, 2]),
+            ),
+            (
+                np.array(
+                    [485262859849170944, 519039857054449664, 552816854259728384],
+                    dtype="uint64",
+                ),
+                np.array([90, 114, 27]),
+                np.array([4, 4, 4]),
+            ),
+            (
+                np.array(
+                    [
+                        [2017612633061982208],
+                        [1801439850948198400],
+                        [1747396655419752448],
+                    ],
+                    dtype="uint64",
+                ),
+                np.array([[3], [19], [86]]),
+                np.array([[0], [1], [2]]),
+            ),
+            (
+                np.array(
+                    [[[485262859849170944, 519039857054449664, 552816854259728384]]],
+                    dtype="uint64",
+                ),
+                np.array([[[90, 114, 27]]]),
+                np.array([[[4, 4, 4]]]),
+            ),
+        ),
+    )
+    def test_from_zuniq(self, cell_ids, expected_cell_ids, expected_depths):
+        actual_cell_ids, actual_depths = healpix_geo.ring.from_zuniq(cell_ids)
+
+        np.testing.assert_equal(actual_cell_ids, expected_cell_ids)
+        np.testing.assert_equal(actual_depths, expected_depths)
+
+    @pytest.mark.parametrize(
+        ["cell_ids", "depths", "expected"],
+        (
+            (
+                np.array([3, 19, 86]),
+                np.array([0, 1, 2]),
+                np.array(
+                    [2017612633061982208, 1801439850948198400, 1747396655419752448],
+                    dtype="uint64",
+                ),
+            ),
+            (
+                np.array([90, 114, 27]),
+                np.array([4, 4, 4]),
+                np.array(
+                    [485262859849170944, 519039857054449664, 552816854259728384],
+                    dtype="uint64",
+                ),
+            ),
+            (
+                np.array([[3], [19], [86]]),
+                np.array([[0], [1], [2]]),
+                np.array(
+                    [
+                        [2017612633061982208],
+                        [1801439850948198400],
+                        [1747396655419752448],
+                    ],
+                    dtype="uint64",
+                ),
+            ),
+            (
+                np.array([[[90, 114, 27]]]),
+                np.array([[[4, 4, 4]]]),
+                np.array(
+                    [[[485262859849170944, 519039857054449664, 552816854259728384]]],
+                    dtype="uint64",
+                ),
+            ),
+        ),
+    )
+    def test_to_zuniq(self, cell_ids, depths, expected):
+        actual = healpix_geo.ring.to_zuniq(cell_ids, depths)
+
+        np.testing.assert_equal(actual, expected)

--- a/python/healpix-geo/python/healpix_geo/tests/test_conversion.py
+++ b/python/healpix-geo/python/healpix_geo/tests/test_conversion.py
@@ -190,3 +190,158 @@ class TestZuniq:
 
         np.testing.assert_equal(actual_cell_ids, expected_cell_ids)
         np.testing.assert_equal(actual_depths, expected_depths)
+
+
+class TestNested:
+    @pytest.mark.parametrize(
+        ["cell_ids", "depths", "expected"],
+        (
+            (
+                np.array([3, 12, 48]),
+                np.array([0, 1, 2]),
+                np.array([3, 19, 111], dtype="uint64"),
+            ),
+            (
+                np.array([215, 230, 245]),
+                4,
+                np.array([973, 119, 736], dtype="uint64"),
+            ),
+            (
+                np.array([[3], [12], [48]]),
+                np.array([[0], [1], [2]]),
+                np.array([[3], [19], [111]], dtype="uint64"),
+            ),
+            (
+                np.array([[[215, 230, 245]]]),
+                np.array([[[4, 4, 4]]]),
+                np.array([[[973, 119, 736]]], dtype="uint64"),
+            ),
+        ),
+    )
+    def test_from_ring(self, cell_ids, depths, expected):
+        actual = healpix_geo.nested.from_ring(cell_ids, depths)
+
+        np.testing.assert_equal(actual, expected)
+
+    @pytest.mark.parametrize(
+        ["cell_ids", "depths", "expected_cell_ids"],
+        (
+            (
+                np.array([3, 19, 111], dtype="uint64"),
+                np.array([0, 1, 2], dtype="uint8"),
+                np.array([3, 12, 48]),
+            ),
+            (
+                np.array([973, 119, 736], dtype="uint64"),
+                4,
+                np.array([215, 230, 245]),
+            ),
+            (
+                np.array([[3], [19], [111]], dtype="uint64"),
+                np.array([[0], [1], [2]], dtype="uint8"),
+                np.array([[3], [12], [48]]),
+            ),
+            (
+                np.array([[[973, 119, 736]]], dtype="uint64"),
+                np.array([[[4, 4, 4]]], dtype="uint8"),
+                np.array([[[215, 230, 245]]]),
+            ),
+        ),
+    )
+    def test_to_ring(self, cell_ids, depths, expected_cell_ids):
+        actual_cell_ids = healpix_geo.nested.to_ring(cell_ids, depths)
+
+        np.testing.assert_equal(actual_cell_ids, expected_cell_ids)
+
+    @pytest.mark.parametrize(
+        ["cell_ids", "expected_cell_ids", "expected_depths"],
+        (
+            (
+                np.array(
+                    [2017612633061982208, 1801439850948198400, 1747396655419752448],
+                    dtype="uint64",
+                ),
+                np.array([3, 12, 48]),
+                np.array([0, 1, 2]),
+            ),
+            (
+                np.array(
+                    [485262859849170944, 519039857054449664, 552816854259728384],
+                    dtype="uint64",
+                ),
+                np.array([215, 230, 245]),
+                np.array([4, 4, 4]),
+            ),
+            (
+                np.array(
+                    [
+                        [2017612633061982208],
+                        [1801439850948198400],
+                        [1747396655419752448],
+                    ],
+                    dtype="uint64",
+                ),
+                np.array([[3], [12], [48]]),
+                np.array([[0], [1], [2]]),
+            ),
+            (
+                np.array(
+                    [[[485262859849170944, 519039857054449664, 552816854259728384]]],
+                    dtype="uint64",
+                ),
+                np.array([[[215, 230, 245]]]),
+                np.array([[[4, 4, 4]]]),
+            ),
+        ),
+    )
+    def test_from_zuniq(self, cell_ids, expected_cell_ids, expected_depths):
+        actual_cell_ids, actual_depths = healpix_geo.nested.from_zuniq(cell_ids)
+
+        np.testing.assert_equal(actual_cell_ids, expected_cell_ids)
+        np.testing.assert_equal(actual_depths, expected_depths)
+
+    @pytest.mark.parametrize(
+        ["cell_ids", "depths", "expected"],
+        (
+            (
+                np.array([3, 12, 48]),
+                np.array([0, 1, 2]),
+                np.array(
+                    [2017612633061982208, 1801439850948198400, 1747396655419752448],
+                    dtype="uint64",
+                ),
+            ),
+            (
+                np.array([215, 230, 245]),
+                np.array([4, 4, 4]),
+                np.array(
+                    [485262859849170944, 519039857054449664, 552816854259728384],
+                    dtype="uint64",
+                ),
+            ),
+            (
+                np.array([[3], [12], [48]]),
+                np.array([[0], [1], [2]]),
+                np.array(
+                    [
+                        [2017612633061982208],
+                        [1801439850948198400],
+                        [1747396655419752448],
+                    ],
+                    dtype="uint64",
+                ),
+            ),
+            (
+                np.array([[[215, 230, 245]]]),
+                np.array([[[4, 4, 4]]]),
+                np.array(
+                    [[[485262859849170944, 519039857054449664, 552816854259728384]]],
+                    dtype="uint64",
+                ),
+            ),
+        ),
+    )
+    def test_to_zuniq(self, cell_ids, depths, expected):
+        actual = healpix_geo.nested.to_zuniq(cell_ids, depths)
+
+        np.testing.assert_equal(actual, expected)

--- a/python/healpix-geo/python/healpix_geo/tests/test_conversion.py
+++ b/python/healpix-geo/python/healpix_geo/tests/test_conversion.py
@@ -6,52 +6,6 @@ import healpix_geo
 
 class TestZuniq:
     @pytest.mark.parametrize(
-        ["cell_ids", "depths", "expected"],
-        (
-            (
-                np.array([3, 12, 48]),
-                np.array([0, 1, 2]),
-                np.array(
-                    [2017612633061982208, 1801439850948198400, 1747396655419752448],
-                    dtype="uint64",
-                ),
-            ),
-            (
-                np.array([215, 230, 245]),
-                np.array([4, 4, 4]),
-                np.array(
-                    [485262859849170944, 519039857054449664, 552816854259728384],
-                    dtype="uint64",
-                ),
-            ),
-            (
-                np.array([[3], [12], [48]]),
-                np.array([[0], [1], [2]]),
-                np.array(
-                    [
-                        [2017612633061982208],
-                        [1801439850948198400],
-                        [1747396655419752448],
-                    ],
-                    dtype="uint64",
-                ),
-            ),
-            (
-                np.array([[[215, 230, 245]]]),
-                np.array([[[4, 4, 4]]]),
-                np.array(
-                    [[[485262859849170944, 519039857054449664, 552816854259728384]]],
-                    dtype="uint64",
-                ),
-            ),
-        ),
-    )
-    def test_from_nested(self, cell_ids, depths, expected):
-        actual = healpix_geo.zuniq.from_nested(cell_ids, depths)
-
-        np.testing.assert_equal(actual, expected)
-
-    @pytest.mark.parametrize(
         ["cell_ids", "expected_cell_ids", "expected_depths"],
         (
             (
@@ -97,52 +51,6 @@ class TestZuniq:
 
         np.testing.assert_equal(actual_cell_ids, expected_cell_ids)
         np.testing.assert_equal(actual_depths, expected_depths)
-
-    @pytest.mark.parametrize(
-        ["cell_ids", "depths", "expected"],
-        (
-            (
-                np.array([3, 12, 48]),
-                np.array([0, 1, 2]),
-                np.array(
-                    [2017612633061982208, 2810246167479189504, 4017210867614482432],
-                    dtype="uint64",
-                ),
-            ),
-            (
-                np.array([215, 230, 245]),
-                np.array([4, 4, 4]),
-                np.array(
-                    [2192127118622588928, 269090077735387136, 1658450562779185152],
-                    dtype="uint64",
-                ),
-            ),
-            (
-                np.array([[3], [12], [48]]),
-                np.array([[0], [1], [2]]),
-                np.array(
-                    [
-                        [2017612633061982208],
-                        [2810246167479189504],
-                        [4017210867614482432],
-                    ],
-                    dtype="uint64",
-                ),
-            ),
-            (
-                np.array([[[215, 230, 245]]]),
-                np.array([[[4, 4, 4]]]),
-                np.array(
-                    [[[2192127118622588928, 269090077735387136, 1658450562779185152]]],
-                    dtype="uint64",
-                ),
-            ),
-        ),
-    )
-    def test_from_ring(self, cell_ids, depths, expected):
-        actual = healpix_geo.zuniq.from_ring(cell_ids, depths)
-
-        np.testing.assert_equal(actual, expected)
 
     @pytest.mark.parametrize(
         ["cell_ids", "expected_cell_ids", "expected_depths"],
@@ -194,36 +102,6 @@ class TestZuniq:
 
 class TestNested:
     @pytest.mark.parametrize(
-        ["cell_ids", "depths", "expected"],
-        (
-            (
-                np.array([3, 12, 48]),
-                np.array([0, 1, 2]),
-                np.array([3, 19, 111], dtype="uint64"),
-            ),
-            (
-                np.array([215, 230, 245]),
-                4,
-                np.array([973, 119, 736], dtype="uint64"),
-            ),
-            (
-                np.array([[3], [12], [48]]),
-                np.array([[0], [1], [2]]),
-                np.array([[3], [19], [111]], dtype="uint64"),
-            ),
-            (
-                np.array([[[215, 230, 245]]]),
-                np.array([[[4, 4, 4]]]),
-                np.array([[[973, 119, 736]]], dtype="uint64"),
-            ),
-        ),
-    )
-    def test_from_ring(self, cell_ids, depths, expected):
-        actual = healpix_geo.nested.from_ring(cell_ids, depths)
-
-        np.testing.assert_equal(actual, expected)
-
-    @pytest.mark.parametrize(
         ["cell_ids", "depths", "expected_cell_ids"],
         (
             (
@@ -252,53 +130,6 @@ class TestNested:
         actual_cell_ids = healpix_geo.nested.to_ring(cell_ids, depths)
 
         np.testing.assert_equal(actual_cell_ids, expected_cell_ids)
-
-    @pytest.mark.parametrize(
-        ["cell_ids", "expected_cell_ids", "expected_depths"],
-        (
-            (
-                np.array(
-                    [2017612633061982208, 1801439850948198400, 1747396655419752448],
-                    dtype="uint64",
-                ),
-                np.array([3, 12, 48]),
-                np.array([0, 1, 2]),
-            ),
-            (
-                np.array(
-                    [485262859849170944, 519039857054449664, 552816854259728384],
-                    dtype="uint64",
-                ),
-                np.array([215, 230, 245]),
-                np.array([4, 4, 4]),
-            ),
-            (
-                np.array(
-                    [
-                        [2017612633061982208],
-                        [1801439850948198400],
-                        [1747396655419752448],
-                    ],
-                    dtype="uint64",
-                ),
-                np.array([[3], [12], [48]]),
-                np.array([[0], [1], [2]]),
-            ),
-            (
-                np.array(
-                    [[[485262859849170944, 519039857054449664, 552816854259728384]]],
-                    dtype="uint64",
-                ),
-                np.array([[[215, 230, 245]]]),
-                np.array([[[4, 4, 4]]]),
-            ),
-        ),
-    )
-    def test_from_zuniq(self, cell_ids, expected_cell_ids, expected_depths):
-        actual_cell_ids, actual_depths = healpix_geo.nested.from_zuniq(cell_ids)
-
-        np.testing.assert_equal(actual_cell_ids, expected_cell_ids)
-        np.testing.assert_equal(actual_depths, expected_depths)
 
     @pytest.mark.parametrize(
         ["cell_ids", "depths", "expected"],
@@ -349,36 +180,6 @@ class TestNested:
 
 class TestRing:
     @pytest.mark.parametrize(
-        ["cell_ids", "depths", "expected"],
-        (
-            (
-                np.array([3, 12, 48]),
-                np.array([0, 1, 2]),
-                np.array([3, 19, 86], dtype="uint64"),
-            ),
-            (
-                np.array([215, 230, 245]),
-                4,
-                np.array([90, 114, 27], dtype="uint64"),
-            ),
-            (
-                np.array([[3], [12], [48]]),
-                np.array([[0], [1], [2]]),
-                np.array([[3], [19], [86]], dtype="uint64"),
-            ),
-            (
-                np.array([[[215, 230, 245]]]),
-                np.array([[[4, 4, 4]]]),
-                np.array([[[90, 114, 27]]], dtype="uint64"),
-            ),
-        ),
-    )
-    def test_from_nested(self, cell_ids, depths, expected):
-        actual = healpix_geo.ring.from_nested(cell_ids, depths)
-
-        np.testing.assert_equal(actual, expected)
-
-    @pytest.mark.parametrize(
         ["cell_ids", "depths", "expected_cell_ids"],
         (
             (
@@ -407,53 +208,6 @@ class TestRing:
         actual_cell_ids = healpix_geo.ring.to_nested(cell_ids, depths)
 
         np.testing.assert_equal(actual_cell_ids, expected_cell_ids)
-
-    @pytest.mark.parametrize(
-        ["cell_ids", "expected_cell_ids", "expected_depths"],
-        (
-            (
-                np.array(
-                    [2017612633061982208, 1801439850948198400, 1747396655419752448],
-                    dtype="uint64",
-                ),
-                np.array([3, 19, 86]),
-                np.array([0, 1, 2]),
-            ),
-            (
-                np.array(
-                    [485262859849170944, 519039857054449664, 552816854259728384],
-                    dtype="uint64",
-                ),
-                np.array([90, 114, 27]),
-                np.array([4, 4, 4]),
-            ),
-            (
-                np.array(
-                    [
-                        [2017612633061982208],
-                        [1801439850948198400],
-                        [1747396655419752448],
-                    ],
-                    dtype="uint64",
-                ),
-                np.array([[3], [19], [86]]),
-                np.array([[0], [1], [2]]),
-            ),
-            (
-                np.array(
-                    [[[485262859849170944, 519039857054449664, 552816854259728384]]],
-                    dtype="uint64",
-                ),
-                np.array([[[90, 114, 27]]]),
-                np.array([[[4, 4, 4]]]),
-            ),
-        ),
-    )
-    def test_from_zuniq(self, cell_ids, expected_cell_ids, expected_depths):
-        actual_cell_ids, actual_depths = healpix_geo.ring.from_zuniq(cell_ids)
-
-        np.testing.assert_equal(actual_cell_ids, expected_cell_ids)
-        np.testing.assert_equal(actual_depths, expected_depths)
 
     @pytest.mark.parametrize(
         ["cell_ids", "depths", "expected"],

--- a/python/healpix-geo/python/healpix_geo/tests/test_conversion.py
+++ b/python/healpix-geo/python/healpix_geo/tests/test_conversion.py
@@ -97,3 +97,96 @@ class TestZuniq:
 
         np.testing.assert_equal(actual_cell_ids, expected_cell_ids)
         np.testing.assert_equal(actual_depths, expected_depths)
+
+    @pytest.mark.parametrize(
+        ["cell_ids", "depths", "expected"],
+        (
+            (
+                np.array([3, 12, 48]),
+                np.array([0, 1, 2]),
+                np.array(
+                    [2017612633061982208, 2810246167479189504, 4017210867614482432],
+                    dtype="uint64",
+                ),
+            ),
+            (
+                np.array([215, 230, 245]),
+                np.array([4, 4, 4]),
+                np.array(
+                    [2192127118622588928, 269090077735387136, 1658450562779185152],
+                    dtype="uint64",
+                ),
+            ),
+            (
+                np.array([[3], [12], [48]]),
+                np.array([[0], [1], [2]]),
+                np.array(
+                    [
+                        [2017612633061982208],
+                        [2810246167479189504],
+                        [4017210867614482432],
+                    ],
+                    dtype="uint64",
+                ),
+            ),
+            (
+                np.array([[[215, 230, 245]]]),
+                np.array([[[4, 4, 4]]]),
+                np.array(
+                    [[[2192127118622588928, 269090077735387136, 1658450562779185152]]],
+                    dtype="uint64",
+                ),
+            ),
+        ),
+    )
+    def test_from_ring(self, cell_ids, depths, expected):
+        actual = healpix_geo.zuniq.from_ring(cell_ids, depths)
+
+        np.testing.assert_equal(actual, expected)
+
+    @pytest.mark.parametrize(
+        ["cell_ids", "expected_cell_ids", "expected_depths"],
+        (
+            (
+                np.array(
+                    [2017612633061982208, 2810246167479189504, 4017210867614482432],
+                    dtype="uint64",
+                ),
+                np.array([3, 12, 48]),
+                np.array([0, 1, 2]),
+            ),
+            (
+                np.array(
+                    [2192127118622588928, 269090077735387136, 1658450562779185152],
+                    dtype="uint64",
+                ),
+                np.array([215, 230, 245]),
+                np.array([4, 4, 4]),
+            ),
+            (
+                np.array(
+                    [
+                        [2017612633061982208],
+                        [2810246167479189504],
+                        [4017210867614482432],
+                    ],
+                    dtype="uint64",
+                ),
+                np.array([[3], [12], [48]]),
+                np.array([[0], [1], [2]]),
+            ),
+            (
+                np.array(
+                    [[[2192127118622588928, 269090077735387136, 1658450562779185152]]],
+                    dtype="uint64",
+                ),
+                np.array([[[215, 230, 245]]]),
+                np.array([[[4, 4, 4]]]),
+            ),
+        ),
+    )
+    def test_to_ring(self, cell_ids, expected_cell_ids, expected_depths):
+        actual_cell_ids, actual_depths = healpix_geo.zuniq.to_ring(cell_ids)
+
+        np.testing.assert_equal(actual_cell_ids, expected_cell_ids)
+        np.testing.assert_equal(actual_depths, expected_depths)

--- a/python/healpix-geo/python/healpix_geo/tests/test_inference.py
+++ b/python/healpix-geo/python/healpix_geo/tests/test_inference.py
@@ -219,7 +219,7 @@ class TestHealpixToGeographic:
 
                 return cdshealpix.nested.healpix_to_lonlat(cell_ids, depths)
 
-            cell_ids = healpix_geo.zuniq.from_nested(cell_ids, depth)
+            cell_ids = healpix_geo.nested.to_zuniq(cell_ids, depth)
             param_cds = depth
         else:
             param_cds = depth
@@ -364,7 +364,7 @@ class TestGeographicToHealpix:
 
             def cds_lonlat_to_healpix(lon, lat, depth):
                 cell_ids = cdshealpix.nested.lonlat_to_healpix(lon, lat, depth)
-                return healpix_geo.zuniq.from_nested(cell_ids, depth)
+                return healpix_geo.nested.to_zuniq(cell_ids, depth)
 
             param_cds = depth
             hg_lonlat_to_healpix = healpix_geo.zuniq.lonlat_to_healpix
@@ -400,7 +400,7 @@ class TestGeographicToHealpix:
 
             def cds(lon, lat, depth):
                 cell_ids = cdshealpix.nested.lonlat_to_healpix(lon, lat, depth)
-                return healpix_geo.zuniq.from_nested(cell_ids, depth)
+                return healpix_geo.nested.to_zuniq(cell_ids, depth)
 
             param_cds = depth
             hg = healpix_geo.zuniq.lonlat_to_healpix
@@ -544,7 +544,7 @@ class TestHealpixToCartesian:
         ns = getattr(healpix_geo, scheme)
         params = {"ellipsoid": ellipsoid}
         if scheme == "zuniq":
-            ipix = ns.from_nested(ipix, depth)
+            ipix = healpix_geo.nested.to_zuniq(ipix, depth)
         else:
             params["depth"] = depth
 

--- a/python/healpix-geo/python/healpix_geo/typing.py
+++ b/python/healpix-geo/python/healpix_geo/typing.py
@@ -1,5 +1,8 @@
 from typing import Protocol, TypedDict
 
+import numpy as np
+import numpy.typing as npt
+
 
 class SphereDict(TypedDict):
     radius: float
@@ -23,3 +26,5 @@ _SphereLike = SphereDict | SphereType
 _EllipsoidLike = EllipsoidDict | EllipsoidType
 
 EllipsoidLike = str | _SphereLike | _EllipsoidLike
+
+DepthType = int | npt.NDArray[np.uint8]

--- a/python/healpix-geo/python/healpix_geo/zuniq.py
+++ b/python/healpix-geo/python/healpix_geo/zuniq.py
@@ -6,56 +6,12 @@ import marray
 import numpy as np
 
 from healpix_geo import healpix_geo
-from healpix_geo.utils import _check_depth, _check_ipixels
+from healpix_geo.utils import _check_depth
 
 if TYPE_CHECKING:
     import numpy.typing as npt
 
     from healpix_geo.typing import DepthType
-
-
-def from_nested(
-    ipix: npt.NDArray[np.uint64], depth: DepthType, num_threads: int = 0
-) -> npt.NDArray[np.uint64]:
-    """Convert from nested to zuniq
-
-    Parameters
-    ----------
-    ipix : `numpy.ndarray`
-        The HEALPix cell indexes in the nested scheme given as a `np.uint64` numpy array.
-    depth : int or array-like of int
-        The HEALPix cell depth given as scalar or a `np.uint8` numpy array.
-    num_threads : int, optional
-        Specifies the number of threads to use for the computation. Default to 0 means
-        it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
-        or the number of logical CPUs (otherwise)
-
-    Returns
-    -------
-    zuniq : array-like of int
-        The cell ids in the zuniq scheme.
-
-    Examples
-    --------
-    >>> import healpix_geo.zuniq
-    >>> import numpy as np
-    >>> ipix_nested = np.array([32, 125, 45, 91], dtype="uint64")
-    >>> depth = np.array([1, 3, 2, 4], dtype="uint8")
-    >>> ipix_zuniq = healpix_geo.zuniq.from_nested(ipix_nested, depth)
-    >>> ipix_zuniq
-    array([4683743612465315840, 1130403506469994496, 1639310264362860544,
-            206039682952200192], dtype=uint64)
-    """
-    _check_depth(depth)
-
-    ipix = np.atleast_1d(ipix)
-    _check_ipixels(data=ipix, depth=depth)
-    ipix = ipix.astype(np.uint64)
-
-    depth = depth if isinstance(depth, int) else depth.astype("uint8")
-    num_threads = np.uint16(num_threads)
-
-    return healpix_geo.zuniq.from_nested(ipix, depth, num_threads)
 
 
 def to_nested(
@@ -103,50 +59,6 @@ def to_nested(
     num_threads = np.uint16(num_threads)
 
     return healpix_geo.zuniq.to_nested(ipix, num_threads)
-
-
-def from_ring(
-    ipix: npt.NDArray[np.uint64], depth: DepthType, num_threads: int = 0
-) -> npt.NDArray[np.uint64]:
-    """Convert from ring to zuniq
-
-    Parameters
-    ----------
-    ipix : `numpy.ndarray`
-        The HEALPix cell indexes in the ring scheme given as a `np.uint64` numpy array.
-    depth : int or array-like of int
-        The HEALPix cell depth given as scalar or a `np.uint8` numpy array.
-    num_threads : int, optional
-        Specifies the number of threads to use for the computation. Default to 0 means
-        it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
-        or the number of logical CPUs (otherwise)
-
-    Returns
-    -------
-    zuniq : array-like of int
-        The cell ids in the zuniq scheme.
-
-    Examples
-    --------
-    >>> import healpix_geo.zuniq
-    >>> import numpy as np
-    >>> ipix_ring = np.array([32, 125, 45, 91], dtype="uint64")
-    >>> depth = np.array([1, 3, 2, 4], dtype="uint8")
-    >>> ipix_zuniq = healpix_geo.zuniq.from_ring(ipix_ring, depth)
-    >>> ipix_zuniq
-    array([3530822107858468864,  806144333299318784,  882705526964617216,
-           1106759608426299392], dtype=uint64)
-    """
-    _check_depth(depth)
-
-    ipix = np.atleast_1d(ipix)
-    _check_ipixels(data=ipix, depth=depth)
-    ipix = ipix.astype(np.uint64)
-
-    depth = depth if isinstance(depth, int) else depth.astype("uint8")
-    num_threads = np.uint16(num_threads)
-
-    return healpix_geo.zuniq.from_ring(ipix, depth, num_threads)
 
 
 def to_ring(

--- a/python/healpix-geo/python/healpix_geo/zuniq.py
+++ b/python/healpix-geo/python/healpix_geo/zuniq.py
@@ -99,6 +99,93 @@ def to_nested(ipix, num_threads=0):
     return healpix_geo.zuniq.to_nested(ipix, num_threads)
 
 
+def from_ring(ipix, depth, num_threads=0):
+    """Convert from ring to zuniq
+
+    Parameters
+    ----------
+    ipix : `numpy.ndarray`
+        The HEALPix cell indexes in the ring scheme given as a `np.uint64` numpy array.
+    depth : int or array-like of int
+        The HEALPix cell depth given as scalar or a `np.uint8` numpy array.
+    num_threads : int, optional
+        Specifies the number of threads to use for the computation. Default to 0 means
+        it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
+        or the number of logical CPUs (otherwise)
+
+    Returns
+    -------
+    zuniq : array-like of int
+        The cell ids in the zuniq scheme.
+
+    Examples
+    --------
+    >>> import healpix_geo.zuniq
+    >>> import numpy as np
+    >>> ipix_ring = np.array([32, 125, 45, 91], dtype="uint64")
+    >>> depth = np.array([1, 3, 2, 4], dtype="uint8")
+    >>> ipix_zuniq = healpix_geo.zuniq.from_ring(ipix_ring, depth)
+    >>> ipix_zuniq
+    array([3530822107858468864,  806144333299318784,  882705526964617216,
+           1106759608426299392], dtype=uint64)
+    """
+    _check_depth(depth)
+
+    ipix = np.atleast_1d(ipix)
+    _check_ipixels(data=ipix, depth=depth)
+    ipix = ipix.astype(np.uint64)
+
+    depth = depth if isinstance(depth, int) else depth.astype("uint8")
+    num_threads = np.uint16(num_threads)
+
+    return healpix_geo.zuniq.from_ring(ipix, depth, num_threads)
+
+
+def to_ring(ipix, num_threads=0):
+    """Convert from zuniq to ring
+
+    Parameters
+    ----------
+    ipix : `numpy.ndarray`
+        The HEALPix cell indexes in the zuniq scheme given as a `np.uint64` numpy array.
+    num_threads : int, optional
+        Specifies the number of threads to use for the computation. Default to 0 means
+        it will choose the number of threads based on the RAYON_NUM_THREADS environment variable (if set),
+        or the number of logical CPUs (otherwise)
+
+    Returns
+    -------
+    ring : array-like of int
+        The cell ids in the ring scheme.
+    depth : int or array-like of int
+        The HEALPix cell depth given as scalar or a `np.uint8` numpy array.
+
+    Examples
+    --------
+    >>> import healpix_geo.zuniq
+    >>> import numpy as np
+    >>> ipix_zuniq = np.array(
+    ...     [
+    ...         4683743612465315840,
+    ...         1130403506469994496,
+    ...         1639310264362860544,
+    ...         206039682952200192,
+    ...     ],
+    ...     dtype="uint64",
+    ... )
+    >>> ipix_ring, depth = healpix_geo.zuniq.to_ring(ipix_zuniq)
+    >>> ipix_ring
+    array([ 44,   7,   9, 432], dtype=uint64)
+    >>> depth
+    array([1, 3, 2, 4], dtype=uint8)
+    """
+    ipix = np.atleast_1d(ipix).astype(np.uint64)
+
+    num_threads = np.uint16(num_threads)
+
+    return healpix_geo.zuniq.to_ring(ipix, num_threads)
+
+
 def healpix_to_lonlat(ipix, ellipsoid, num_threads=0):
     r"""Get the longitudes and latitudes of the center of some HEALPix cells.
 

--- a/python/healpix-geo/python/healpix_geo/zuniq.py
+++ b/python/healpix-geo/python/healpix_geo/zuniq.py
@@ -11,8 +11,12 @@ from healpix_geo.utils import _check_depth, _check_ipixels
 if TYPE_CHECKING:
     import numpy.typing as npt
 
+    from healpix_geo.typing import DepthType
 
-def from_nested(ipix, depth, num_threads=0):
+
+def from_nested(
+    ipix: npt.NDArray[np.uint64], depth: DepthType, num_threads: int = 0
+) -> npt.NDArray[np.uint64]:
     """Convert from nested to zuniq
 
     Parameters
@@ -54,7 +58,9 @@ def from_nested(ipix, depth, num_threads=0):
     return healpix_geo.zuniq.from_nested(ipix, depth, num_threads)
 
 
-def to_nested(ipix, num_threads=0):
+def to_nested(
+    ipix: npt.NDArray[np.uint64], num_threads: int = 0
+) -> tuple[npt.NDArray[np.uint64], DepthType]:
     """Convert from zuniq to nested
 
     Parameters
@@ -99,7 +105,9 @@ def to_nested(ipix, num_threads=0):
     return healpix_geo.zuniq.to_nested(ipix, num_threads)
 
 
-def from_ring(ipix, depth, num_threads=0):
+def from_ring(
+    ipix: npt.NDArray[np.uint64], depth: DepthType, num_threads: int = 0
+) -> npt.NDArray[np.uint64]:
     """Convert from ring to zuniq
 
     Parameters
@@ -141,7 +149,9 @@ def from_ring(ipix, depth, num_threads=0):
     return healpix_geo.zuniq.from_ring(ipix, depth, num_threads)
 
 
-def to_ring(ipix, num_threads=0):
+def to_ring(
+    ipix: npt.NDArray[np.uint64], num_threads: int = 0
+) -> tuple[npt.NDArray[np.uint64], DepthType]:
     """Convert from zuniq to ring
 
     Parameters

--- a/python/healpix-geo/src/indexing_schemes/depth.rs
+++ b/python/healpix-geo/src/indexing_schemes/depth.rs
@@ -1,22 +1,55 @@
-use numpy::{PyArrayDyn, PyArrayMethods};
+use numpy::dtype;
+use numpy::{
+    Ix1, PyArrayDescrMethods, PyArrayDyn, PyArrayMethods, PyReadonlyArray, PyUntypedArray,
+    PyUntypedArrayMethods,
+};
+use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
+use pyo3::types::PyInt;
 
-use healpix_geo_core::vectorized::depth::DepthLike as Depth;
+use healpix_geo_core::vectorized::depth::Depth;
 
-#[derive(FromPyObject)]
-pub(crate) enum DepthLike {
-    Constant(u8),
-    Array(Py<PyArrayDyn<u8>>),
+pub(crate) enum DepthLike<'py> {
+    Scalar(u8),
+    Array(PyReadonlyArray<'py, u8, Ix1>),
 }
 
-impl DepthLike {
-    pub fn into_depth(self, py: Python) -> PyResult<Depth> {
+impl<'py> FromPyObject<'_, 'py> for DepthLike<'py> {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(value) = obj.cast::<PyInt>() {
+            let scalar: u8 = value.extract()?;
+            Ok(Self::Scalar(scalar))
+        } else if let Ok(value) = obj.cast::<PyUntypedArray>() {
+            let owned = value.to_owned();
+            let array: &Bound<'py, PyUntypedArray> = owned.cast::<PyUntypedArray>()?;
+
+            let element_type = array.dtype();
+            if !element_type.is_equiv_to(&dtype::<u8>(obj.py())) {
+                Err(PyTypeError::new_err("Only uint8 is supported."))
+            } else {
+                let array = array.cast::<PyArrayDyn<u8>>()?.reshape([array.len()])?;
+
+                let readonly = array.readonly();
+
+                Ok(Self::Array(readonly))
+            }
+        } else {
+            Err(PyTypeError::new_err(
+                "`depth` must be either a scalar int or an array of unsigned integers",
+            ))
+        }
+    }
+}
+
+impl<'a> DepthLike<'a> {
+    pub fn as_depth(&'a self) -> PyResult<Depth<'a>> {
         match self {
-            Self::Constant(depth) => Ok(Depth::Scalar(depth)),
+            Self::Scalar(depth) => Ok(Depth::Scalar(depth)),
             Self::Array(depths) => {
-                let bound = depths.bind(py);
-                let depths_: Vec<u8> = bound.to_vec()?;
-                Ok(Depth::Array(depths_))
+                let slice = depths.as_slice()?;
+                Ok(Depth::Array(slice))
             }
         }
     }

--- a/python/healpix-geo/src/indexing_schemes/nested/conversion.rs
+++ b/python/healpix-geo/src/indexing_schemes/nested/conversion.rs
@@ -68,7 +68,7 @@ pub(crate) fn from_ring<'py>(
     let flattened_ = flattened.readonly();
 
     let depth_ = depth.as_depth()?;
-    let nested = vectorized::to_zuniq(flattened_.as_slice()?, depth_, nthreads as usize);
+    let nested = vectorized::from_ring(flattened_.as_slice()?, depth_, nthreads as usize);
 
     Ok(PyArray1::from_vec(py, nested)
         .reshape(input_shape)?
@@ -90,7 +90,7 @@ pub(crate) fn to_ring<'py>(
     let flattened_ = flattened.readonly();
 
     let depth_ = depth.as_depth()?;
-    let ring = vectorized::to_zuniq(flattened_.as_slice()?, depth_, nthreads as usize);
+    let ring = vectorized::to_ring(flattened_.as_slice()?, depth_, nthreads as usize);
 
     Ok(PyArray1::from_vec(py, ring)
         .reshape(input_shape)?

--- a/python/healpix-geo/src/indexing_schemes/nested/conversion.rs
+++ b/python/healpix-geo/src/indexing_schemes/nested/conversion.rs
@@ -1,0 +1,99 @@
+use numpy::{PyArray1, PyArrayDyn, PyArrayMethods, PyUntypedArrayMethods};
+use pyo3::prelude::*;
+
+use healpix_geo_core::vectorized::nested::conversion as vectorized;
+
+use crate::indexing_schemes::depth::DepthLike;
+
+#[allow(clippy::type_complexity)]
+#[pyfunction]
+pub(crate) fn from_zuniq<'py>(
+    py: Python<'py>,
+    zuniq: &Bound<'py, PyArrayDyn<u64>>,
+    nthreads: u16,
+) -> PyResult<(Bound<'py, PyArrayDyn<u64>>, Bound<'py, PyArrayDyn<u8>>)> {
+    let input_shape = zuniq.shape();
+
+    let flattened = zuniq.reshape([zuniq.len()])?;
+    let flattened_ = flattened.readonly();
+    let (ipix, depths) = vectorized::from_zuniq(flattened_.as_slice()?, nthreads as usize)
+        .into_iter()
+        .unzip();
+
+    Ok((
+        PyArray1::from_vec(py, ipix)
+            .reshape(input_shape)?
+            .to_dyn()
+            .clone(),
+        PyArray1::from_vec(py, depths)
+            .reshape(input_shape)?
+            .to_dyn()
+            .clone(),
+    ))
+}
+
+#[allow(clippy::type_complexity)]
+#[pyfunction]
+pub(crate) fn to_zuniq<'py>(
+    py: Python<'py>,
+    nested: &Bound<'py, PyArrayDyn<u64>>,
+    depth: DepthLike,
+    nthreads: u16,
+) -> PyResult<Bound<'py, PyArrayDyn<u64>>> {
+    let input_shape = nested.shape();
+
+    let flattened = nested.reshape([nested.len()])?;
+    let flattened_ = flattened.readonly();
+
+    let depth_ = depth.as_depth()?;
+    let zuniq = vectorized::to_zuniq(flattened_.as_slice()?, depth_, nthreads as usize);
+
+    Ok(PyArray1::from_vec(py, zuniq)
+        .reshape(input_shape)?
+        .to_dyn()
+        .clone())
+}
+
+#[allow(clippy::type_complexity)]
+#[pyfunction]
+pub(crate) fn from_ring<'py>(
+    py: Python<'py>,
+    ring: &Bound<'py, PyArrayDyn<u64>>,
+    depth: DepthLike,
+    nthreads: u16,
+) -> PyResult<Bound<'py, PyArrayDyn<u64>>> {
+    let input_shape = ring.shape();
+
+    let flattened = ring.reshape([ring.len()])?;
+    let flattened_ = flattened.readonly();
+
+    let depth_ = depth.as_depth()?;
+    let nested = vectorized::to_zuniq(flattened_.as_slice()?, depth_, nthreads as usize);
+
+    Ok(PyArray1::from_vec(py, nested)
+        .reshape(input_shape)?
+        .to_dyn()
+        .clone())
+}
+
+#[allow(clippy::type_complexity)]
+#[pyfunction]
+pub(crate) fn to_ring<'py>(
+    py: Python<'py>,
+    nested: &Bound<'py, PyArrayDyn<u64>>,
+    depth: DepthLike,
+    nthreads: u16,
+) -> PyResult<Bound<'py, PyArrayDyn<u64>>> {
+    let input_shape = nested.shape();
+
+    let flattened = nested.reshape([nested.len()])?;
+    let flattened_ = flattened.readonly();
+
+    let depth_ = depth.as_depth()?;
+    let ring = vectorized::to_zuniq(flattened_.as_slice()?, depth_, nthreads as usize);
+
+    Ok(PyArray1::from_vec(py, ring)
+        .reshape(input_shape)?
+        .to_dyn()
+        .clone())
+}

--- a/python/healpix-geo/src/indexing_schemes/nested/conversion.rs
+++ b/python/healpix-geo/src/indexing_schemes/nested/conversion.rs
@@ -7,33 +7,6 @@ use crate::indexing_schemes::depth::DepthLike;
 
 #[allow(clippy::type_complexity)]
 #[pyfunction]
-pub(crate) fn from_zuniq<'py>(
-    py: Python<'py>,
-    zuniq: &Bound<'py, PyArrayDyn<u64>>,
-    nthreads: u16,
-) -> PyResult<(Bound<'py, PyArrayDyn<u64>>, Bound<'py, PyArrayDyn<u8>>)> {
-    let input_shape = zuniq.shape();
-
-    let flattened = zuniq.reshape([zuniq.len()])?;
-    let flattened_ = flattened.readonly();
-    let (ipix, depths) = vectorized::from_zuniq(flattened_.as_slice()?, nthreads as usize)
-        .into_iter()
-        .unzip();
-
-    Ok((
-        PyArray1::from_vec(py, ipix)
-            .reshape(input_shape)?
-            .to_dyn()
-            .clone(),
-        PyArray1::from_vec(py, depths)
-            .reshape(input_shape)?
-            .to_dyn()
-            .clone(),
-    ))
-}
-
-#[allow(clippy::type_complexity)]
-#[pyfunction]
 pub(crate) fn to_zuniq<'py>(
     py: Python<'py>,
     nested: &Bound<'py, PyArrayDyn<u64>>,
@@ -49,28 +22,6 @@ pub(crate) fn to_zuniq<'py>(
     let zuniq = vectorized::to_zuniq(flattened_.as_slice()?, depth_, nthreads as usize);
 
     Ok(PyArray1::from_vec(py, zuniq)
-        .reshape(input_shape)?
-        .to_dyn()
-        .clone())
-}
-
-#[allow(clippy::type_complexity)]
-#[pyfunction]
-pub(crate) fn from_ring<'py>(
-    py: Python<'py>,
-    ring: &Bound<'py, PyArrayDyn<u64>>,
-    depth: DepthLike,
-    nthreads: u16,
-) -> PyResult<Bound<'py, PyArrayDyn<u64>>> {
-    let input_shape = ring.shape();
-
-    let flattened = ring.reshape([ring.len()])?;
-    let flattened_ = flattened.readonly();
-
-    let depth_ = depth.as_depth()?;
-    let nested = vectorized::from_ring(flattened_.as_slice()?, depth_, nthreads as usize);
-
-    Ok(PyArray1::from_vec(py, nested)
         .reshape(input_shape)?
         .to_dyn()
         .clone())

--- a/python/healpix-geo/src/indexing_schemes/nested/mod.rs
+++ b/python/healpix-geo/src/indexing_schemes/nested/mod.rs
@@ -1,9 +1,11 @@
+mod conversion;
 mod coordinates;
 mod coverage;
 mod hierarchy;
 mod mesh;
 mod sets;
 
+pub(crate) use self::conversion::{from_ring, from_zuniq, to_ring, to_zuniq};
 pub(crate) use self::coordinates::{
     angular_distances, bilinear_interpolation, cartesian_to_healpix, healpix_to_cartesian,
     healpix_to_lonlat, lonlat_to_healpix, vertices,

--- a/python/healpix-geo/src/indexing_schemes/nested/mod.rs
+++ b/python/healpix-geo/src/indexing_schemes/nested/mod.rs
@@ -5,7 +5,7 @@ mod hierarchy;
 mod mesh;
 mod sets;
 
-pub(crate) use self::conversion::{from_ring, from_zuniq, to_ring, to_zuniq};
+pub(crate) use self::conversion::{to_ring, to_zuniq};
 pub(crate) use self::coordinates::{
     angular_distances, bilinear_interpolation, cartesian_to_healpix, healpix_to_cartesian,
     healpix_to_lonlat, lonlat_to_healpix, vertices,

--- a/python/healpix-geo/src/indexing_schemes/ring/conversion.rs
+++ b/python/healpix-geo/src/indexing_schemes/ring/conversion.rs
@@ -68,7 +68,7 @@ pub(crate) fn from_nested<'py>(
     let flattened_ = flattened.readonly();
 
     let depth_ = depth.as_depth()?;
-    let ring = vectorized::to_zuniq(flattened_.as_slice()?, depth_, nthreads as usize);
+    let ring = vectorized::from_nested(flattened_.as_slice()?, depth_, nthreads as usize);
 
     Ok(PyArray1::from_vec(py, ring)
         .reshape(input_shape)?
@@ -90,7 +90,7 @@ pub(crate) fn to_nested<'py>(
     let flattened_ = flattened.readonly();
 
     let depth_ = depth.as_depth()?;
-    let nested = vectorized::to_zuniq(flattened_.as_slice()?, depth_, nthreads as usize);
+    let nested = vectorized::to_nested(flattened_.as_slice()?, depth_, nthreads as usize);
 
     Ok(PyArray1::from_vec(py, nested)
         .reshape(input_shape)?

--- a/python/healpix-geo/src/indexing_schemes/ring/conversion.rs
+++ b/python/healpix-geo/src/indexing_schemes/ring/conversion.rs
@@ -1,0 +1,99 @@
+use numpy::{PyArray1, PyArrayDyn, PyArrayMethods, PyUntypedArrayMethods};
+use pyo3::prelude::*;
+
+use healpix_geo_core::vectorized::ring::conversion as vectorized;
+
+use crate::indexing_schemes::depth::DepthLike;
+
+#[allow(clippy::type_complexity)]
+#[pyfunction]
+pub(crate) fn from_zuniq<'py>(
+    py: Python<'py>,
+    zuniq: &Bound<'py, PyArrayDyn<u64>>,
+    nthreads: u16,
+) -> PyResult<(Bound<'py, PyArrayDyn<u64>>, Bound<'py, PyArrayDyn<u8>>)> {
+    let input_shape = zuniq.shape();
+
+    let flattened = zuniq.reshape([zuniq.len()])?;
+    let flattened_ = flattened.readonly();
+    let (ring, depths) = vectorized::from_zuniq(flattened_.as_slice()?, nthreads as usize)
+        .into_iter()
+        .unzip();
+
+    Ok((
+        PyArray1::from_vec(py, ring)
+            .reshape(input_shape)?
+            .to_dyn()
+            .clone(),
+        PyArray1::from_vec(py, depths)
+            .reshape(input_shape)?
+            .to_dyn()
+            .clone(),
+    ))
+}
+
+#[allow(clippy::type_complexity)]
+#[pyfunction]
+pub(crate) fn to_zuniq<'py>(
+    py: Python<'py>,
+    ring: &Bound<'py, PyArrayDyn<u64>>,
+    depth: DepthLike,
+    nthreads: u16,
+) -> PyResult<Bound<'py, PyArrayDyn<u64>>> {
+    let input_shape = ring.shape();
+
+    let flattened = ring.reshape([ring.len()])?;
+    let flattened_ = flattened.readonly();
+
+    let depth_ = depth.as_depth()?;
+    let zuniq = vectorized::to_zuniq(flattened_.as_slice()?, depth_, nthreads as usize);
+
+    Ok(PyArray1::from_vec(py, zuniq)
+        .reshape(input_shape)?
+        .to_dyn()
+        .clone())
+}
+
+#[allow(clippy::type_complexity)]
+#[pyfunction]
+pub(crate) fn from_nested<'py>(
+    py: Python<'py>,
+    nested: &Bound<'py, PyArrayDyn<u64>>,
+    depth: DepthLike,
+    nthreads: u16,
+) -> PyResult<Bound<'py, PyArrayDyn<u64>>> {
+    let input_shape = nested.shape();
+
+    let flattened = nested.reshape([nested.len()])?;
+    let flattened_ = flattened.readonly();
+
+    let depth_ = depth.as_depth()?;
+    let ring = vectorized::to_zuniq(flattened_.as_slice()?, depth_, nthreads as usize);
+
+    Ok(PyArray1::from_vec(py, ring)
+        .reshape(input_shape)?
+        .to_dyn()
+        .clone())
+}
+
+#[allow(clippy::type_complexity)]
+#[pyfunction]
+pub(crate) fn to_nested<'py>(
+    py: Python<'py>,
+    ring: &Bound<'py, PyArrayDyn<u64>>,
+    depth: DepthLike,
+    nthreads: u16,
+) -> PyResult<Bound<'py, PyArrayDyn<u64>>> {
+    let input_shape = ring.shape();
+
+    let flattened = ring.reshape([ring.len()])?;
+    let flattened_ = flattened.readonly();
+
+    let depth_ = depth.as_depth()?;
+    let nested = vectorized::to_zuniq(flattened_.as_slice()?, depth_, nthreads as usize);
+
+    Ok(PyArray1::from_vec(py, nested)
+        .reshape(input_shape)?
+        .to_dyn()
+        .clone())
+}

--- a/python/healpix-geo/src/indexing_schemes/ring/conversion.rs
+++ b/python/healpix-geo/src/indexing_schemes/ring/conversion.rs
@@ -7,33 +7,6 @@ use crate::indexing_schemes::depth::DepthLike;
 
 #[allow(clippy::type_complexity)]
 #[pyfunction]
-pub(crate) fn from_zuniq<'py>(
-    py: Python<'py>,
-    zuniq: &Bound<'py, PyArrayDyn<u64>>,
-    nthreads: u16,
-) -> PyResult<(Bound<'py, PyArrayDyn<u64>>, Bound<'py, PyArrayDyn<u8>>)> {
-    let input_shape = zuniq.shape();
-
-    let flattened = zuniq.reshape([zuniq.len()])?;
-    let flattened_ = flattened.readonly();
-    let (ring, depths) = vectorized::from_zuniq(flattened_.as_slice()?, nthreads as usize)
-        .into_iter()
-        .unzip();
-
-    Ok((
-        PyArray1::from_vec(py, ring)
-            .reshape(input_shape)?
-            .to_dyn()
-            .clone(),
-        PyArray1::from_vec(py, depths)
-            .reshape(input_shape)?
-            .to_dyn()
-            .clone(),
-    ))
-}
-
-#[allow(clippy::type_complexity)]
-#[pyfunction]
 pub(crate) fn to_zuniq<'py>(
     py: Python<'py>,
     ring: &Bound<'py, PyArrayDyn<u64>>,
@@ -49,28 +22,6 @@ pub(crate) fn to_zuniq<'py>(
     let zuniq = vectorized::to_zuniq(flattened_.as_slice()?, depth_, nthreads as usize);
 
     Ok(PyArray1::from_vec(py, zuniq)
-        .reshape(input_shape)?
-        .to_dyn()
-        .clone())
-}
-
-#[allow(clippy::type_complexity)]
-#[pyfunction]
-pub(crate) fn from_nested<'py>(
-    py: Python<'py>,
-    nested: &Bound<'py, PyArrayDyn<u64>>,
-    depth: DepthLike,
-    nthreads: u16,
-) -> PyResult<Bound<'py, PyArrayDyn<u64>>> {
-    let input_shape = nested.shape();
-
-    let flattened = nested.reshape([nested.len()])?;
-    let flattened_ = flattened.readonly();
-
-    let depth_ = depth.as_depth()?;
-    let ring = vectorized::from_nested(flattened_.as_slice()?, depth_, nthreads as usize);
-
-    Ok(PyArray1::from_vec(py, ring)
         .reshape(input_shape)?
         .to_dyn()
         .clone())

--- a/python/healpix-geo/src/indexing_schemes/ring/mod.rs
+++ b/python/healpix-geo/src/indexing_schemes/ring/mod.rs
@@ -1,8 +1,10 @@
+mod conversion;
 mod coordinates;
 mod coverage;
 mod hierarchy;
 mod mesh;
 
+pub(crate) use self::conversion::{from_nested, from_zuniq, to_nested, to_zuniq};
 pub(crate) use self::coordinates::{
     angular_distances, bilinear_interpolation, cartesian_to_healpix, healpix_to_cartesian,
     healpix_to_lonlat, lonlat_to_healpix, vertices,

--- a/python/healpix-geo/src/indexing_schemes/ring/mod.rs
+++ b/python/healpix-geo/src/indexing_schemes/ring/mod.rs
@@ -4,7 +4,7 @@ mod coverage;
 mod hierarchy;
 mod mesh;
 
-pub(crate) use self::conversion::{from_nested, from_zuniq, to_nested, to_zuniq};
+pub(crate) use self::conversion::{to_nested, to_zuniq};
 pub(crate) use self::coordinates::{
     angular_distances, bilinear_interpolation, cartesian_to_healpix, healpix_to_cartesian,
     healpix_to_lonlat, lonlat_to_healpix, vertices,

--- a/python/healpix-geo/src/indexing_schemes/zuniq/conversion.rs
+++ b/python/healpix-geo/src/indexing_schemes/zuniq/conversion.rs
@@ -12,7 +12,7 @@ pub(crate) fn from_nested<'py>(
     nthreads: u16,
 ) -> PyResult<Bound<'py, PyArrayDyn<u64>>> {
     let input_shape = nested.shape();
-    let depth_ = depth.into_depth(py)?;
+    let depth_ = depth.as_depth()?;
 
     let flattened = nested.reshape([nested.len()])?;
     let flattened_ = flattened.readonly();

--- a/python/healpix-geo/src/indexing_schemes/zuniq/conversion.rs
+++ b/python/healpix-geo/src/indexing_schemes/zuniq/conversion.rs
@@ -16,9 +16,9 @@ pub(crate) fn from_nested<'py>(
 
     let flattened = nested.reshape([nested.len()])?;
     let flattened_ = flattened.readonly();
-    let result = vectorized::from_nested(flattened_.as_slice()?, depth_, nthreads as usize);
+    let zuniq = vectorized::from_nested(flattened_.as_slice()?, depth_, nthreads as usize);
 
-    Ok(PyArray1::from_vec(py, result)
+    Ok(PyArray1::from_vec(py, zuniq)
         .reshape(input_shape)?
         .to_dyn()
         .clone())
@@ -40,6 +40,52 @@ pub(crate) fn to_nested<'py>(
 
     Ok((
         PyArray1::from_vec(py, nested)
+            .reshape(input_shape)?
+            .to_dyn()
+            .clone(),
+        PyArray1::from_vec(py, depths)
+            .reshape(input_shape)?
+            .to_dyn()
+            .clone(),
+    ))
+}
+
+#[pyfunction]
+pub(crate) fn from_ring<'py>(
+    py: Python<'py>,
+    ring: &Bound<'py, PyArrayDyn<u64>>,
+    depth: DepthLike,
+    nthreads: u16,
+) -> PyResult<Bound<'py, PyArrayDyn<u64>>> {
+    let input_shape = ring.shape();
+    let depth_ = depth.as_depth()?;
+
+    let flattened = ring.reshape([ring.len()])?;
+    let flattened_ = flattened.readonly();
+    let zuniq = vectorized::from_ring(flattened_.as_slice()?, depth_, nthreads as usize);
+
+    Ok(PyArray1::from_vec(py, zuniq)
+        .reshape(input_shape)?
+        .to_dyn()
+        .clone())
+}
+
+#[allow(clippy::type_complexity)]
+#[pyfunction]
+pub(crate) fn to_ring<'py>(
+    py: Python<'py>,
+    zuniq: &Bound<'py, PyArrayDyn<u64>>,
+    nthreads: u16,
+) -> PyResult<(Bound<'py, PyArrayDyn<u64>>, Bound<'py, PyArrayDyn<u8>>)> {
+    let input_shape = zuniq.shape();
+
+    let flattened = zuniq.reshape([zuniq.len()])?;
+    let flattened_ = flattened.readonly();
+
+    let (ring, depths) = vectorized::to_ring(flattened_.as_slice()?, nthreads as usize);
+
+    Ok((
+        PyArray1::from_vec(py, ring)
             .reshape(input_shape)?
             .to_dyn()
             .clone(),

--- a/python/healpix-geo/src/indexing_schemes/zuniq/conversion.rs
+++ b/python/healpix-geo/src/indexing_schemes/zuniq/conversion.rs
@@ -1,28 +1,7 @@
 use numpy::{PyArray1, PyArrayDyn, PyArrayMethods, PyUntypedArrayMethods};
 use pyo3::prelude::*;
 
-use crate::indexing_schemes::depth::DepthLike;
 use healpix_geo_core::vectorized::zuniq::conversion as vectorized;
-
-#[pyfunction]
-pub(crate) fn from_nested<'py>(
-    py: Python<'py>,
-    nested: &Bound<'py, PyArrayDyn<u64>>,
-    depth: DepthLike,
-    nthreads: u16,
-) -> PyResult<Bound<'py, PyArrayDyn<u64>>> {
-    let input_shape = nested.shape();
-    let depth_ = depth.as_depth()?;
-
-    let flattened = nested.reshape([nested.len()])?;
-    let flattened_ = flattened.readonly();
-    let zuniq = vectorized::from_nested(flattened_.as_slice()?, depth_, nthreads as usize);
-
-    Ok(PyArray1::from_vec(py, zuniq)
-        .reshape(input_shape)?
-        .to_dyn()
-        .clone())
-}
 
 #[allow(clippy::type_complexity)]
 #[pyfunction]
@@ -48,26 +27,6 @@ pub(crate) fn to_nested<'py>(
             .to_dyn()
             .clone(),
     ))
-}
-
-#[pyfunction]
-pub(crate) fn from_ring<'py>(
-    py: Python<'py>,
-    ring: &Bound<'py, PyArrayDyn<u64>>,
-    depth: DepthLike,
-    nthreads: u16,
-) -> PyResult<Bound<'py, PyArrayDyn<u64>>> {
-    let input_shape = ring.shape();
-    let depth_ = depth.as_depth()?;
-
-    let flattened = ring.reshape([ring.len()])?;
-    let flattened_ = flattened.readonly();
-    let zuniq = vectorized::from_ring(flattened_.as_slice()?, depth_, nthreads as usize);
-
-    Ok(PyArray1::from_vec(py, zuniq)
-        .reshape(input_shape)?
-        .to_dyn()
-        .clone())
 }
 
 #[allow(clippy::type_complexity)]

--- a/python/healpix-geo/src/indexing_schemes/zuniq/coordinates.rs
+++ b/python/healpix-geo/src/indexing_schemes/zuniq/coordinates.rs
@@ -55,7 +55,7 @@ pub(crate) fn lonlat_to_healpix<'py>(
         .collect();
 
     let ipix = match depth {
-        DepthLike::Constant(d) => {
+        DepthLike::Scalar(d) => {
             let layer = healpix::nested::get(d);
 
             vectorized::lonlat_to_healpix(&coords, layer, &ellipsoid, nthreads as usize)

--- a/python/healpix-geo/src/indexing_schemes/zuniq/mod.rs
+++ b/python/healpix-geo/src/indexing_schemes/zuniq/mod.rs
@@ -4,7 +4,7 @@ mod coverage;
 mod hierarchy;
 mod mesh;
 
-pub(crate) use self::conversion::{from_nested, from_ring, to_nested, to_ring};
+pub(crate) use self::conversion::{to_nested, to_ring};
 pub(crate) use self::coordinates::{
     bilinear_interpolation, cartesian_to_healpix, healpix_to_cartesian, healpix_to_lonlat,
     lonlat_to_healpix, vertices,

--- a/python/healpix-geo/src/indexing_schemes/zuniq/mod.rs
+++ b/python/healpix-geo/src/indexing_schemes/zuniq/mod.rs
@@ -4,7 +4,7 @@ mod coverage;
 mod hierarchy;
 mod mesh;
 
-pub(crate) use self::conversion::{from_nested, to_nested};
+pub(crate) use self::conversion::{from_nested, from_ring, to_nested, to_ring};
 pub(crate) use self::coordinates::{
     bilinear_interpolation, cartesian_to_healpix, healpix_to_cartesian, healpix_to_lonlat,
     lonlat_to_healpix, vertices,

--- a/python/healpix-geo/src/lib.rs
+++ b/python/healpix-geo/src/lib.rs
@@ -16,10 +16,9 @@ mod nested {
     #[pymodule_export]
     use crate::indexing_schemes::nested::{
         angular_distances, bilinear_interpolation, box_coverage, cartesian_to_healpix,
-        cone_coverage, elliptical_cone_coverage, from_ring, from_zuniq, healpix_to_cartesian,
-        healpix_to_lonlat, internal_boundary, kth_neighbourhood, kth_neighbours, lonlat_to_healpix,
-        polygon_coverage, siblings, to_ring, to_zuniq, vertex_indices, vertices, zone_coverage,
-        zoom_to,
+        cone_coverage, elliptical_cone_coverage, healpix_to_cartesian, healpix_to_lonlat,
+        internal_boundary, kth_neighbourhood, kth_neighbours, lonlat_to_healpix, polygon_coverage,
+        siblings, to_ring, to_zuniq, vertex_indices, vertices, zone_coverage, zoom_to,
     };
 }
 
@@ -28,9 +27,9 @@ mod ring {
     #[pymodule_export]
     use crate::indexing_schemes::ring::{
         angular_distances, bilinear_interpolation, box_coverage, cartesian_to_healpix,
-        cone_coverage, elliptical_cone_coverage, from_nested, from_zuniq, healpix_to_cartesian,
-        healpix_to_lonlat, kth_neighbourhood, kth_neighbours, lonlat_to_healpix, polygon_coverage,
-        to_nested, to_zuniq, vertex_indices, vertices, zone_coverage,
+        cone_coverage, elliptical_cone_coverage, healpix_to_cartesian, healpix_to_lonlat,
+        kth_neighbourhood, kth_neighbours, lonlat_to_healpix, polygon_coverage, to_nested,
+        to_zuniq, vertex_indices, vertices, zone_coverage,
     };
 }
 
@@ -39,9 +38,9 @@ mod zuniq {
     #[pymodule_export]
     use crate::indexing_schemes::zuniq::{
         bilinear_interpolation, box_coverage, cartesian_to_healpix, cone_coverage,
-        elliptical_cone_coverage, from_nested, from_ring, healpix_to_cartesian, healpix_to_lonlat,
-        kth_neighbourhood, kth_neighbours, lonlat_to_healpix, polygon_coverage, to_nested, to_ring,
-        vertex_indices, vertices, zone_coverage,
+        elliptical_cone_coverage, healpix_to_cartesian, healpix_to_lonlat, kth_neighbourhood,
+        kth_neighbours, lonlat_to_healpix, polygon_coverage, to_nested, to_ring, vertex_indices,
+        vertices, zone_coverage,
     };
 }
 

--- a/python/healpix-geo/src/lib.rs
+++ b/python/healpix-geo/src/lib.rs
@@ -16,9 +16,10 @@ mod nested {
     #[pymodule_export]
     use crate::indexing_schemes::nested::{
         angular_distances, bilinear_interpolation, box_coverage, cartesian_to_healpix,
-        cone_coverage, elliptical_cone_coverage, healpix_to_cartesian, healpix_to_lonlat,
-        internal_boundary, kth_neighbourhood, kth_neighbours, lonlat_to_healpix, polygon_coverage,
-        siblings, vertex_indices, vertices, zone_coverage, zoom_to,
+        cone_coverage, elliptical_cone_coverage, from_ring, from_zuniq, healpix_to_cartesian,
+        healpix_to_lonlat, internal_boundary, kth_neighbourhood, kth_neighbours, lonlat_to_healpix,
+        polygon_coverage, siblings, to_ring, to_zuniq, vertex_indices, vertices, zone_coverage,
+        zoom_to,
     };
 }
 
@@ -27,9 +28,9 @@ mod ring {
     #[pymodule_export]
     use crate::indexing_schemes::ring::{
         angular_distances, bilinear_interpolation, box_coverage, cartesian_to_healpix,
-        cone_coverage, elliptical_cone_coverage, healpix_to_cartesian, healpix_to_lonlat,
-        kth_neighbourhood, kth_neighbours, lonlat_to_healpix, polygon_coverage, vertex_indices,
-        vertices, zone_coverage,
+        cone_coverage, elliptical_cone_coverage, from_nested, from_zuniq, healpix_to_cartesian,
+        healpix_to_lonlat, kth_neighbourhood, kth_neighbours, lonlat_to_healpix, polygon_coverage,
+        to_nested, to_zuniq, vertex_indices, vertices, zone_coverage,
     };
 }
 
@@ -38,8 +39,8 @@ mod zuniq {
     #[pymodule_export]
     use crate::indexing_schemes::zuniq::{
         bilinear_interpolation, box_coverage, cartesian_to_healpix, cone_coverage,
-        elliptical_cone_coverage, from_nested, healpix_to_cartesian, healpix_to_lonlat,
-        kth_neighbourhood, kth_neighbours, lonlat_to_healpix, polygon_coverage, to_nested,
+        elliptical_cone_coverage, from_nested, from_ring, healpix_to_cartesian, healpix_to_lonlat,
+        kth_neighbourhood, kth_neighbours, lonlat_to_healpix, polygon_coverage, to_nested, to_ring,
         vertex_indices, vertices, zone_coverage,
     };
 }

--- a/rust/healpix-geo-core/src/scalar/nested/conversion.rs
+++ b/rust/healpix-geo-core/src/scalar/nested/conversion.rs
@@ -1,15 +1,5 @@
 use cdshealpix as healpix;
 
-pub fn from_zuniq(hash: &u64) -> (u64, u8) {
-    let (depth, hash_nested) = healpix::nested::from_zuniq(*hash);
-
-    (hash_nested, depth)
-}
-
-pub fn from_ring(hash: &u64, depth: &u8) -> u64 {
-    healpix::nested::get(*depth).from_ring(*hash)
-}
-
 pub fn to_zuniq(hash: &u64, depth: &u8) -> u64 {
     healpix::nested::to_zuniq_unsafe(*depth, *hash)
 }

--- a/rust/healpix-geo-core/src/scalar/ring/conversion.rs
+++ b/rust/healpix-geo-core/src/scalar/ring/conversion.rs
@@ -1,16 +1,5 @@
 use cdshealpix as healpix;
 
-pub fn from_zuniq(hash: &u64) -> (u64, u8) {
-    let (depth, hash_nested) = healpix::nested::from_zuniq(*hash);
-    let hash_ring = healpix::nested::get(depth).to_ring(hash_nested);
-
-    (hash_ring, depth)
-}
-
-pub fn from_nested(hash: &u64, depth: &u8) -> u64 {
-    healpix::nested::get(*depth).to_ring(*hash)
-}
-
 pub fn to_zuniq(hash: &u64, depth: &u8) -> u64 {
     let hash_nested = healpix::nested::get(*depth).from_ring(*hash);
 

--- a/rust/healpix-geo-core/src/scalar/zuniq/conversion.rs
+++ b/rust/healpix-geo-core/src/scalar/zuniq/conversion.rs
@@ -1,13 +1,5 @@
 use cdshealpix as healpix;
 
-pub fn from_nested(hash: &u64, depth: &u8) -> u64 {
-    healpix::nested::to_zuniq_unsafe(*depth, *hash)
-}
-
-pub fn from_ring(hash: &u64, depth: &u8) -> u64 {
-    healpix::nested::to_zuniq_unsafe(*depth, healpix::nested::get(*depth).from_ring(*hash))
-}
-
 pub fn to_nested(hash: &u64) -> (u64, u8) {
     let (depth, hash_nested) = healpix::nested::from_zuniq(*hash);
 

--- a/rust/healpix-geo-core/src/vectorized/depth.rs
+++ b/rust/healpix-geo-core/src/vectorized/depth.rs
@@ -1,4 +1,4 @@
-enum Depth<'a> {
+pub enum Depth<'a> {
     Scalar(&'a u8),
     Array(&'a [u8]),
 }

--- a/rust/healpix-geo-core/src/vectorized/depth.rs
+++ b/rust/healpix-geo-core/src/vectorized/depth.rs
@@ -1,5 +1,4 @@
-pub enum DepthLike {
-    // TODO: figure out how to avoid copying the data
-    Scalar(u8),
-    Array(Vec<u8>),
+enum Depth<'a> {
+    Scalar(&'a u8),
+    Array(&'a [u8]),
 }

--- a/rust/healpix-geo-core/src/vectorized/nested/conversion.rs
+++ b/rust/healpix-geo-core/src/vectorized/nested/conversion.rs
@@ -1,11 +1,9 @@
 #[cfg(not(target_arch = "wasm32"))]
 use rayon::prelude::*;
 
-use cdshealpix::nested::Layer;
-
 use crate::maybe_parallelize;
-use crate::scalar::depth::Depth;
 use crate::scalar::nested::conversion as scalar;
+use crate::vectorized::depth::Depth;
 
 pub fn from_zuniq(ipix: &[u64], nthreads: usize) -> Vec<(u64, u8)> {
     let mut result = Vec::<(u64, u8)>::with_capacity(ipix.len());
@@ -33,7 +31,7 @@ pub fn from_ring(ipix: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
     result
 }
 
-pub fn to_zuniq(hash: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
+pub fn to_zuniq(ipix: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
     let mut result = Vec::<u64>::with_capacity(ipix.len());
 
     match depth {
@@ -51,7 +49,7 @@ pub fn to_zuniq(hash: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
     result
 }
 
-pub fn to_ring(hash: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
+pub fn to_ring(ipix: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
     let mut result = Vec::<u64>::with_capacity(ipix.len());
 
     match depth {

--- a/rust/healpix-geo-core/src/vectorized/nested/conversion.rs
+++ b/rust/healpix-geo-core/src/vectorized/nested/conversion.rs
@@ -4,12 +4,8 @@ use rayon::prelude::*;
 use cdshealpix::nested::Layer;
 
 use crate::maybe_parallelize;
+use crate::scalar::depth::Depth;
 use crate::scalar::nested::conversion as scalar;
-
-enum Depth<'a> {
-    Scalar(&'a u8),
-    Array(&'a [u8]),
-}
 
 pub fn from_zuniq(ipix: &[u64], nthreads: usize) -> Vec<(u64, u8)> {
     let mut result = Vec::<(u64, u8)>::with_capacity(ipix.len());

--- a/rust/healpix-geo-core/src/vectorized/nested/conversion.rs
+++ b/rust/healpix-geo-core/src/vectorized/nested/conversion.rs
@@ -5,32 +5,6 @@ use crate::maybe_parallelize;
 use crate::scalar::nested::conversion as scalar;
 use crate::vectorized::depth::Depth;
 
-pub fn from_zuniq(ipix: &[u64], nthreads: usize) -> Vec<(u64, u8)> {
-    let mut result = Vec::<(u64, u8)>::with_capacity(ipix.len());
-
-    maybe_parallelize!(nthreads, ipix, result, scalar::from_zuniq);
-
-    result
-}
-
-pub fn from_ring(ipix: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
-    let mut result = Vec::<u64>::with_capacity(ipix.len());
-
-    match depth {
-        Depth::Scalar(d) => {
-            maybe_parallelize!(nthreads, ipix, result, |hash| scalar::from_ring(hash, d));
-        }
-        Depth::Array(d) => {
-            let zipped: Vec<_> = ipix.iter().zip(d.iter()).collect();
-            maybe_parallelize!(nthreads, zipped, result, |(hash, depth)| scalar::from_ring(
-                hash, depth
-            ));
-        }
-    };
-
-    result
-}
-
 pub fn to_zuniq(ipix: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
     let mut result = Vec::<u64>::with_capacity(ipix.len());
 

--- a/rust/healpix-geo-core/src/vectorized/nested/conversion.rs
+++ b/rust/healpix-geo-core/src/vectorized/nested/conversion.rs
@@ -1,0 +1,74 @@
+#[cfg(not(target_arch = "wasm32"))]
+use rayon::prelude::*;
+
+use cdshealpix::nested::Layer;
+
+use crate::maybe_parallelize;
+use crate::scalar::nested::conversion as scalar;
+
+enum Depth<'a> {
+    Scalar(&'a u8),
+    Array(&'a [u8]),
+}
+
+pub fn from_zuniq(ipix: &[u64], nthreads: usize) -> Vec<(u64, u8)> {
+    let mut result = Vec::<(u64, u8)>::with_capacity(ipix.len());
+
+    maybe_parallelize!(nthreads, ipix, result, scalar::from_zuniq);
+
+    result
+}
+
+pub fn from_ring(ipix: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
+    let mut result = Vec::<u64>::with_capacity(ipix.len());
+
+    match depth {
+        Depth::Scalar(d) => {
+            maybe_parallelize!(nthreads, ipix, result, |hash| scalar::from_ring(hash, d));
+        }
+        Depth::Array(d) => {
+            let zipped: Vec<_> = ipix.iter().zip(d.iter()).collect();
+            maybe_parallelize!(nthreads, zipped, result, |(hash, depth)| scalar::from_ring(
+                hash, depth
+            ));
+        }
+    };
+
+    result
+}
+
+pub fn to_zuniq(hash: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
+    let mut result = Vec::<u64>::with_capacity(ipix.len());
+
+    match depth {
+        Depth::Scalar(d) => {
+            maybe_parallelize!(nthreads, ipix, result, |hash| scalar::to_zuniq(hash, d));
+        }
+        Depth::Array(d) => {
+            let zipped: Vec<_> = ipix.iter().zip(d.iter()).collect();
+            maybe_parallelize!(nthreads, zipped, result, |(hash, depth)| scalar::to_zuniq(
+                hash, depth
+            ));
+        }
+    };
+
+    result
+}
+
+pub fn to_ring(hash: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
+    let mut result = Vec::<u64>::with_capacity(ipix.len());
+
+    match depth {
+        Depth::Scalar(d) => {
+            maybe_parallelize!(nthreads, ipix, result, |hash| scalar::to_ring(hash, d));
+        }
+        Depth::Array(d) => {
+            let zipped: Vec<_> = ipix.iter().zip(d.iter()).collect();
+            maybe_parallelize!(nthreads, zipped, result, |(hash, depth)| scalar::to_ring(
+                hash, depth
+            ));
+        }
+    };
+
+    result
+}

--- a/rust/healpix-geo-core/src/vectorized/nested/mod.rs
+++ b/rust/healpix-geo-core/src/vectorized/nested/mod.rs
@@ -1,3 +1,4 @@
+pub mod conversion;
 pub mod coordinates;
 pub mod coverage;
 pub mod distances;

--- a/rust/healpix-geo-core/src/vectorized/ring/conversion.rs
+++ b/rust/healpix-geo-core/src/vectorized/ring/conversion.rs
@@ -1,11 +1,9 @@
 #[cfg(not(target_arch = "wasm32"))]
 use rayon::prelude::*;
 
-use cdshealpix::nested::Layer;
-
 use crate::maybe_parallelize;
-use crate::scalar::depth::Depth;
 use crate::scalar::ring::conversion as scalar;
+use crate::vectorized::depth::Depth;
 
 pub fn from_zuniq(ipix: &[u64], nthreads: usize) -> Vec<(u64, u8)> {
     let mut result = Vec::<(u64, u8)>::with_capacity(ipix.len());
@@ -35,7 +33,7 @@ pub fn from_nested(ipix: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
     result
 }
 
-pub fn to_zuniq(hash: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
+pub fn to_zuniq(ipix: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
     let mut result = Vec::<u64>::with_capacity(ipix.len());
 
     match depth {
@@ -53,7 +51,7 @@ pub fn to_zuniq(hash: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
     result
 }
 
-pub fn to_nested(hash: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
+pub fn to_nested(ipix: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
     let mut result = Vec::<u64>::with_capacity(ipix.len());
 
     match depth {

--- a/rust/healpix-geo-core/src/vectorized/ring/conversion.rs
+++ b/rust/healpix-geo-core/src/vectorized/ring/conversion.rs
@@ -1,0 +1,72 @@
+#[cfg(not(target_arch = "wasm32"))]
+use rayon::prelude::*;
+
+use cdshealpix::nested::Layer;
+
+use crate::maybe_parallelize;
+use crate::scalar::depth::Depth;
+use crate::scalar::ring::conversion as scalar;
+
+pub fn from_zuniq(ipix: &[u64], nthreads: usize) -> Vec<(u64, u8)> {
+    let mut result = Vec::<(u64, u8)>::with_capacity(ipix.len());
+
+    maybe_parallelize!(nthreads, ipix, result, scalar::from_zuniq);
+
+    result
+}
+
+pub fn from_nested(ipix: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
+    let mut result = Vec::<u64>::with_capacity(ipix.len());
+
+    match depth {
+        Depth::Scalar(depth) => {
+            maybe_parallelize!(nthreads, ipix, result, |hash| scalar::from_nested(
+                hash, depth
+            ));
+        }
+        Depth::Array(depths) => {
+            let zipped: Vec<_> = ipix.iter().zip(depths.iter()).collect();
+            maybe_parallelize!(nthreads, zipped, result, |(hash, depth)| {
+                scalar::from_nested(hash, depth)
+            });
+        }
+    };
+
+    result
+}
+
+pub fn to_zuniq(hash: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
+    let mut result = Vec::<u64>::with_capacity(ipix.len());
+
+    match depth {
+        Depth::Scalar(d) => {
+            maybe_parallelize!(nthreads, ipix, result, |hash| scalar::to_zuniq(hash, d));
+        }
+        Depth::Array(d) => {
+            let zipped: Vec<_> = ipix.iter().zip(d.iter()).collect();
+            maybe_parallelize!(nthreads, zipped, result, |(hash, depth)| scalar::to_zuniq(
+                hash, depth
+            ));
+        }
+    };
+
+    result
+}
+
+pub fn to_nested(hash: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
+    let mut result = Vec::<u64>::with_capacity(ipix.len());
+
+    match depth {
+        Depth::Scalar(d) => {
+            maybe_parallelize!(nthreads, ipix, result, |hash| scalar::to_nested(hash, d));
+        }
+        Depth::Array(d) => {
+            let zipped: Vec<_> = ipix.iter().zip(d.iter()).collect();
+            maybe_parallelize!(nthreads, zipped, result, |(hash, depth)| scalar::to_nested(
+                hash, depth
+            ));
+        }
+    };
+
+    result
+}

--- a/rust/healpix-geo-core/src/vectorized/ring/conversion.rs
+++ b/rust/healpix-geo-core/src/vectorized/ring/conversion.rs
@@ -5,34 +5,6 @@ use crate::maybe_parallelize;
 use crate::scalar::ring::conversion as scalar;
 use crate::vectorized::depth::Depth;
 
-pub fn from_zuniq(ipix: &[u64], nthreads: usize) -> Vec<(u64, u8)> {
-    let mut result = Vec::<(u64, u8)>::with_capacity(ipix.len());
-
-    maybe_parallelize!(nthreads, ipix, result, scalar::from_zuniq);
-
-    result
-}
-
-pub fn from_nested(ipix: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
-    let mut result = Vec::<u64>::with_capacity(ipix.len());
-
-    match depth {
-        Depth::Scalar(depth) => {
-            maybe_parallelize!(nthreads, ipix, result, |hash| scalar::from_nested(
-                hash, depth
-            ));
-        }
-        Depth::Array(depths) => {
-            let zipped: Vec<_> = ipix.iter().zip(depths.iter()).collect();
-            maybe_parallelize!(nthreads, zipped, result, |(hash, depth)| {
-                scalar::from_nested(hash, depth)
-            });
-        }
-    };
-
-    result
-}
-
 pub fn to_zuniq(ipix: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
     let mut result = Vec::<u64>::with_capacity(ipix.len());
 

--- a/rust/healpix-geo-core/src/vectorized/ring/mod.rs
+++ b/rust/healpix-geo-core/src/vectorized/ring/mod.rs
@@ -1,3 +1,4 @@
+pub mod conversion;
 pub mod coordinates;
 pub mod coverage;
 pub mod distances;

--- a/rust/healpix-geo-core/src/vectorized/zuniq/conversion.rs
+++ b/rust/healpix-geo-core/src/vectorized/zuniq/conversion.rs
@@ -1,53 +1,9 @@
 use crate::maybe_parallelize;
-use crate::vectorized::depth::Depth;
 
 use crate::scalar::zuniq::conversion as scalar;
 
 #[cfg(not(target_arch = "wasm32"))]
 use rayon::prelude::*;
-
-pub fn from_nested(ipix: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
-    let mut result = Vec::<u64>::with_capacity(ipix.len());
-
-    match depth {
-        Depth::Scalar(depth) => {
-            maybe_parallelize!(nthreads, ipix, result, |hash| scalar::from_nested(
-                hash, depth
-            ));
-        }
-        Depth::Array(depths) => {
-            let joined: Vec<(&u64, &u8)> = ipix.iter().zip(depths.iter()).collect();
-            maybe_parallelize!(nthreads, &joined, result, |(hash, depth)| {
-                scalar::from_nested(hash, depth)
-            });
-        }
-    }
-
-    result
-}
-
-pub fn from_ring(ipix: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
-    let mut result = Vec::<u64>::with_capacity(ipix.len());
-
-    match depth {
-        Depth::Scalar(depth) => {
-            maybe_parallelize!(nthreads, ipix, result, |hash| scalar::from_ring(
-                hash, depth
-            ));
-        }
-        Depth::Array(depths) => {
-            let joined: Vec<(&u64, &u8)> = ipix.iter().zip(depths.iter()).collect();
-            maybe_parallelize!(
-                nthreads,
-                &joined,
-                result,
-                |(hash, depth)| scalar::from_ring(hash, depth),
-            );
-        }
-    }
-
-    result
-}
 
 pub fn to_nested(ipix: &[u64], nthreads: usize) -> (Vec<u64>, Vec<u8>) {
     let mut result = Vec::<(u64, u8)>::with_capacity(ipix.len());

--- a/rust/healpix-geo-core/src/vectorized/zuniq/conversion.rs
+++ b/rust/healpix-geo-core/src/vectorized/zuniq/conversion.rs
@@ -1,21 +1,21 @@
 use crate::maybe_parallelize;
-use crate::vectorized::depth::DepthLike;
+use crate::vectorized::depth::Depth;
 
 use crate::scalar::zuniq::conversion as scalar;
 
 #[cfg(not(target_arch = "wasm32"))]
 use rayon::prelude::*;
 
-pub fn from_nested(ipix: &[u64], depth: DepthLike, nthreads: usize) -> Vec<u64> {
+pub fn from_nested(ipix: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
     let mut result = Vec::<u64>::with_capacity(ipix.len());
 
     match depth {
-        DepthLike::Scalar(depth) => {
+        Depth::Scalar(depth) => {
             maybe_parallelize!(nthreads, ipix, result, |hash| scalar::from_nested(
                 hash, &depth
             ));
         }
-        DepthLike::Array(depths) => {
+        Depth::Array(depths) => {
             let joined: Vec<(&u64, &u8)> = ipix.iter().zip(depths.iter()).collect();
             maybe_parallelize!(nthreads, &joined, result, |(hash, depth)| {
                 scalar::from_nested(hash, depth)
@@ -26,16 +26,16 @@ pub fn from_nested(ipix: &[u64], depth: DepthLike, nthreads: usize) -> Vec<u64> 
     result
 }
 
-pub fn from_ring(ipix: &[u64], depth: DepthLike, nthreads: usize) -> Vec<u64> {
+pub fn from_ring(ipix: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
     let mut result = Vec::<u64>::with_capacity(ipix.len());
 
     match depth {
-        DepthLike::Scalar(depth) => {
+        Depth::Scalar(depth) => {
             maybe_parallelize!(nthreads, ipix, result, |hash| scalar::from_ring(
                 hash, &depth
             ));
         }
-        DepthLike::Array(depths) => {
+        Depth::Array(depths) => {
             let joined: Vec<(&u64, &u8)> = ipix.iter().zip(depths.iter()).collect();
             maybe_parallelize!(
                 nthreads,

--- a/rust/healpix-geo-core/src/vectorized/zuniq/conversion.rs
+++ b/rust/healpix-geo-core/src/vectorized/zuniq/conversion.rs
@@ -12,7 +12,7 @@ pub fn from_nested(ipix: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
     match depth {
         Depth::Scalar(depth) => {
             maybe_parallelize!(nthreads, ipix, result, |hash| scalar::from_nested(
-                hash, &depth
+                hash, depth
             ));
         }
         Depth::Array(depths) => {
@@ -32,7 +32,7 @@ pub fn from_ring(ipix: &[u64], depth: Depth, nthreads: usize) -> Vec<u64> {
     match depth {
         Depth::Scalar(depth) => {
             maybe_parallelize!(nthreads, ipix, result, |hash| scalar::from_ring(
-                hash, &depth
+                hash, depth
             ));
         }
         Depth::Array(depths) => {


### PR DESCRIPTION
Before this we'd need to use `cdshealpix` to convert, which pulls in `astropy` again.

I'll need to think about the `healpix_geo.auto.convert` function a bit more, I'm not quite content with the additional `level` parameter.

cc @carloshorn, since you asked about this during the conference two weeks ago.