### PR TITLE
function to lookup ellipsoid names

### DIFF
--- a/python/healpix-geo/docs/api.rst
+++ b/python/healpix-geo/docs/api.rst
@@ -73,6 +73,12 @@ Ellipsoids
    **Always use** ``ellipsoid="WGS84"`` for real geospatial applications.
    See :doc:`tutorials/ellipsoid_basics` for more details.
 
+.. currentmodule:: healpix_geo
+
+.. autosummary::
+   :toctree: generated/
+
+   ellipsoid.resolve
 
 Conventions
 ===========

--- a/python/healpix-geo/python/healpix_geo/auto.py
+++ b/python/healpix-geo/python/healpix_geo/auto.py
@@ -38,6 +38,13 @@ class Grid:
     ellipsoid: EllipsoidLike = "sphere"
     """The reference ellipsoid of the grid."""
 
+    def __post_init__(self):
+        if isinstance(self.ellipsoid, str):
+            from healpix_geo.ellipsoid import resolve
+
+            # normalize to an object or dict
+            object.__setattr__(self, "ellipsoid", resolve(self.ellipsoid))
+
     def _as_params(self):
         params = {"ellipsoid": self.ellipsoid}
         if self.indexing_scheme != "zuniq":
@@ -271,7 +278,7 @@ def vertices(
     >>> ipix = np.array([42, 6, 10])
     >>> grid = hg.Grid(level=12, indexing_scheme="nested", ellipsoid="sphere")
     >>> grid
-    Grid(level=12, indexing_scheme='nested', ellipsoid='sphere')
+    Grid(level=12, indexing_scheme='nested', ellipsoid={'name': 'sphere', 'radius': 6370997.0})
 
     Compute just the vertices:
 
@@ -396,7 +403,7 @@ def bilinear_interpolation(
 
     >>> grid = hg.Grid(level=12, indexing_scheme="nested", ellipsoid="sphere")
     >>> grid
-    Grid(level=12, indexing_scheme='nested', ellipsoid='sphere')
+    Grid(level=12, indexing_scheme='nested', ellipsoid={'name': 'sphere', 'radius': 6370997.0})
 
     Define coordinates
 
@@ -476,7 +483,7 @@ def kth_neighbours(
     >>> ipix = np.array([42, 6, 10])
     >>> grid = hg.Grid(level=12, indexing_scheme="nested", ellipsoid="sphere")
     >>> grid
-    Grid(level=12, indexing_scheme='nested', ellipsoid='sphere')
+    Grid(level=12, indexing_scheme='nested', ellipsoid={'name': 'sphere', 'radius': 6370997.0})
     >>> ring = 3
     >>> neighbours = hg.kth_neighbours(ipix, grid, ring=ring)
     >>> neighbours
@@ -538,7 +545,7 @@ def kth_neighbourhood(
     >>> ipix = np.array([42, 6, 10])
     >>> grid = hg.Grid(level=12, indexing_scheme="nested", ellipsoid="sphere")
     >>> grid
-    Grid(level=12, indexing_scheme='nested', ellipsoid='sphere')
+    Grid(level=12, indexing_scheme='nested', ellipsoid={'name': 'sphere', 'radius': 6370997.0})
     >>> ring = 3
     >>> neighbours = hg.kth_neighbourhood(ipix, grid, ring=ring)
     >>> neighbours

--- a/python/healpix-geo/python/healpix_geo/ellipsoid.py
+++ b/python/healpix-geo/python/healpix_geo/ellipsoid.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from healpix_geo.typing import EllipsoidLike
+
+
+def resolve(name: str) -> EllipsoidLike:
+    """Look up the ellipsoid based on a name
+
+    Parameters
+    ----------
+    name : str
+        The name of the ellipsoid.
+
+    Returns
+    -------
+    mapping
+        The parameters of the ellipsoid. The passed name will be included.
+
+    Raises
+    ------
+    ValueError
+        If the name is unknown.
+    """
+    from healpix_geo.healpix_geo import resolve_ellipsoid
+
+    return resolve_ellipsoid(name)

--- a/python/healpix-geo/python/healpix_geo/tests/test_auto.py
+++ b/python/healpix-geo/python/healpix_geo/tests/test_auto.py
@@ -32,6 +32,23 @@ def test_dispatch_module_failing(scheme):
 
 
 @pytest.mark.parametrize(
+    ["ellipsoid", "expected"],
+    (
+        pytest.param("unitsphere", {"name": "unitsphere", "radius": 1.0}, id="name"),
+        pytest.param(
+            {"name": "sphere", "radius": 6370997.0},
+            {"name": "sphere", "radius": 6370997.0},
+            id="mapping",
+        ),
+    ),
+)
+def test_constructor_ellipsoid(ellipsoid, expected) -> None:
+    grid = auto.Grid(level=5, indexing_scheme="nested", ellipsoid=ellipsoid)
+
+    assert grid.ellipsoid == expected
+
+
+@pytest.mark.parametrize(
     ["grid", "expected"],
     (
         (

--- a/python/healpix-geo/python/healpix_geo/tests/test_ellipsoid.py
+++ b/python/healpix-geo/python/healpix_geo/tests/test_ellipsoid.py
@@ -1,0 +1,27 @@
+import pytest
+
+from healpix_geo import ellipsoid
+from healpix_geo.typing import EllipsoidLike
+
+
+@pytest.mark.parametrize(
+    ["name", "expected"],
+    (
+        pytest.param(
+            "WGS84",
+            {
+                "name": "WGS84",
+                "semimajor_axis": 6378137.0,
+                "inverse_flattening": 298.257223563,
+            },
+            id="WGS84",
+        ),
+        pytest.param(
+            "unitsphere", {"name": "unitsphere", "radius": 1.0}, id="unitsphere"
+        ),
+    ),
+)
+def test_resolve(name: str, expected: EllipsoidLike) -> None:
+    actual = ellipsoid.resolve(name)
+
+    assert actual == expected

--- a/python/healpix-geo/src/ellipsoid.rs
+++ b/python/healpix-geo/src/ellipsoid.rs
@@ -1,7 +1,8 @@
 use geodesy::ellps::Ellipsoid as GeoEllipsoid;
-use healpix_geo_core::ellipsoid::{Ellipsoid, ReferenceEllipsoid, ReferenceSphere};
+use healpix_geo_core::ellipsoid::{Ellipsoid, ReferenceBody, ReferenceEllipsoid, ReferenceSphere};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use pyo3::types::{IntoPyDict, PyDict, PyDictMethods};
 
 #[derive(FromPyObject)]
 pub(crate) enum EllipsoidLike {
@@ -78,4 +79,23 @@ impl EllipsoidLike {
             }
         }
     }
+}
+
+#[pyfunction]
+pub(crate) fn resolve_ellipsoid<'py>(
+    py: Python<'py>,
+    name: String,
+) -> PyResult<Bound<'py, PyDict>> {
+    let mapping = PyDict::new(py);
+    mapping.set_item("name", &name)?;
+
+    let ellipsoid = EllipsoidLike::Named(name).into_ellipsoid()?;
+
+    let mut parameters = ellipsoid.to_mapping();
+    if let Some(v) = parameters.remove("flattening") {
+        parameters.insert("inverse_flattening".to_string(), 1.0 / v);
+    }
+    mapping.update(parameters.into_py_dict(py)?.as_mapping())?;
+
+    Ok(mapping)
 }

--- a/python/healpix-geo/src/lib.rs
+++ b/python/healpix-geo/src/lib.rs
@@ -69,4 +69,7 @@ mod healpix_geo {
     use crate::geometry::{cartesian_to_lonlat, lonlat_to_cartesian};
     #[pymodule_export]
     use crate::mesh::vertex_to_geographic;
+
+    #[pymodule_export]
+    use crate::ellipsoid::resolve_ellipsoid;
 }


### PR DESCRIPTION
This allows us to enforce parametrizing the ellipsoid instead of just providing the name, which I believe is a better strategy in the long run (especially if we want to also support astronomical ellipsoids of revolution).