### PR TITLE
Add direction-preserving NESTED neighbours

### DIFF
--- a/python/healpix-geo/docs/api/nested.rst
+++ b/python/healpix-geo/docs/api/nested.rst
@@ -51,6 +51,7 @@ Navigation in the hierarchical structure of HEALPix.
 
    kth_neighbours
    kth_neighbourhood
+   neighbours
    zoom_to
    siblings
 

--- a/python/healpix-geo/python/healpix_geo/nested.py
+++ b/python/healpix-geo/python/healpix_geo/nested.py
@@ -593,9 +593,7 @@ def neighbours(
     ipix = ipix.astype(np.uint64)
 
     num_threads = np.uint16(num_threads)
-    return healpix_geo.nested.neighbours(
-        depth, ipix, connectivity, num_threads
-    )
+    return healpix_geo.nested.neighbours(depth, ipix, connectivity, num_threads)
 
 
 def kth_neighbours(ipix, depth, ring, num_threads=0):

--- a/python/healpix-geo/python/healpix_geo/nested.py
+++ b/python/healpix-geo/python/healpix_geo/nested.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import marray
 import numpy as np
@@ -549,6 +549,53 @@ def bilinear_interpolation(
     mask = weights == 0
 
     return xp.asarray(ipix, mask=mask), xp.asarray(weights, mask=mask)
+
+
+def neighbours(
+    ipix,
+    depth,
+    *,
+    connectivity: Literal["edge", "edge_or_vertex"] = "edge_or_vertex",
+    num_threads=0,
+):
+    """Get direction-preserving immediate neighbours of NESTED HEALPix cells.
+
+    Parameters
+    ----------
+    ipix : `numpy.ndarray`
+        The NESTED HEALPix cell indexes.
+    depth : int
+        The depth of the HEALPix cells.
+    connectivity : {"edge", "edge_or_vertex"}, optional
+        ``"edge"`` returns the four edge-sharing neighbours in ``SW, NW,
+        NE, SE`` order. ``"edge_or_vertex"`` returns all eight directional
+        positions in ``SW, W, NW, N, NE, E, SE, S`` order.
+    num_threads : int, optional
+        Number of threads. The default, 0, uses the Rayon global thread pool
+        for sufficiently large inputs and a sequential path for small inputs.
+
+    Returns
+    -------
+    neighbours : `numpy.ndarray`
+        An ``np.int64`` array with shape ``ipix.shape + (4,)`` for edge
+        connectivity or ``ipix.shape + (8,)`` for edge-or-vertex
+        connectivity. Scalar inputs are normalized to one-dimensional input,
+        producing shape ``(1, 4)`` or ``(1, 8)``. Missing directional
+        positions are represented by ``-1`` and never shift other positions.
+    """
+    _check_depth(depth)
+
+    if connectivity not in ("edge", "edge_or_vertex"):
+        raise ValueError("connectivity must be 'edge' or 'edge_or_vertex'")
+
+    ipix = np.atleast_1d(ipix)
+    _check_ipixels(data=ipix, depth=depth)
+    ipix = ipix.astype(np.uint64)
+
+    num_threads = np.uint16(num_threads)
+    return healpix_geo.nested.neighbours(
+        depth, ipix, connectivity, num_threads
+    )
 
 
 def kth_neighbours(ipix, depth, ring, num_threads=0):

--- a/python/healpix-geo/python/healpix_geo/tests/test_neighbours.py
+++ b/python/healpix-geo/python/healpix_geo/tests/test_neighbours.py
@@ -320,3 +320,150 @@ def test_kth_neighbours(depth, cell_ids, ring, indexing_scheme, expected):
     actual = func(cell_ids)
     print(repr(actual))
     np.testing.assert_equal(actual, expected)
+
+
+@pytest.mark.parametrize(
+    ("connectivity", "expected"),
+    [
+        pytest.param(
+            "edge",
+            np.array([[111, 21, 43, 40]], dtype="int64"),
+            id="edge",
+        ),
+        pytest.param(
+            "edge_or_vertex",
+            np.array(
+                [[111, -1, 21, 23, 43, 41, 40, 109]],
+                dtype="int64",
+            ),
+            id="edge-or-vertex",
+        ),
+    ],
+)
+def test_direction_preserving_neighbours(connectivity, expected):
+    actual = healpix_geo.nested.neighbours(
+        np.array([42], dtype="uint64"),
+        depth=2,
+        connectivity=connectivity,
+        num_threads=1,
+    )
+
+    np.testing.assert_equal(actual, expected)
+    assert actual.flags.c_contiguous
+
+
+@pytest.mark.parametrize(
+    ("connectivity", "width"),
+    [
+        pytest.param("edge", 4, id="edge"),
+        pytest.param("edge_or_vertex", 8, id="edge-or-vertex"),
+    ],
+)
+def test_neighbours_preserves_input_shape(connectivity, width):
+    cells = np.array([[42, 43], [44, 45]], dtype="uint64")
+
+    result = healpix_geo.nested.neighbours(
+        cells,
+        depth=2,
+        connectivity=connectivity,
+    )
+
+    assert result.shape == cells.shape + (width,)
+    assert result.dtype == np.dtype("int64")
+    assert result.flags.c_contiguous
+
+
+@pytest.mark.parametrize(
+    ("connectivity", "width"),
+    [
+        pytest.param("edge", 4, id="edge"),
+        pytest.param("edge_or_vertex", 8, id="edge-or-vertex"),
+    ],
+)
+def test_neighbours_scalar_and_empty_shapes(connectivity, width):
+    scalar = healpix_geo.nested.neighbours(
+        42,
+        depth=2,
+        connectivity=connectivity,
+    )
+    empty = healpix_geo.nested.neighbours(
+        np.array([], dtype="uint64"),
+        depth=2,
+        connectivity=connectivity,
+    )
+
+    assert scalar.shape == (1, width)
+    assert empty.shape == (0, width)
+    assert scalar.flags.c_contiguous
+    assert empty.flags.c_contiguous
+
+
+def test_neighbours_rejects_invalid_connectivity():
+    with pytest.raises(
+        ValueError,
+        match="connectivity must be 'edge' or 'edge_or_vertex'",
+    ):
+        healpix_geo.nested.neighbours(
+            np.array([42], dtype="uint64"),
+            depth=2,
+            connectivity="invalid",
+        )
+
+
+@pytest.mark.parametrize("depth", range(6))
+def test_edge_neighbour_topology_for_every_cell(depth):
+    cells = np.arange(12 * 4**depth, dtype="uint64")
+    edge = healpix_geo.nested.neighbours(
+        cells,
+        depth=depth,
+        connectivity="edge",
+    )
+    full = healpix_geo.nested.neighbours(
+        cells,
+        depth=depth,
+        connectivity="edge_or_vertex",
+    )
+
+    assert edge.shape == (cells.size, 4)
+    assert np.all(edge >= 0)
+    assert np.all(edge < cells.size)
+
+    # Each edge neighbour must be present in the full neighbourhood.
+    assert np.all(np.any(edge[:, :, None] == full[:, None, :], axis=2))
+
+    # Edge adjacency is symmetric for every cell, including singularities.
+    for direction in range(edge.shape[1]):
+        neighbour_rows = edge[edge[:, direction]]
+        assert np.all(np.any(neighbour_rows == cells[:, None], axis=1))
+
+    valid_full_count = np.count_nonzero(full >= 0, axis=1)
+    if depth == 0:
+        assert np.all(valid_full_count == 6)
+    else:
+        assert np.all((valid_full_count == 7) | (valid_full_count == 8))
+
+
+def test_neighbours_threading_paths_agree():
+    cells = np.arange(12_000, dtype="uint64")
+
+    sequential = healpix_geo.nested.neighbours(
+        cells,
+        depth=5,
+        connectivity="edge_or_vertex",
+        num_threads=1,
+    )
+    automatic = healpix_geo.nested.neighbours(
+        cells,
+        depth=5,
+        connectivity="edge_or_vertex",
+        num_threads=0,
+    )
+    explicit_parallel = healpix_geo.nested.neighbours(
+        cells,
+        depth=5,
+        connectivity="edge_or_vertex",
+        num_threads=2,
+    )
+
+    np.testing.assert_equal(automatic, sequential)
+    np.testing.assert_equal(explicit_parallel, sequential)

--- a/python/healpix-geo/src/indexing_schemes/nested/hierarchy.rs
+++ b/python/healpix-geo/src/indexing_schemes/nested/hierarchy.rs
@@ -1,8 +1,45 @@
 use cdshealpix as healpix;
 use numpy::{PyArray1, PyArray2, PyArrayDyn, PyArrayMethods, PyUntypedArrayMethods};
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 use healpix_geo_core::vectorized::nested::hierarchy as vectorized;
+
+/// Return immediate neighbours in fixed directional positions.
+#[pyfunction]
+pub(crate) fn neighbours<'py>(
+    py: Python<'py>,
+    depth: u8,
+    ipix: &Bound<'py, PyArrayDyn<u64>>,
+    connectivity: &str,
+    nthreads: u16,
+) -> PyResult<Bound<'py, PyArrayDyn<i64>>> {
+    let input_shape = ipix.shape();
+    let ipix_ = ipix.readonly();
+    let layer = healpix::nested::get(depth);
+
+    let directions = match connectivity {
+        "edge" => &healpix_geo_core::scalar::nested::hierarchy::EDGE_DIRECTIONS[..],
+        "edge_or_vertex" => {
+            &healpix_geo_core::scalar::nested::hierarchy::EDGE_OR_VERTEX_DIRECTIONS[..]
+        }
+        _ => {
+            return Err(PyValueError::new_err(
+                "connectivity must be 'edge' or 'edge_or_vertex'",
+            ));
+        }
+    };
+
+    let result = vectorized::neighbours(ipix_.as_slice()?, layer, directions, nthreads as usize);
+
+    let output_shape: Vec<usize> = input_shape
+        .iter()
+        .copied()
+        .chain([directions.len()])
+        .collect();
+
+    PyArray1::from_vec(py, result).reshape(output_shape.as_slice())
+}
 
 /// Wrapper of `kth_neighbours`
 #[pyfunction]

--- a/python/healpix-geo/src/indexing_schemes/nested/mod.rs
+++ b/python/healpix-geo/src/indexing_schemes/nested/mod.rs
@@ -13,6 +13,8 @@ pub(crate) use self::coordinates::{
 pub(crate) use self::coverage::{
     box_coverage, cone_coverage, elliptical_cone_coverage, polygon_coverage, zone_coverage,
 };
-pub(crate) use self::hierarchy::{kth_neighbourhood, kth_neighbours, siblings, zoom_to};
+pub(crate) use self::hierarchy::{
+    kth_neighbourhood, kth_neighbours, neighbours, siblings, zoom_to,
+};
 pub(crate) use self::mesh::vertex_indices;
 pub(crate) use self::sets::internal_boundary;

--- a/python/healpix-geo/src/lib.rs
+++ b/python/healpix-geo/src/lib.rs
@@ -17,8 +17,9 @@ mod nested {
     use crate::indexing_schemes::nested::{
         angular_distances, bilinear_interpolation, box_coverage, cartesian_to_healpix,
         cone_coverage, elliptical_cone_coverage, healpix_to_cartesian, healpix_to_lonlat,
-        internal_boundary, kth_neighbourhood, kth_neighbours, lonlat_to_healpix, polygon_coverage,
-        siblings, to_ring, to_zuniq, vertex_indices, vertices, zone_coverage, zoom_to,
+        internal_boundary, kth_neighbourhood, kth_neighbours, lonlat_to_healpix, neighbours,
+        polygon_coverage, siblings, to_ring, to_zuniq, vertex_indices, vertices, zone_coverage,
+        zoom_to,
     };
 }
 

--- a/rust/healpix-geo-core/src/scalar/nested/hierarchy.rs
+++ b/rust/healpix-geo-core/src/scalar/nested/hierarchy.rs
@@ -1,4 +1,33 @@
-use cdshealpix::nested::Layer;
+use cdshealpix::{compass_point::MainWind, nested::Layer};
+
+pub const EDGE_DIRECTIONS: [MainWind; 4] = [MainWind::SW, MainWind::NW, MainWind::NE, MainWind::SE];
+
+pub const EDGE_OR_VERTEX_DIRECTIONS: [MainWind; 8] = [
+    MainWind::SW,
+    MainWind::W,
+    MainWind::NW,
+    MainWind::N,
+    MainWind::NE,
+    MainWind::E,
+    MainWind::SE,
+    MainWind::S,
+];
+
+/// Write immediate neighbours into fixed directional positions.
+///
+/// Missing directions are represented by `-1`. Unlike `kth_neighbours`,
+/// this function never compacts the remaining values when a direction is
+/// missing.
+pub fn write_neighbours(hash: &u64, layer: &Layer, directions: &[MainWind], output: &mut [i64]) {
+    debug_assert_eq!(directions.len(), output.len());
+
+    let neighbours = layer.neighbours(*hash, false);
+    for (value, direction) in output.iter_mut().zip(directions) {
+        *value = neighbours
+            .get(*direction)
+            .map_or(-1, |neighbour| *neighbour as i64);
+    }
+}
 
 pub fn kth_neighbours(hash: &u64, layer: &Layer, ring: &u32) -> Vec<i64> {
     let r = *ring;
@@ -27,4 +56,29 @@ pub fn kth_neighbourhood(hash: &u64, layer: &Layer, ring: &u32) -> Vec<i64> {
     }
 
     neighbours
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_write_edge_neighbours() {
+        let layer = cdshealpix::nested::get(2);
+        let mut result = [-1; 4];
+
+        write_neighbours(&42, layer, &EDGE_DIRECTIONS, &mut result);
+
+        assert_eq!(result, [111, 21, 43, 40]);
+    }
+
+    #[test]
+    fn test_write_full_neighbours_preserves_missing_direction() {
+        let layer = cdshealpix::nested::get(2);
+        let mut result = [-1; 8];
+
+        write_neighbours(&42, layer, &EDGE_OR_VERTEX_DIRECTIONS, &mut result);
+
+        assert_eq!(result, [111, -1, 21, 23, 43, 41, 40, 109]);
+    }
 }

--- a/rust/healpix-geo-core/src/vectorized/nested/hierarchy.rs
+++ b/rust/healpix-geo-core/src/vectorized/nested/hierarchy.rs
@@ -2,10 +2,71 @@
 use rayon::prelude::*;
 
 use cdshealpix as healpix;
+use cdshealpix::compass_point::MainWind;
 use cdshealpix::nested::Layer;
 
 use crate::maybe_parallelize;
 use crate::scalar::nested::hierarchy as scalar;
+
+/// Below this size, creating or scheduling parallel work is generally more
+/// expensive than the immediate-neighbour calculation itself.
+const AUTO_PARALLEL_THRESHOLD: usize = 32_768;
+
+/// Return immediate neighbours without losing their directional positions.
+///
+/// The result is a flat row-major buffer with `directions.len()` values per
+/// input cell. Missing positions are represented by `-1`.
+pub fn neighbours(
+    ipix: &[u64],
+    layer: &Layer,
+    directions: &[MainWind],
+    nthreads: usize,
+) -> Vec<i64> {
+    let width = directions.len();
+    debug_assert!(width > 0);
+
+    let mut result = vec![-1; ipix.len() * width];
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let write_parallel = |output: &mut [i64]| {
+            output
+                .par_chunks_mut(width)
+                .zip(ipix.par_iter())
+                .for_each(|(row, hash)| scalar::write_neighbours(hash, layer, directions, row));
+        };
+
+        match nthreads {
+            1 => result
+                .chunks_mut(width)
+                .zip(ipix)
+                .for_each(|(row, hash)| scalar::write_neighbours(hash, layer, directions, row)),
+            0 if ipix.len() < AUTO_PARALLEL_THRESHOLD => result
+                .chunks_mut(width)
+                .zip(ipix)
+                .for_each(|(row, hash)| scalar::write_neighbours(hash, layer, directions, row)),
+            0 => write_parallel(&mut result),
+            _ => {
+                let pool = rayon::ThreadPoolBuilder::new()
+                    .num_threads(nthreads)
+                    .build()
+                    .unwrap();
+                pool.install(|| write_parallel(&mut result));
+            }
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = nthreads;
+        result
+            .chunks_mut(width)
+            .zip(ipix)
+            .for_each(|(row, hash)| scalar::write_neighbours(hash, layer, directions, row));
+    }
+
+    result
+}
 
 pub fn kth_neighbours(ipix: &[u64], layer: &Layer, ring: &u32, nthreads: usize) -> Vec<Vec<i64>> {
     let mut result = Vec::<Vec<i64>>::with_capacity(ipix.len());


### PR DESCRIPTION
## Summary

Add a direction-preserving immediate-neighbour API for NESTED HEALPix cells.

```python
healpix_geo.nested.neighbours(
    ipix,
    depth,
    *,
    connectivity="edge_or_vertex",
    num_threads=0,
)
```

This provides the topology primitive needed to replace the temporary `healpy.get_all_neighbours(..., nest=True)` backend used by connected-component analysis in `healpix-analyse`.


Closes #246.
Related to #240.
Downstream use case: [GRID4EARTH/healpix-analyse#31](https://github.com/GRID4EARTH/healpix-analyse/pull/31), which currently uses `healpy.get_all_neighbours(..., nest=True)` as a temporary fallback.

## API

Two connectivity modes are supported:

### Edge

```python
connectivity="edge"
```

Returns four edge-sharing neighbours in deterministic order:

```text
SW, NW, NE, SE
```

The output shape is:

```text
ipix.shape + (4,)
```

### Edge or vertex

```python
connectivity="edge_or_vertex"
```

Returns all eight directional positions in deterministic order:

```text
SW, W, NW, N, NE, E, SE, S
```

The output shape is:

```text
ipix.shape + (8,)
```

Missing directional positions are represented by `-1` without shifting the remaining positions.

Scalar inputs are normalized consistently with the existing APIs and produce `(1, 4)` or `(1, 8)`. Multidimensional input shape is preserved. Output is C-contiguous `numpy.int64`.

## Implementation

The existing `kth_neighbours(..., ring=1)` result cannot safely be sliced by fixed columns because CDSHEALPix omits unavailable `MainWindMap` entries before `healpix-geo` adds trailing `-1` padding. At singularity cells, this compacts the remaining values and loses their directional positions.

The new implementation instead:

- calls CDSHEALPix `Layer::neighbours(hash, false)`;
- retrieves values with explicit `MainWind` keys;
- writes missing values as `-1` in their original directional slots;
- allocates one flat row-major `N × 4` or `N × 8` buffer;
- avoids per-cell `Vec` allocations and `Vec<Vec<i64>>`;
- uses a sequential path below 32,768 cells to avoid Rayon overhead;
- uses the global Rayon pool for larger inputs when `num_threads=0`;
- uses an explicit Rayon pool when a thread count greater than one is requested;
- reshapes the flat buffer only at the Python boundary.

## Correctness

During development, every cell at depths 0 through 6 was compared with:

```python
healpy.get_all_neighbours(
    nside,
    cells,
    nest=True,
)
```

The comparison checked exact directional positions for both connectivity modes, not only unordered neighbour sets.

All 65,532 cells matched exactly, including:

- all base pixels;
- base-pixel boundaries and corners;
- polar cells;
- singularity cells;
- missing full-neighbour directions.

The committed tests also cover:

- scalar, one-dimensional, multidimensional, and empty input;
- shape, dtype, and C-contiguous layout;
- deterministic direction order;
- invalid connectivity;
- four valid edge neighbours for every tested cell;
- symmetric edge adjacency;
- edge neighbours being a subset of the full neighbourhood;
- sequential, automatic, and explicit-thread results agreeing.

## Performance

Benchmark environment:

- macOS 26.4, arm64
- 18 logical CPUs
- Python 3.12
- NumPy 2.5.2
- healpy 1.20.0
- release build
- depth 12
- random valid NESTED cell IDs
- 9 repetitions
- median reported

The adapted healpy timing includes the direction selection, transpose, and C-contiguous copy required to produce the same output layout as this API and as the current `healpix-analyse` topology adapter.

| Cells | Connectivity | healpy adapted | Existing `kth_neighbours`, auto | New API, 1 thread | New API, auto |
|---:|---|---:|---:|---:|---:|
| 1,000 | edge | 0.029 ms | 0.606 ms | 0.022 ms | 0.022 ms |
| 1,000 | edge-or-vertex | 0.029 ms | 0.599 ms | 0.026 ms | 0.026 ms |
| 10,000 | edge | 0.276 ms | 1.154 ms | 0.161 ms | 0.161 ms |
| 10,000 | edge-or-vertex | 0.283 ms | 1.174 ms | 0.188 ms | 0.198 ms |
| 100,000 | edge | 4.891 ms | 5.407 ms | 1.874 ms | 1.148 ms |
| 100,000 | edge-or-vertex | 4.533 ms | 6.032 ms | 2.400 ms | 1.239 ms |
| 1,000,000 | edge | 32.728 ms | 49.716 ms | 17.580 ms | 4.188 ms |
| 1,000,000 | edge-or-vertex | 36.831 ms | 76.026 ms | 32.654 ms | 11.071 ms |

Compared with the adapted healpy path, the new automatic-threaded API is:

- 7.8x faster for one million edge-neighbour queries;
- 3.3x faster for one million edge-or-vertex queries.

Compared with the existing automatic-threaded `kth_neighbours` path at one million cells, it is:

- 11.9x faster for edge connectivity;
- 6.9x faster for edge-or-vertex connectivity.

## Test status

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Rust core: `80 passed`
- Python: `365 passed, 6 skipped`

The skipped Python tests are existing optional-environment tests and are unrelated to this change.

## Follow-up

After this API is released, `healpix-analyse._topology` can replace its temporary healpy backend without changing the public connected-component API.
