### PR TITLE
Add NESTED face topology primitives

### DIFF
--- a/python/healpix-geo/docs/api/nested.rst
+++ b/python/healpix-geo/docs/api/nested.rst
@@ -31,6 +31,18 @@ Indexing Scheme Conversions
    to_ring
    to_zuniq
 
+Face-local Topology
+~~~~~~~~~~~~~~~~~~~
+
+Integer-only conversion and navigation within HEALPix base faces.
+
+.. autosummary::
+   :toctree: ../generated/
+
+   pix2xyf
+   xyf2pix
+   face_neighbour_transform
+
 Interpolation
 ~~~~~~~~~~~~~
 

--- a/python/healpix-geo/python/healpix_geo/nested.py
+++ b/python/healpix-geo/python/healpix_geo/nested.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 import marray
 import numpy as np
@@ -17,8 +17,165 @@ RangeMOCIndex = healpix_geo.nested.RangeMOCIndex
 internal_boundary = healpix_geo.nested.internal_boundary
 
 
+class FaceTransform(NamedTuple):
+    """Orientation of a neighbouring HEALPix base face.
+
+    Apply ``swap_xy`` first, then ``flip_x`` and ``flip_y`` to orient a
+    face-local array in the target face's coordinate frame.
+    """
+
+    target_face: int
+    swap_xy: bool
+    flip_x: bool
+    flip_y: bool
+
+
 def create_empty(depth):
     return RangeMOCIndex.empty(depth)
+
+
+def face_neighbour_transform(face, direction):
+    """Return the adjacent base face and relative coordinate orientation.
+
+    Parameters
+    ----------
+    face : int
+        Source base-face index in the closed range ``[0, 11]``.
+    direction : {"N", "NE", "E", "SE", "S", "SW", "W", "NW"}
+        HEALPix direction in the source face's local coordinate frame. Matching
+        is case-insensitive.
+
+    Returns
+    -------
+    `FaceTransform` or None
+        The target face and the axis swap/reversal required to orient source
+        coordinates in the target frame. ``None`` means the source base face
+        has no distinct neighbour in that direction.
+
+    Notes
+    -----
+    This operation is independent of depth. It reports orientation only; a
+    caller remapping an ``nside`` by ``nside`` array should swap axes first,
+    then replace a flipped coordinate ``v`` with ``nside - 1 - v``.
+
+    Examples
+    --------
+    >>> from healpix_geo.nested import face_neighbour_transform
+    >>> face_neighbour_transform(0, "N")
+    FaceTransform(target_face=2, swap_xy=False, flip_x=True, flip_y=True)
+    >>> face_neighbour_transform(4, "N") is None
+    True
+    """
+    if not isinstance(face, (int, np.integer)) or face < 0 or face > 11:
+        raise ValueError("Face must be in the [0, 11] closed range")
+    if not isinstance(direction, str):
+        raise TypeError("direction must be a string")
+
+    transform = healpix_geo.nested.face_neighbour_transform(np.uint8(face), direction)
+    return None if transform is None else FaceTransform(*transform)
+
+
+def pix2xyf(cell_ids, depth, num_threads=0):
+    """Convert NESTED cell indexes to base-face-local coordinates.
+
+    This is an integer-only topology operation. At ``depth``, each of the 12
+    base faces is a ``2**depth`` by ``2**depth`` grid. Array inputs are
+    broadcast against an array-valued ``depth`` and output shapes are
+    preserved.
+
+    Parameters
+    ----------
+    cell_ids : array-like of int
+        NESTED cell indexes.
+    depth : int or array-like of int
+        HEALPix depth in the closed range ``[0, 29]``.
+    num_threads : int, optional
+        Number of worker threads. Zero uses the Rayon default.
+
+    Returns
+    -------
+    face, x, y : tuple of `numpy.ndarray`
+        Base-face indexes as ``uint8`` and face-local coordinates as ``uint32``.
+
+    Examples
+    --------
+    >>> from healpix_geo.nested import pix2xyf
+    >>> pix2xyf([0, 3, 4, 47], 1)
+    (array([ 0,  0,  1, 11], dtype=uint8), array([0, 1, 0, 1], dtype=uint32), array([0, 1, 0, 1], dtype=uint32))
+    """
+    _check_depth(depth)
+    cell_ids = np.atleast_1d(cell_ids)
+
+    if isinstance(depth, int):
+        broadcast_depth = depth
+    else:
+        cell_ids, broadcast_depth = np.broadcast_arrays(cell_ids, np.asarray(depth))
+        broadcast_depth = np.ascontiguousarray(broadcast_depth, dtype=np.uint8)
+
+    _check_ipixels(data=cell_ids, depth=broadcast_depth)
+    cell_ids = np.ascontiguousarray(cell_ids, dtype=np.uint64)
+    num_threads = np.uint16(num_threads)
+
+    return healpix_geo.nested.pix2xyf(cell_ids, broadcast_depth, num_threads)
+
+
+def xyf2pix(face, x, y, depth, num_threads=0):
+    """Convert base-face-local coordinates to NESTED cell indexes.
+
+    ``face``, ``x``, ``y``, and an array-valued ``depth`` follow NumPy
+    broadcasting rules. Coordinates must lie inside the selected base face.
+
+    Parameters
+    ----------
+    face : array-like of int
+        Base-face indexes in the closed range ``[0, 11]``.
+    x, y : array-like of int
+        Face-local coordinates in ``[0, 2**depth - 1]``.
+    depth : int or array-like of int
+        HEALPix depth in the closed range ``[0, 29]``.
+    num_threads : int, optional
+        Number of worker threads. Zero uses the Rayon default.
+
+    Returns
+    -------
+    cell_ids : `numpy.ndarray`
+        NESTED cell indexes as ``uint64``.
+
+    Examples
+    --------
+    >>> from healpix_geo.nested import xyf2pix
+    >>> xyf2pix([0, 0, 1, 11], [0, 1, 0, 1], [0, 1, 0, 1], 1)
+    array([ 0,  3,  4, 47], dtype=uint64)
+    """
+    _check_depth(depth)
+    face = np.atleast_1d(face)
+    x = np.atleast_1d(x)
+    y = np.atleast_1d(y)
+
+    if isinstance(depth, int):
+        face, x, y = np.broadcast_arrays(face, x, y)
+        broadcast_depth = depth
+    else:
+        face, x, y, broadcast_depth = np.broadcast_arrays(face, x, y, np.asarray(depth))
+        broadcast_depth = np.ascontiguousarray(broadcast_depth, dtype=np.uint8)
+
+    if (face < 0).any() or (face > 11).any():
+        raise ValueError("Face must be in the [0, 11] closed range")
+
+    nside = 2 ** np.asarray(broadcast_depth, dtype=np.uint64)
+    if (x < 0).any() or (x >= nside).any():
+        raise ValueError("x must be in the [0, 2**depth - 1] closed range")
+    if (y < 0).any() or (y >= nside).any():
+        raise ValueError("y must be in the [0, 2**depth - 1] closed range")
+
+    num_threads = np.uint16(num_threads)
+    return healpix_geo.nested.xyf2pix(
+        np.ascontiguousarray(face, dtype=np.uint8),
+        np.ascontiguousarray(x, dtype=np.uint32),
+        np.ascontiguousarray(y, dtype=np.uint32),
+        broadcast_depth,
+        num_threads,
+    )
 
 
 def to_ring(

--- a/python/healpix-geo/python/healpix_geo/nested.py
+++ b/python/healpix-geo/python/healpix_geo/nested.py
@@ -54,9 +54,10 @@ def face_neighbour_transform(face, direction):
 
     Notes
     -----
-    This operation is independent of depth. It reports orientation only; a
-    caller remapping an ``nside`` by ``nside`` array should swap axes first,
-    then replace a flipped coordinate ``v`` with ``nside - 1 - v``.
+    This is a scalar-only operation and is independent of depth. It reports
+    orientation only; a caller remapping an ``nside`` by ``nside`` array should
+    swap axes first, then replace a flipped coordinate ``v`` with
+    ``nside - 1 - v``.
 
     Examples
     --------
@@ -66,7 +67,9 @@ def face_neighbour_transform(face, direction):
     >>> face_neighbour_transform(4, "N") is None
     True
     """
-    if not isinstance(face, (int, np.integer)) or face < 0 or face > 11:
+    if not isinstance(face, (int, np.integer)):
+        raise TypeError("face must be an integer")
+    if face < 0 or face > 11:
         raise ValueError("Face must be in the [0, 11] closed range")
     if not isinstance(direction, str):
         raise TypeError("direction must be a string")

--- a/python/healpix-geo/python/healpix_geo/nested.py
+++ b/python/healpix-geo/python/healpix_geo/nested.py
@@ -54,10 +54,11 @@ def face_neighbour_transform(face, direction):
 
     Notes
     -----
-    This is a scalar-only operation and is independent of depth. It reports
-    orientation only; a caller remapping an ``nside`` by ``nside`` array should
-    swap axes first, then replace a flipped coordinate ``v`` with
-    ``nside - 1 - v``.
+    This operation accepts one face and direction because the transform is
+    constant for each face/direction pair and is independent of depth. Callers
+    should obtain it once and apply it to vectorized coordinate arrays. When
+    remapping an ``nside`` by ``nside`` array, swap axes first, then replace a
+    flipped coordinate ``v`` with ``nside - 1 - v``.
 
     Examples
     --------

--- a/python/healpix-geo/python/healpix_geo/tests/test_topology.py
+++ b/python/healpix-geo/python/healpix_geo/tests/test_topology.py
@@ -1,0 +1,199 @@
+import numpy as np
+import pytest
+
+from healpix_geo import nested
+
+DIRECTIONS = ("N", "NE", "E", "SE", "S", "SW", "W", "NW")
+EXPECTED_NEIGHBOUR_FACES = (
+    (2, 1, None, 5, 8, 4, None, 3),
+    (3, 2, None, 6, 9, 5, None, 0),
+    (0, 3, None, 7, 10, 6, None, 1),
+    (1, 0, None, 4, 11, 7, None, 2),
+    (None, 0, 5, 8, None, 11, 7, 3),
+    (None, 1, 6, 9, None, 8, 4, 0),
+    (None, 2, 7, 10, None, 9, 5, 1),
+    (None, 3, 4, 11, None, 10, 6, 2),
+    (0, 5, None, 9, 10, 11, None, 4),
+    (1, 6, None, 10, 11, 8, None, 5),
+    (2, 7, None, 11, 8, 9, None, 6),
+    (3, 4, None, 8, 9, 10, None, 7),
+)
+
+
+def test_face_neighbour_transform_all_faces_and_directions():
+    for face, expected_faces in enumerate(EXPECTED_NEIGHBOUR_FACES):
+        for direction, expected_face in zip(DIRECTIONS, expected_faces, strict=True):
+            transform = nested.face_neighbour_transform(face, direction)
+            if expected_face is None:
+                assert transform is None
+            else:
+                assert transform.target_face == expected_face
+
+
+def test_face_neighbour_transform_orientation_cases():
+    assert nested.face_neighbour_transform(0, "n") == nested.FaceTransform(
+        target_face=2, swap_xy=False, flip_x=True, flip_y=True
+    )
+    assert nested.face_neighbour_transform(0, "NE") == nested.FaceTransform(
+        target_face=1, swap_xy=True, flip_x=False, flip_y=True
+    )
+    assert nested.face_neighbour_transform(4, "E") == nested.FaceTransform(
+        target_face=5, swap_xy=False, flip_x=False, flip_y=False
+    )
+    assert nested.face_neighbour_transform(8, "SE") == nested.FaceTransform(
+        target_face=9, swap_xy=True, flip_x=True, flip_y=False
+    )
+    assert nested.face_neighbour_transform(8, "S") == nested.FaceTransform(
+        target_face=10, swap_xy=False, flip_x=True, flip_y=True
+    )
+
+
+@pytest.mark.parametrize("face", [-1, 12, 256])
+def test_face_neighbour_transform_rejects_invalid_face(face):
+    with pytest.raises(ValueError, match="Face"):
+        nested.face_neighbour_transform(face, "N")
+
+
+def test_face_neighbour_transform_rejects_invalid_direction():
+    with pytest.raises(ValueError, match="direction"):
+        nested.face_neighbour_transform(0, "up")
+    with pytest.raises(TypeError, match="direction"):
+        nested.face_neighbour_transform(0, 0)
+
+
+@pytest.mark.parametrize("depth", range(6))
+def test_exhaustive_small_depth_round_trip(depth):
+    pixels = np.arange(12 * 4**depth, dtype=np.uint64)
+
+    face, x, y = nested.pix2xyf(pixels, depth)
+
+    np.testing.assert_array_equal(nested.xyf2pix(face, x, y, depth), pixels)
+    actual_face, actual_x, actual_y = nested.pix2xyf(
+        nested.xyf2pix(face, x, y, depth), depth
+    )
+    np.testing.assert_array_equal(actual_face, face)
+    np.testing.assert_array_equal(actual_x, x)
+    np.testing.assert_array_equal(actual_y, y)
+
+
+def test_level_zero_is_the_base_face():
+    pixels = np.arange(12, dtype=np.uint64)
+
+    face, x, y = nested.pix2xyf(pixels, 0)
+
+    np.testing.assert_array_equal(face, np.arange(12, dtype=np.uint8))
+    np.testing.assert_array_equal(x, np.zeros(12, dtype=np.uint32))
+    np.testing.assert_array_equal(y, np.zeros(12, dtype=np.uint32))
+
+
+def test_scalar_inputs_return_length_one_arrays():
+    face, x, y = nested.pix2xyf(47, 1)
+
+    np.testing.assert_array_equal(face, np.array([11], dtype=np.uint8))
+    np.testing.assert_array_equal(x, np.array([1], dtype=np.uint32))
+    np.testing.assert_array_equal(y, np.array([1], dtype=np.uint32))
+    np.testing.assert_array_equal(
+        nested.xyf2pix(11, 1, 1, 1), np.array([47], dtype=np.uint64)
+    )
+
+
+def test_multidimensional_shape_and_dtypes_are_preserved():
+    pixels = np.arange(48, dtype=np.uint64).reshape(2, 3, 8)
+
+    face, x, y = nested.pix2xyf(pixels, 1)
+
+    assert face.shape == pixels.shape
+    assert x.shape == pixels.shape
+    assert y.shape == pixels.shape
+    assert face.dtype == np.uint8
+    assert x.dtype == np.uint32
+    assert y.dtype == np.uint32
+    actual = nested.xyf2pix(face, x, y, 1)
+    assert actual.shape == pixels.shape
+    assert actual.dtype == np.uint64
+    np.testing.assert_array_equal(actual, pixels)
+
+
+def test_xyf2pix_broadcasts_inputs():
+    face = np.arange(12, dtype=np.uint8)[:, np.newaxis]
+    x = np.arange(4, dtype=np.uint32)[np.newaxis, :]
+    y = np.array(2, dtype=np.uint32)
+
+    pixels = nested.xyf2pix(face, x, y, 2)
+
+    assert pixels.shape == (12, 4)
+    actual_face, actual_x, actual_y = nested.pix2xyf(pixels, 2)
+    np.testing.assert_array_equal(actual_face, np.broadcast_to(face, (12, 4)))
+    np.testing.assert_array_equal(actual_x, np.broadcast_to(x, (12, 4)))
+    np.testing.assert_array_equal(actual_y, np.full((12, 4), 2, dtype=np.uint32))
+
+
+def test_array_depth_broadcasts_with_pixels():
+    depth = np.array([0, 1, 2, 10, 29], dtype=np.uint8)
+    face = np.array([0, 3, 7, 11, 5], dtype=np.uint8)
+    x = np.array([0, 1, 3, 1023, 2**29 - 1], dtype=np.uint32)
+    y = np.array([0, 0, 2, 17, 123_456_789], dtype=np.uint32)
+
+    pixels = nested.xyf2pix(face, x, y, depth)
+    actual = nested.pix2xyf(pixels, depth)
+
+    for component, expected in zip(actual, (face, x, y), strict=True):
+        np.testing.assert_array_equal(component, expected)
+
+
+@pytest.mark.parametrize(
+    ("face", "x", "y", "depth", "message"),
+    [
+        (-1, 0, 0, 1, "Face"),
+        (12, 0, 0, 1, "Face"),
+        (0, -1, 0, 1, "x"),
+        (0, 2, 0, 1, "x"),
+        (0, 0, -1, 1, "y"),
+        (0, 0, 2, 1, "y"),
+    ],
+)
+def test_xyf2pix_rejects_invalid_coordinates(face, x, y, depth, message):
+    with pytest.raises(ValueError, match=message):
+        nested.xyf2pix(face, x, y, depth)
+
+
+@pytest.mark.parametrize("depth", [-1, 30])
+def test_topology_rejects_invalid_depth(depth):
+    with pytest.raises(ValueError, match="Depth"):
+        nested.pix2xyf([0], depth)
+    with pytest.raises(ValueError, match="Depth"):
+        nested.xyf2pix([0], [0], [0], depth)
+
+
+def test_pix2xyf_rejects_invalid_cell_id():
+    with pytest.raises(ValueError, match="out of"):
+        nested.pix2xyf([48], 1)
+
+
+def test_matches_healpy_reference():
+    healpy = pytest.importorskip("healpy")
+    rng = np.random.default_rng(234243)
+
+    for depth in (0, 1, 2, 7, 14, 29):
+        nside = 2**depth
+        npix = 12 * nside**2
+        pixels = rng.integers(0, npix, size=256, dtype=np.uint64)
+
+        face, x, y = nested.pix2xyf(pixels, depth)
+        expected_x, expected_y, expected_face = healpy.pix2xyf(
+            nside, pixels.astype(np.int64), nest=True
+        )
+
+        np.testing.assert_array_equal(face, expected_face)
+        np.testing.assert_array_equal(x, expected_x)
+        np.testing.assert_array_equal(y, expected_y)
+        np.testing.assert_array_equal(
+            nested.xyf2pix(face, x, y, depth),
+            healpy.xyf2pix(
+                nside,
+                x.astype(np.int64),
+                y.astype(np.int64),
+                face.astype(np.int64),
+                nest=True,
+            ),
+        )

--- a/python/healpix-geo/python/healpix_geo/tests/test_topology.py
+++ b/python/healpix-geo/python/healpix_geo/tests/test_topology.py
@@ -54,6 +54,12 @@ def test_face_neighbour_transform_rejects_invalid_face(face):
         nested.face_neighbour_transform(face, "N")
 
 
+@pytest.mark.parametrize("face", ["0", 0.0, [0]])
+def test_face_neighbour_transform_rejects_non_integer_face(face):
+    with pytest.raises(TypeError, match="face must be an integer"):
+        nested.face_neighbour_transform(face, "N")
+
+
 def test_face_neighbour_transform_rejects_invalid_direction():
     with pytest.raises(ValueError, match="direction"):
         nested.face_neighbour_transform(0, "up")

--- a/python/healpix-geo/src/indexing_schemes/nested/mod.rs
+++ b/python/healpix-geo/src/indexing_schemes/nested/mod.rs
@@ -4,6 +4,7 @@ mod coverage;
 mod hierarchy;
 mod mesh;
 mod sets;
+mod topology;
 
 pub(crate) use self::conversion::{to_ring, to_zuniq};
 pub(crate) use self::coordinates::{
@@ -16,3 +17,4 @@ pub(crate) use self::coverage::{
 pub(crate) use self::hierarchy::{kth_neighbourhood, kth_neighbours, siblings, zoom_to};
 pub(crate) use self::mesh::vertex_indices;
 pub(crate) use self::sets::internal_boundary;
+pub(crate) use self::topology::{face_neighbour_transform, pix2xyf, xyf2pix};

--- a/python/healpix-geo/src/indexing_schemes/nested/topology.rs
+++ b/python/healpix-geo/src/indexing_schemes/nested/topology.rs
@@ -1,0 +1,113 @@
+use numpy::{PyArray1, PyArrayDyn, PyArrayMethods, PyUntypedArrayMethods};
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+use cdshealpix::compass_point::MainWind;
+use healpix_geo_core::vectorized::nested::topology as vectorized;
+
+use crate::indexing_schemes::depth::DepthLike;
+
+#[pyfunction]
+pub(crate) fn face_neighbour_transform(
+    face: u8,
+    direction: &str,
+) -> PyResult<Option<(u8, bool, bool, bool)>> {
+    if face >= 12 {
+        return Err(PyValueError::new_err(
+            "face must be in the [0, 11] closed range",
+        ));
+    }
+    let direction = match direction.to_ascii_uppercase().as_str() {
+        "N" => MainWind::N,
+        "NE" => MainWind::NE,
+        "E" => MainWind::E,
+        "SE" => MainWind::SE,
+        "S" => MainWind::S,
+        "SW" => MainWind::SW,
+        "W" => MainWind::W,
+        "NW" => MainWind::NW,
+        _ => {
+            return Err(PyValueError::new_err(
+                "direction must be one of N, NE, E, SE, S, SW, W, or NW",
+            ));
+        }
+    };
+
+    Ok(
+        vectorized::face_neighbour_transform(face, direction).map(|transform| {
+            (
+                transform.target_face,
+                transform.swap_xy,
+                transform.flip_x,
+                transform.flip_y,
+            )
+        }),
+    )
+}
+
+#[allow(clippy::type_complexity)]
+#[pyfunction]
+pub(crate) fn pix2xyf<'py>(
+    py: Python<'py>,
+    nested: &Bound<'py, PyArrayDyn<u64>>,
+    depth: DepthLike,
+    nthreads: u16,
+) -> PyResult<(
+    Bound<'py, PyArrayDyn<u8>>,
+    Bound<'py, PyArrayDyn<u32>>,
+    Bound<'py, PyArrayDyn<u32>>,
+)> {
+    let input_shape = nested.shape();
+    let flattened = nested.reshape([nested.len()])?;
+    let flattened = flattened.readonly();
+    let depth = depth.as_depth()?;
+
+    let (face, x, y) = vectorized::pix2xyf(flattened.as_slice()?, depth, nthreads as usize);
+
+    Ok((
+        PyArray1::from_vec(py, face)
+            .reshape(input_shape)?
+            .to_dyn()
+            .clone(),
+        PyArray1::from_vec(py, x)
+            .reshape(input_shape)?
+            .to_dyn()
+            .clone(),
+        PyArray1::from_vec(py, y)
+            .reshape(input_shape)?
+            .to_dyn()
+            .clone(),
+    ))
+}
+
+#[pyfunction]
+pub(crate) fn xyf2pix<'py>(
+    py: Python<'py>,
+    face: &Bound<'py, PyArrayDyn<u8>>,
+    x: &Bound<'py, PyArrayDyn<u32>>,
+    y: &Bound<'py, PyArrayDyn<u32>>,
+    depth: DepthLike,
+    nthreads: u16,
+) -> PyResult<Bound<'py, PyArrayDyn<u64>>> {
+    let input_shape = face.shape();
+    let face = face.reshape([face.len()])?;
+    let x = x.reshape([x.len()])?;
+    let y = y.reshape([y.len()])?;
+    let face = face.readonly();
+    let x = x.readonly();
+    let y = y.readonly();
+    let depth = depth.as_depth()?;
+
+    let nested = vectorized::xyf2pix(
+        face.as_slice()?,
+        x.as_slice()?,
+        y.as_slice()?,
+        depth,
+        nthreads as usize,
+    );
+
+    Ok(PyArray1::from_vec(py, nested)
+        .reshape(input_shape)?
+        .to_dyn()
+        .clone())
+}

--- a/python/healpix-geo/src/lib.rs
+++ b/python/healpix-geo/src/lib.rs
@@ -16,9 +16,10 @@ mod nested {
     #[pymodule_export]
     use crate::indexing_schemes::nested::{
         angular_distances, bilinear_interpolation, box_coverage, cartesian_to_healpix,
-        cone_coverage, elliptical_cone_coverage, healpix_to_cartesian, healpix_to_lonlat,
-        internal_boundary, kth_neighbourhood, kth_neighbours, lonlat_to_healpix, polygon_coverage,
-        siblings, to_ring, to_zuniq, vertex_indices, vertices, zone_coverage, zoom_to,
+        cone_coverage, elliptical_cone_coverage, face_neighbour_transform, healpix_to_cartesian,
+        healpix_to_lonlat, internal_boundary, kth_neighbourhood, kth_neighbours, lonlat_to_healpix,
+        pix2xyf, polygon_coverage, siblings, to_ring, to_zuniq, vertex_indices, vertices, xyf2pix,
+        zone_coverage, zoom_to,
     };
 }
 

--- a/rust/healpix-geo-core/src/vectorized/nested/mod.rs
+++ b/rust/healpix-geo-core/src/vectorized/nested/mod.rs
@@ -4,3 +4,4 @@ pub mod coverage;
 pub mod distances;
 pub mod hierarchy;
 pub mod mesh;
+pub mod topology;

--- a/rust/healpix-geo-core/src/vectorized/nested/topology.rs
+++ b/rust/healpix-geo-core/src/vectorized/nested/topology.rs
@@ -1,0 +1,217 @@
+//! Integer-only topology operations for NESTED cells.
+
+#[cfg(not(target_arch = "wasm32"))]
+use rayon::prelude::*;
+
+use cdshealpix::compass_point::MainWind;
+use cdshealpix::nested::get;
+use cdshealpix::nested::zordercurve::get_zoc;
+
+use crate::maybe_parallelize;
+use crate::vectorized::depth::Depth;
+
+#[inline]
+fn pix2xyf_scalar(hash: u64, depth: u8) -> (u8, u32, u32) {
+    let twice_depth = depth << 1;
+    let zoc = get_zoc(depth);
+    let ij = zoc.h2ij(hash & ((1_u64 << twice_depth) - 1));
+    ((hash >> twice_depth) as u8, zoc.ij2i(ij), zoc.ij2j(ij))
+}
+
+#[inline]
+fn xyf2pix_scalar(face: u8, x: u32, y: u32, depth: u8) -> u64 {
+    ((face as u64) << (depth << 1)) | get_zoc(depth).ij2h(x, y)
+}
+
+/// The target base face and its orientation relative to the source face.
+///
+/// The booleans describe an array transform applied in this order: swap the
+/// axes, then reverse the target x and/or y axis. Translation is intentionally
+/// omitted because it depends on the coordinate extent used by the caller.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FaceTransform {
+    pub target_face: u8,
+    pub swap_xy: bool,
+    pub flip_x: bool,
+    pub flip_y: bool,
+}
+
+/// Return the canonical orientation of a neighbouring HEALPix base face.
+///
+/// `None` means that the base face has no distinct neighbour in that direction.
+/// The result is derived from `cdshealpix`'s coordinate transform instead of a
+/// separately maintained adjacency or orientation table.
+pub fn face_neighbour_transform(face: u8, direction: MainWind) -> Option<FaceTransform> {
+    if face >= 12 || direction == MainWind::C {
+        return None;
+    }
+
+    // Any depth >= 1 is sufficient: the affine transform has the same signed
+    // permutation at every depth. Sampling its basis vectors avoids duplicating
+    // the canonical face-orientation rules implemented by cdshealpix.
+    let layer = get(1);
+    let (target_face, origin_x, origin_y) =
+        layer.to_neighbour_base_cell_coo(face, 0, 0, direction)?;
+    let (target_x, x_axis_x, x_axis_y) = layer.to_neighbour_base_cell_coo(face, 1, 0, direction)?;
+    let (target_y, y_axis_x, y_axis_y) = layer.to_neighbour_base_cell_coo(face, 0, 1, direction)?;
+    debug_assert_eq!(target_face, target_x);
+    debug_assert_eq!(target_face, target_y);
+
+    let dx = (x_axis_x - origin_x, x_axis_y - origin_y);
+    let dy = (y_axis_x - origin_x, y_axis_y - origin_y);
+    debug_assert!(matches!(dx, (1 | -1, 0) | (0, 1 | -1)));
+    debug_assert!(matches!(dy, (1 | -1, 0) | (0, 1 | -1)));
+
+    let swap_xy = dx.1 != 0;
+    let (flip_x, flip_y) = if swap_xy {
+        (dy.0 < 0, dx.1 < 0)
+    } else {
+        (dx.0 < 0, dy.1 < 0)
+    };
+
+    Some(FaceTransform {
+        target_face,
+        swap_xy,
+        flip_x,
+        flip_y,
+    })
+}
+
+/// Split NESTED cell indexes into base-face-local coordinates.
+///
+/// Inputs are assumed to have already been validated. The returned vectors have
+/// the same length and contain `(face, x, y)` components in matching order.
+pub fn pix2xyf(ipix: &[u64], depth: Depth, nthreads: usize) -> (Vec<u8>, Vec<u32>, Vec<u32>) {
+    let mut result = Vec::<(u8, u32, u32)>::with_capacity(ipix.len());
+
+    match depth {
+        Depth::Scalar(depth) => {
+            maybe_parallelize!(nthreads, ipix, result, |hash| pix2xyf_scalar(*hash, *depth));
+        }
+        Depth::Array(depths) => {
+            let zipped: Vec<_> = ipix.iter().zip(depths.iter()).collect();
+            maybe_parallelize!(nthreads, zipped, result, |(hash, depth)| {
+                pix2xyf_scalar(**hash, **depth)
+            });
+        }
+    }
+
+    let mut face = Vec::with_capacity(result.len());
+    let mut x = Vec::with_capacity(result.len());
+    let mut y = Vec::with_capacity(result.len());
+    for (face_value, x_value, y_value) in result {
+        face.push(face_value);
+        x.push(x_value);
+        y.push(y_value);
+    }
+    (face, x, y)
+}
+
+/// Combine base faces and face-local coordinates into NESTED cell indexes.
+///
+/// Inputs are assumed to have equal lengths and to have already been validated.
+pub fn xyf2pix(face: &[u8], x: &[u32], y: &[u32], depth: Depth, nthreads: usize) -> Vec<u64> {
+    let inputs: Vec<_> = face.iter().zip(x.iter()).zip(y.iter()).collect();
+    let mut result = Vec::<u64>::with_capacity(face.len());
+
+    match depth {
+        Depth::Scalar(depth) => {
+            maybe_parallelize!(nthreads, inputs, result, |((face, x), y)| {
+                xyf2pix_scalar(**face, **x, **y, *depth)
+            });
+        }
+        Depth::Array(depths) => {
+            let inputs: Vec<_> = inputs.iter().zip(depths.iter()).collect();
+            maybe_parallelize!(nthreads, inputs, result, |(((face, x), y), depth)| {
+                xyf2pix_scalar(**face, **x, **y, **depth)
+            });
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cdshealpix::compass_point::MainWind::{E, N, NE, NW, S, SE, SW, W};
+
+    #[test]
+    fn exhaustive_small_depth_round_trips() {
+        for depth in 0..=5 {
+            let npix = 12_u64 << (depth << 1);
+            let pixels: Vec<_> = (0..npix).collect();
+            let (face, x, y) = pix2xyf(&pixels, Depth::Scalar(&depth), 1);
+            let actual = xyf2pix(&face, &x, &y, Depth::Scalar(&depth), 1);
+            assert_eq!(actual, pixels);
+        }
+    }
+
+    #[test]
+    fn level_zero_is_the_base_face() {
+        let pixels: Vec<_> = (0..12).collect();
+        let depth = 0;
+        let (face, x, y) = pix2xyf(&pixels, Depth::Scalar(&depth), 1);
+        assert_eq!(face, (0..12).collect::<Vec<_>>());
+        assert_eq!(x, vec![0; 12]);
+        assert_eq!(y, vec![0; 12]);
+        assert_eq!(xyf2pix(&face, &x, &y, Depth::Scalar(&depth), 1), pixels);
+    }
+
+    #[test]
+    fn supports_per_cell_depths() {
+        let depths = [0, 1, 2, 10, 29];
+        let face = [0, 3, 7, 11, 5];
+        let x = [0, 1, 3, 1023, (1 << 29) - 1];
+        let y = [0, 0, 2, 17, 123_456_789];
+        let pixels = xyf2pix(&face, &x, &y, Depth::Array(&depths), 1);
+        let actual = pix2xyf(&pixels, Depth::Array(&depths), 1);
+        assert_eq!(actual, (face.to_vec(), x.to_vec(), y.to_vec()));
+    }
+
+    #[test]
+    fn face_transforms_match_cdshealpix_for_every_face_and_direction() {
+        let directions = [N, NE, E, SE, S, SW, W, NW];
+        let layer = get(2);
+
+        for face in 0..12 {
+            for direction in directions {
+                let actual = face_neighbour_transform(face, direction);
+                let expected_face = cdshealpix::neighbour(face, direction);
+                assert_eq!(actual.map(|transform| transform.target_face), expected_face);
+
+                let Some(transform) = actual else {
+                    continue;
+                };
+
+                let raw: Vec<_> = (0..4)
+                    .flat_map(|x| {
+                        (0..4).map(move |y| {
+                            layer
+                                .to_neighbour_base_cell_coo(face, x, y, direction)
+                                .unwrap()
+                        })
+                    })
+                    .collect();
+                let min_x = raw.iter().map(|(_, x, _)| *x).min().unwrap();
+                let min_y = raw.iter().map(|(_, _, y)| *y).min().unwrap();
+
+                for (index, (target_face, raw_x, raw_y)) in raw.into_iter().enumerate() {
+                    let x = (index / 4) as i32;
+                    let y = (index % 4) as i32;
+                    let (mut expected_x, mut expected_y) =
+                        if transform.swap_xy { (y, x) } else { (x, y) };
+                    if transform.flip_x {
+                        expected_x = 3 - expected_x;
+                    }
+                    if transform.flip_y {
+                        expected_y = 3 - expected_y;
+                    }
+
+                    assert_eq!(target_face, transform.target_face);
+                    assert_eq!((raw_x - min_x, raw_y - min_y), (expected_x, expected_y));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Title: Add NESTED face/xy topology primitives

## Summary

- add vectorized `nested.pix2xyf()` and `nested.xyf2pix()` APIs
- add `nested.face_neighbour_transform()` for canonical base-face adjacency and orientation
- support scalar, multidimensional, and broadcast NumPy inputs
- validate depths, cell IDs, faces, and face-local coordinates

## Implementation

The conversion functions reuse the existing `cds-healpix-rust` NESTED Z-order implementation through `get_zoc()`. No separate Morton codec or geographic conversion is introduced.

Face transforms are derived from `cds-healpix-rust`’s canonical `Layer::to_neighbour_base_cell_coo()` machinery. The public result contains:

- target face
- whether to swap x/y
- whether to flip the target x axis
- whether to flip the target y axis

## Testing

- exhaustive pixel round trips for depths 0 through 5
- representative per-cell depths through depth 29
- all 12 base faces and all eight directions
- scalar, multidimensional, broadcasting, dtype, and invalid-input cases
- independent cross-checks against `healpy.pix2xyf()` and `healpy.xyf2pix()`
- full Rust and Python regression suites

Closes #243.