### PR TITLE
Promote integrated HEALPix APIs to main

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - "main"
+      - "integration"
   pull_request:
     branches:
       - "main"
+      - "integration"
   workflow_dispatch: # allows triggering manually
 
 concurrency:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -2,9 +2,9 @@ name: Rust CI
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "integration"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "integration"]
 
 concurrency:
   group: ${{ github.workflow }}.${{ github.ref }}

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -2,9 +2,9 @@ name: wasm
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "integration"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "integration"]
   release:
     types: ["published"]
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,6 +12,7 @@ on:
   pull_request:
     branches:
       - main
+      - integration
 
 permissions:
   contents: read

--- a/benchmarks/benchmark_cone_coverage_many.py
+++ b/benchmarks/benchmark_cone_coverage_many.py
@@ -1,0 +1,101 @@
+"""Compare scalar and batched nested cone coverage.
+
+The default workload models the 15,069-center Level-20 geometry construction
+observed in a roughly 600 m healpix-analyse Gaussian-filter patch. Run with:
+
+    python benchmarks/benchmark_cone_coverage_many.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import time
+
+import numpy as np
+
+from healpix_geo import nested
+
+
+def make_centers(count: int) -> np.ndarray:
+    side = math.ceil(math.sqrt(count))
+    # About one Level-20 cell (six metres) between centers near Paris.
+    spacing_lat = 6.0 / 111_320.0
+    spacing_lon = spacing_lat / math.cos(math.radians(48.86))
+    axis = np.arange(side, dtype=np.float64) - (side - 1) / 2
+    lon, lat = np.meshgrid(2.35 + axis * spacing_lon, 48.86 + axis * spacing_lat)
+    return np.column_stack((lon.ravel(), lat.ravel()))[:count]
+
+
+def timed(function):
+    start = time.perf_counter()
+    result = function()
+    return time.perf_counter() - start, result
+
+
+def assert_matches_scalar(scalar_rows, batched):
+    offsets, cell_ids, depths, fully_covered = batched
+    assert len(offsets) == len(scalar_rows) + 1
+    for index, expected in enumerate(scalar_rows):
+        start, end = offsets[index : index + 2]
+        np.testing.assert_array_equal(cell_ids[start:end], expected[0])
+        np.testing.assert_array_equal(depths[start:end], expected[1])
+        np.testing.assert_array_equal(fully_covered[start:end], expected[2])
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--count", type=int, default=15_069)
+    parser.add_argument("--depth", type=int, default=20)
+    parser.add_argument("--radius-metres", type=float, default=100.0)
+    args = parser.parse_args()
+
+    centers = make_centers(args.count)
+    radius_degrees = args.radius_metres / 111_320.0
+    kwargs = {"ellipsoid": "WGS84", "flat": True}
+
+    scalar_seconds, scalar_rows = timed(
+        lambda: [
+            nested.cone_coverage(center, radius_degrees, args.depth, **kwargs)
+            for center in centers
+        ]
+    )
+    one_thread_seconds, one_thread = timed(
+        lambda: nested.cone_coverage_many(
+            centers,
+            radius_degrees,
+            args.depth,
+            num_threads=1,
+            **kwargs,
+        )
+    )
+    eight_thread_seconds, eight_threads = timed(
+        lambda: nested.cone_coverage_many(
+            centers,
+            radius_degrees,
+            args.depth,
+            num_threads=8,
+            **kwargs,
+        )
+    )
+
+    assert_matches_scalar(scalar_rows, one_thread)
+    assert_matches_scalar(scalar_rows, eight_threads)
+
+    print(
+        f"centers: {args.count:,}; depth: {args.depth}; radius: {args.radius_metres:g} m"
+    )
+    print(f"scalar Python loop: {scalar_seconds:.6f} s")
+    print(
+        f"batch, one thread: {one_thread_seconds:.6f} s "
+        f"({scalar_seconds / one_thread_seconds:.2f}x)"
+    )
+    print(
+        f"batch, eight threads: {eight_thread_seconds:.6f} s "
+        f"({scalar_seconds / eight_thread_seconds:.2f}x)"
+    )
+    print("correctness: all batched rows exactly match scalar results")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/healpix-geo/docs/api/nested.rst
+++ b/python/healpix-geo/docs/api/nested.rst
@@ -31,6 +31,18 @@ Indexing Scheme Conversions
    to_ring
    to_zuniq
 
+Face-local Topology
+~~~~~~~~~~~~~~~~~~~
+
+Integer-only conversion and navigation within HEALPix base faces.
+
+.. autosummary::
+   :toctree: ../generated/
+
+   pix2xyf
+   xyf2pix
+   face_neighbour_transform
+
 Interpolation
 ~~~~~~~~~~~~~
 

--- a/python/healpix-geo/docs/api/nested.rst
+++ b/python/healpix-geo/docs/api/nested.rst
@@ -63,6 +63,7 @@ Navigation in the hierarchical structure of HEALPix.
 
    kth_neighbours
    kth_neighbourhood
+   neighbours
    zoom_to
    siblings
 

--- a/python/healpix-geo/docs/api/nested.rst
+++ b/python/healpix-geo/docs/api/nested.rst
@@ -82,6 +82,7 @@ Find all the cells which intersect a region.
    box_coverage
    polygon_coverage
    cone_coverage
+   cone_coverage_many
    elliptical_cone_coverage
    internal_boundary
 

--- a/python/healpix-geo/python/healpix_geo/nested.py
+++ b/python/healpix-geo/python/healpix_geo/nested.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Literal, NamedTuple
 
 import marray
 import numpy as np
@@ -710,6 +710,51 @@ def bilinear_interpolation(
     mask = weights == 0
 
     return xp.asarray(ipix, mask=mask), xp.asarray(weights, mask=mask)
+
+
+def neighbours(
+    ipix,
+    depth,
+    *,
+    connectivity: Literal["edge", "edge_or_vertex"] = "edge_or_vertex",
+    num_threads=0,
+):
+    """Get direction-preserving immediate neighbours of NESTED HEALPix cells.
+
+    Parameters
+    ----------
+    ipix : `numpy.ndarray`
+        The NESTED HEALPix cell indexes.
+    depth : int
+        The depth of the HEALPix cells.
+    connectivity : {"edge", "edge_or_vertex"}, optional
+        ``"edge"`` returns the four edge-sharing neighbours in ``SW, NW,
+        NE, SE`` order. ``"edge_or_vertex"`` returns all eight directional
+        positions in ``SW, W, NW, N, NE, E, SE, S`` order.
+    num_threads : int, optional
+        Number of threads. The default, 0, uses the Rayon global thread pool
+        for sufficiently large inputs and a sequential path for small inputs.
+
+    Returns
+    -------
+    neighbours : `numpy.ndarray`
+        An ``np.int64`` array with shape ``ipix.shape + (4,)`` for edge
+        connectivity or ``ipix.shape + (8,)`` for edge-or-vertex
+        connectivity. Scalar inputs are normalized to one-dimensional input,
+        producing shape ``(1, 4)`` or ``(1, 8)``. Missing directional
+        positions are represented by ``-1`` and never shift other positions.
+    """
+    _check_depth(depth)
+
+    if connectivity not in ("edge", "edge_or_vertex"):
+        raise ValueError("connectivity must be 'edge' or 'edge_or_vertex'")
+
+    ipix = np.atleast_1d(ipix)
+    _check_ipixels(data=ipix, depth=depth)
+    ipix = ipix.astype(np.uint64)
+
+    num_threads = np.uint16(num_threads)
+    return healpix_geo.nested.neighbours(depth, ipix, connectivity, num_threads)
 
 
 def kth_neighbours(ipix, depth, ring, num_threads=0):

--- a/python/healpix-geo/python/healpix_geo/nested.py
+++ b/python/healpix-geo/python/healpix_geo/nested.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 import marray
 import numpy as np
@@ -17,8 +17,169 @@ RangeMOCIndex = healpix_geo.nested.RangeMOCIndex
 internal_boundary = healpix_geo.nested.internal_boundary
 
 
+class FaceTransform(NamedTuple):
+    """Orientation of a neighbouring HEALPix base face.
+
+    Apply ``swap_xy`` first, then ``flip_x`` and ``flip_y`` to orient a
+    face-local array in the target face's coordinate frame.
+    """
+
+    target_face: int
+    swap_xy: bool
+    flip_x: bool
+    flip_y: bool
+
+
 def create_empty(depth):
     return RangeMOCIndex.empty(depth)
+
+
+def face_neighbour_transform(face, direction):
+    """Return the adjacent base face and relative coordinate orientation.
+
+    Parameters
+    ----------
+    face : int
+        Source base-face index in the closed range ``[0, 11]``.
+    direction : {"N", "NE", "E", "SE", "S", "SW", "W", "NW"}
+        HEALPix direction in the source face's local coordinate frame. Matching
+        is case-insensitive.
+
+    Returns
+    -------
+    `FaceTransform` or None
+        The target face and the axis swap/reversal required to orient source
+        coordinates in the target frame. ``None`` means the source base face
+        has no distinct neighbour in that direction.
+
+    Notes
+    -----
+    This operation accepts one face and direction because the transform is
+    constant for each face/direction pair and is independent of depth. Callers
+    should obtain it once and apply it to vectorized coordinate arrays. When
+    remapping an ``nside`` by ``nside`` array, swap axes first, then replace a
+    flipped coordinate ``v`` with ``nside - 1 - v``.
+
+    Examples
+    --------
+    >>> from healpix_geo.nested import face_neighbour_transform
+    >>> face_neighbour_transform(0, "N")
+    FaceTransform(target_face=2, swap_xy=False, flip_x=True, flip_y=True)
+    >>> face_neighbour_transform(4, "N") is None
+    True
+    """
+    if not isinstance(face, (int, np.integer)):
+        raise TypeError("face must be an integer")
+    if face < 0 or face > 11:
+        raise ValueError("Face must be in the [0, 11] closed range")
+    if not isinstance(direction, str):
+        raise TypeError("direction must be a string")
+
+    transform = healpix_geo.nested.face_neighbour_transform(np.uint8(face), direction)
+    return None if transform is None else FaceTransform(*transform)
+
+
+def pix2xyf(cell_ids, depth, num_threads=0):
+    """Convert NESTED cell indexes to base-face-local coordinates.
+
+    This is an integer-only topology operation. At ``depth``, each of the 12
+    base faces is a ``2**depth`` by ``2**depth`` grid. Array inputs are
+    broadcast against an array-valued ``depth`` and output shapes are
+    preserved.
+
+    Parameters
+    ----------
+    cell_ids : array-like of int
+        NESTED cell indexes.
+    depth : int or array-like of int
+        HEALPix depth in the closed range ``[0, 29]``.
+    num_threads : int, optional
+        Number of worker threads. Zero uses the Rayon default.
+
+    Returns
+    -------
+    face, x, y : tuple of `numpy.ndarray`
+        Base-face indexes as ``uint8`` and face-local coordinates as ``uint32``.
+
+    Examples
+    --------
+    >>> from healpix_geo.nested import pix2xyf
+    >>> pix2xyf([0, 3, 4, 47], 1)
+    (array([ 0,  0,  1, 11], dtype=uint8), array([0, 1, 0, 1], dtype=uint32), array([0, 1, 0, 1], dtype=uint32))
+    """
+    _check_depth(depth)
+    cell_ids = np.atleast_1d(cell_ids)
+
+    if isinstance(depth, int):
+        broadcast_depth = depth
+    else:
+        cell_ids, broadcast_depth = np.broadcast_arrays(cell_ids, np.asarray(depth))
+        broadcast_depth = np.ascontiguousarray(broadcast_depth, dtype=np.uint8)
+
+    _check_ipixels(data=cell_ids, depth=broadcast_depth)
+    cell_ids = np.ascontiguousarray(cell_ids, dtype=np.uint64)
+    num_threads = np.uint16(num_threads)
+
+    return healpix_geo.nested.pix2xyf(cell_ids, broadcast_depth, num_threads)
+
+
+def xyf2pix(face, x, y, depth, num_threads=0):
+    """Convert base-face-local coordinates to NESTED cell indexes.
+
+    ``face``, ``x``, ``y``, and an array-valued ``depth`` follow NumPy
+    broadcasting rules. Coordinates must lie inside the selected base face.
+
+    Parameters
+    ----------
+    face : array-like of int
+        Base-face indexes in the closed range ``[0, 11]``.
+    x, y : array-like of int
+        Face-local coordinates in ``[0, 2**depth - 1]``.
+    depth : int or array-like of int
+        HEALPix depth in the closed range ``[0, 29]``.
+    num_threads : int, optional
+        Number of worker threads. Zero uses the Rayon default.
+
+    Returns
+    -------
+    cell_ids : `numpy.ndarray`
+        NESTED cell indexes as ``uint64``.
+
+    Examples
+    --------
+    >>> from healpix_geo.nested import xyf2pix
+    >>> xyf2pix([0, 0, 1, 11], [0, 1, 0, 1], [0, 1, 0, 1], 1)
+    array([ 0,  3,  4, 47], dtype=uint64)
+    """
+    _check_depth(depth)
+    face = np.atleast_1d(face)
+    x = np.atleast_1d(x)
+    y = np.atleast_1d(y)
+
+    if isinstance(depth, int):
+        face, x, y = np.broadcast_arrays(face, x, y)
+        broadcast_depth = depth
+    else:
+        face, x, y, broadcast_depth = np.broadcast_arrays(face, x, y, np.asarray(depth))
+        broadcast_depth = np.ascontiguousarray(broadcast_depth, dtype=np.uint8)
+
+    if (face < 0).any() or (face > 11).any():
+        raise ValueError("Face must be in the [0, 11] closed range")
+
+    nside = 2 ** np.asarray(broadcast_depth, dtype=np.uint64)
+    if (x < 0).any() or (x >= nside).any():
+        raise ValueError("x must be in the [0, 2**depth - 1] closed range")
+    if (y < 0).any() or (y >= nside).any():
+        raise ValueError("y must be in the [0, 2**depth - 1] closed range")
+
+    num_threads = np.uint16(num_threads)
+    return healpix_geo.nested.xyf2pix(
+        np.ascontiguousarray(face, dtype=np.uint8),
+        np.ascontiguousarray(x, dtype=np.uint32),
+        np.ascontiguousarray(y, dtype=np.uint32),
+        broadcast_depth,
+        num_threads,
+    )
 
 
 def to_ring(

--- a/python/healpix-geo/python/healpix_geo/nested.py
+++ b/python/healpix-geo/python/healpix_geo/nested.py
@@ -1158,6 +1158,79 @@ def cone_coverage(
     )
 
 
+def cone_coverage_many(
+    centers,
+    radius,
+    depth,
+    *,
+    delta_depth=0,
+    ellipsoid="sphere",
+    flat=True,
+    num_threads=0,
+):
+    """Search the cells covering multiple cones.
+
+    This is the batched equivalent of :func:`cone_coverage`. Each row of the
+    result is identical to a scalar call for the corresponding center. Results
+    are returned in compressed sparse row (CSR) form because different cones
+    may cover different numbers of cells.
+
+    Parameters
+    ----------
+    centers : array-like of float
+        Cone centers as a two-dimensional ``(N, 2)`` array of longitude and
+        latitude pairs in degrees.
+    radius : float
+        Radius shared by all cones, in degrees.
+    depth : int
+        Maximum depth of the cells to return.
+    delta_depth : int, default: 0
+        Additional depth used by the approximate cone coverage algorithm.
+    ellipsoid : ellipsoid-like, default: "sphere"
+        Reference ellipsoid on which to evaluate HEALPix.
+    flat : bool, default: True
+        If ``True``, all returned cells are at ``depth``.
+    num_threads : int, default: 0
+        Number of native worker threads. Zero selects the available parallelism.
+        To keep automatic parallelism conservative, this operation uses at most
+        eight threads; larger values are clamped to eight.
+
+    Returns
+    -------
+    offsets : numpy.ndarray
+        Unsigned offsets with length ``N + 1``. The result for center ``i`` is
+        stored in ``offsets[i]:offsets[i + 1]`` in each following array.
+    cell_ids : numpy.ndarray
+        Concatenated nested HEALPix cell ids.
+    depths : numpy.ndarray
+        Concatenated depths of the returned cells.
+    fully_covered : numpy.ndarray
+        Concatenated flags marking fully covered cells.
+    """
+    _check_depth(depth)
+
+    centers = np.asarray(centers, dtype=np.float64)
+    if centers.ndim != 2 or centers.shape[1] != 2:
+        raise ValueError(
+            "centers must be a two-dimensional array with shape (N, 2), "
+            f"got {centers.shape}"
+        )
+    if num_threads < 0:
+        raise ValueError("num_threads must be non-negative")
+
+    centers = np.ascontiguousarray(centers)
+    num_threads = np.uint16(min(int(num_threads), 8))
+    return healpix_geo.nested.cone_coverage_many(
+        depth,
+        centers,
+        float(radius),
+        delta_depth=delta_depth,
+        ellipsoid=ellipsoid,
+        flat=flat,
+        nthreads=num_threads,
+    )
+
+
 def elliptical_cone_coverage(
     center,
     ellipse_geometry,

--- a/python/healpix-geo/python/healpix_geo/tests/test_coverage.py
+++ b/python/healpix-geo/python/healpix_geo/tests/test_coverage.py
@@ -808,6 +808,76 @@ def test_cone_coverage(scheme, expected_cell_ids, expected_depths, expected_cove
     np.testing.assert_equal(fully_covered, expected_coverage)
 
 
+@pytest.mark.parametrize("ellipsoid", ["sphere", "WGS84"])
+@pytest.mark.parametrize("flat", [True, False])
+@pytest.mark.parametrize("num_threads", [0, 1, 4, 32])
+def test_cone_coverage_many_matches_scalar(ellipsoid, flat, num_threads):
+    centers = np.array(
+        [
+            [45.0, 45.0],
+            [179.999, 0.0],
+            [-179.999, 0.0],
+            [12.0, 89.9],
+            [12.0, -89.9],
+        ]
+    )
+    radius = 0.5
+    depth = 8
+    delta_depth = 1
+
+    offsets, cell_ids, depths, fully_covered = healpix_geo.nested.cone_coverage_many(
+        centers,
+        radius,
+        depth,
+        ellipsoid=ellipsoid,
+        delta_depth=delta_depth,
+        flat=flat,
+        num_threads=num_threads,
+    )
+
+    assert offsets.dtype == np.dtype("uint64")
+    np.testing.assert_equal(offsets.shape, (len(centers) + 1,))
+    for index, center in enumerate(centers):
+        start, end = offsets[index : index + 2]
+        expected = healpix_geo.nested.cone_coverage(
+            center,
+            radius,
+            depth,
+            ellipsoid=ellipsoid,
+            delta_depth=delta_depth,
+            flat=flat,
+        )
+        np.testing.assert_array_equal(cell_ids[start:end], expected[0])
+        np.testing.assert_array_equal(depths[start:end], expected[1])
+        np.testing.assert_array_equal(fully_covered[start:end], expected[2])
+
+
+def test_cone_coverage_many_empty():
+    result = healpix_geo.nested.cone_coverage_many(
+        np.empty((0, 2)), 0.5, 8, ellipsoid="WGS84"
+    )
+
+    np.testing.assert_array_equal(result[0], np.array([0], dtype="uint64"))
+    for array in result[1:]:
+        assert array.size == 0
+
+
+@pytest.mark.parametrize(
+    "centers",
+    [np.array([45.0, 45.0]), np.empty((2, 3)), np.empty((2, 2, 1))],
+)
+def test_cone_coverage_many_rejects_invalid_centers(centers):
+    with pytest.raises(ValueError, match="shape \\(N, 2\\)"):
+        healpix_geo.nested.cone_coverage_many(centers, 0.5, 8)
+
+
+def test_cone_coverage_many_rejects_negative_threads():
+    with pytest.raises(ValueError, match="num_threads must be non-negative"):
+        healpix_geo.nested.cone_coverage_many(
+            np.array([[45.0, 45.0]]), 0.5, 8, num_threads=-1
+        )
+
+
 @pytest.mark.parametrize(
     ["scheme", "expected_cell_ids", "expected_depths", "expected_coverage"],
     (

--- a/python/healpix-geo/python/healpix_geo/tests/test_neighbours.py
+++ b/python/healpix-geo/python/healpix_geo/tests/test_neighbours.py
@@ -320,3 +320,150 @@ def test_kth_neighbours(depth, cell_ids, ring, indexing_scheme, expected):
     actual = func(cell_ids)
     print(repr(actual))
     np.testing.assert_equal(actual, expected)
+
+
+@pytest.mark.parametrize(
+    ("connectivity", "expected"),
+    [
+        pytest.param(
+            "edge",
+            np.array([[111, 21, 43, 40]], dtype="int64"),
+            id="edge",
+        ),
+        pytest.param(
+            "edge_or_vertex",
+            np.array(
+                [[111, -1, 21, 23, 43, 41, 40, 109]],
+                dtype="int64",
+            ),
+            id="edge-or-vertex",
+        ),
+    ],
+)
+def test_direction_preserving_neighbours(connectivity, expected):
+    actual = healpix_geo.nested.neighbours(
+        np.array([42], dtype="uint64"),
+        depth=2,
+        connectivity=connectivity,
+        num_threads=1,
+    )
+
+    np.testing.assert_equal(actual, expected)
+    assert actual.flags.c_contiguous
+
+
+@pytest.mark.parametrize(
+    ("connectivity", "width"),
+    [
+        pytest.param("edge", 4, id="edge"),
+        pytest.param("edge_or_vertex", 8, id="edge-or-vertex"),
+    ],
+)
+def test_neighbours_preserves_input_shape(connectivity, width):
+    cells = np.array([[42, 43], [44, 45]], dtype="uint64")
+
+    result = healpix_geo.nested.neighbours(
+        cells,
+        depth=2,
+        connectivity=connectivity,
+    )
+
+    assert result.shape == cells.shape + (width,)
+    assert result.dtype == np.dtype("int64")
+    assert result.flags.c_contiguous
+
+
+@pytest.mark.parametrize(
+    ("connectivity", "width"),
+    [
+        pytest.param("edge", 4, id="edge"),
+        pytest.param("edge_or_vertex", 8, id="edge-or-vertex"),
+    ],
+)
+def test_neighbours_scalar_and_empty_shapes(connectivity, width):
+    scalar = healpix_geo.nested.neighbours(
+        42,
+        depth=2,
+        connectivity=connectivity,
+    )
+    empty = healpix_geo.nested.neighbours(
+        np.array([], dtype="uint64"),
+        depth=2,
+        connectivity=connectivity,
+    )
+
+    assert scalar.shape == (1, width)
+    assert empty.shape == (0, width)
+    assert scalar.flags.c_contiguous
+    assert empty.flags.c_contiguous
+
+
+def test_neighbours_rejects_invalid_connectivity():
+    with pytest.raises(
+        ValueError,
+        match="connectivity must be 'edge' or 'edge_or_vertex'",
+    ):
+        healpix_geo.nested.neighbours(
+            np.array([42], dtype="uint64"),
+            depth=2,
+            connectivity="invalid",
+        )
+
+
+@pytest.mark.parametrize("depth", range(6))
+def test_edge_neighbour_topology_for_every_cell(depth):
+    cells = np.arange(12 * 4**depth, dtype="uint64")
+    edge = healpix_geo.nested.neighbours(
+        cells,
+        depth=depth,
+        connectivity="edge",
+    )
+    full = healpix_geo.nested.neighbours(
+        cells,
+        depth=depth,
+        connectivity="edge_or_vertex",
+    )
+
+    assert edge.shape == (cells.size, 4)
+    assert np.all(edge >= 0)
+    assert np.all(edge < cells.size)
+
+    # Each edge neighbour must be present in the full neighbourhood.
+    assert np.all(np.any(edge[:, :, None] == full[:, None, :], axis=2))
+
+    # Edge adjacency is symmetric for every cell, including singularities.
+    for direction in range(edge.shape[1]):
+        neighbour_rows = edge[edge[:, direction]]
+        assert np.all(np.any(neighbour_rows == cells[:, None], axis=1))
+
+    valid_full_count = np.count_nonzero(full >= 0, axis=1)
+    if depth == 0:
+        assert np.all(valid_full_count == 6)
+    else:
+        assert np.all((valid_full_count == 7) | (valid_full_count == 8))
+
+
+def test_neighbours_threading_paths_agree():
+    cells = np.arange(12_000, dtype="uint64")
+
+    sequential = healpix_geo.nested.neighbours(
+        cells,
+        depth=5,
+        connectivity="edge_or_vertex",
+        num_threads=1,
+    )
+    automatic = healpix_geo.nested.neighbours(
+        cells,
+        depth=5,
+        connectivity="edge_or_vertex",
+        num_threads=0,
+    )
+    explicit_parallel = healpix_geo.nested.neighbours(
+        cells,
+        depth=5,
+        connectivity="edge_or_vertex",
+        num_threads=2,
+    )
+
+    np.testing.assert_equal(automatic, sequential)
+    np.testing.assert_equal(explicit_parallel, sequential)

--- a/python/healpix-geo/python/healpix_geo/tests/test_topology.py
+++ b/python/healpix-geo/python/healpix_geo/tests/test_topology.py
@@ -1,0 +1,205 @@
+import numpy as np
+import pytest
+
+from healpix_geo import nested
+
+DIRECTIONS = ("N", "NE", "E", "SE", "S", "SW", "W", "NW")
+EXPECTED_NEIGHBOUR_FACES = (
+    (2, 1, None, 5, 8, 4, None, 3),
+    (3, 2, None, 6, 9, 5, None, 0),
+    (0, 3, None, 7, 10, 6, None, 1),
+    (1, 0, None, 4, 11, 7, None, 2),
+    (None, 0, 5, 8, None, 11, 7, 3),
+    (None, 1, 6, 9, None, 8, 4, 0),
+    (None, 2, 7, 10, None, 9, 5, 1),
+    (None, 3, 4, 11, None, 10, 6, 2),
+    (0, 5, None, 9, 10, 11, None, 4),
+    (1, 6, None, 10, 11, 8, None, 5),
+    (2, 7, None, 11, 8, 9, None, 6),
+    (3, 4, None, 8, 9, 10, None, 7),
+)
+
+
+def test_face_neighbour_transform_all_faces_and_directions():
+    for face, expected_faces in enumerate(EXPECTED_NEIGHBOUR_FACES):
+        for direction, expected_face in zip(DIRECTIONS, expected_faces, strict=True):
+            transform = nested.face_neighbour_transform(face, direction)
+            if expected_face is None:
+                assert transform is None
+            else:
+                assert transform.target_face == expected_face
+
+
+def test_face_neighbour_transform_orientation_cases():
+    assert nested.face_neighbour_transform(0, "n") == nested.FaceTransform(
+        target_face=2, swap_xy=False, flip_x=True, flip_y=True
+    )
+    assert nested.face_neighbour_transform(0, "NE") == nested.FaceTransform(
+        target_face=1, swap_xy=True, flip_x=False, flip_y=True
+    )
+    assert nested.face_neighbour_transform(4, "E") == nested.FaceTransform(
+        target_face=5, swap_xy=False, flip_x=False, flip_y=False
+    )
+    assert nested.face_neighbour_transform(8, "SE") == nested.FaceTransform(
+        target_face=9, swap_xy=True, flip_x=True, flip_y=False
+    )
+    assert nested.face_neighbour_transform(8, "S") == nested.FaceTransform(
+        target_face=10, swap_xy=False, flip_x=True, flip_y=True
+    )
+
+
+@pytest.mark.parametrize("face", [-1, 12, 256])
+def test_face_neighbour_transform_rejects_invalid_face(face):
+    with pytest.raises(ValueError, match="Face"):
+        nested.face_neighbour_transform(face, "N")
+
+
+@pytest.mark.parametrize("face", ["0", 0.0, [0]])
+def test_face_neighbour_transform_rejects_non_integer_face(face):
+    with pytest.raises(TypeError, match="face must be an integer"):
+        nested.face_neighbour_transform(face, "N")
+
+
+def test_face_neighbour_transform_rejects_invalid_direction():
+    with pytest.raises(ValueError, match="direction"):
+        nested.face_neighbour_transform(0, "up")
+    with pytest.raises(TypeError, match="direction"):
+        nested.face_neighbour_transform(0, 0)
+
+
+@pytest.mark.parametrize("depth", range(6))
+def test_exhaustive_small_depth_round_trip(depth):
+    pixels = np.arange(12 * 4**depth, dtype=np.uint64)
+
+    face, x, y = nested.pix2xyf(pixels, depth)
+
+    np.testing.assert_array_equal(nested.xyf2pix(face, x, y, depth), pixels)
+    actual_face, actual_x, actual_y = nested.pix2xyf(
+        nested.xyf2pix(face, x, y, depth), depth
+    )
+    np.testing.assert_array_equal(actual_face, face)
+    np.testing.assert_array_equal(actual_x, x)
+    np.testing.assert_array_equal(actual_y, y)
+
+
+def test_level_zero_is_the_base_face():
+    pixels = np.arange(12, dtype=np.uint64)
+
+    face, x, y = nested.pix2xyf(pixels, 0)
+
+    np.testing.assert_array_equal(face, np.arange(12, dtype=np.uint8))
+    np.testing.assert_array_equal(x, np.zeros(12, dtype=np.uint32))
+    np.testing.assert_array_equal(y, np.zeros(12, dtype=np.uint32))
+
+
+def test_scalar_inputs_return_length_one_arrays():
+    face, x, y = nested.pix2xyf(47, 1)
+
+    np.testing.assert_array_equal(face, np.array([11], dtype=np.uint8))
+    np.testing.assert_array_equal(x, np.array([1], dtype=np.uint32))
+    np.testing.assert_array_equal(y, np.array([1], dtype=np.uint32))
+    np.testing.assert_array_equal(
+        nested.xyf2pix(11, 1, 1, 1), np.array([47], dtype=np.uint64)
+    )
+
+
+def test_multidimensional_shape_and_dtypes_are_preserved():
+    pixels = np.arange(48, dtype=np.uint64).reshape(2, 3, 8)
+
+    face, x, y = nested.pix2xyf(pixels, 1)
+
+    assert face.shape == pixels.shape
+    assert x.shape == pixels.shape
+    assert y.shape == pixels.shape
+    assert face.dtype == np.uint8
+    assert x.dtype == np.uint32
+    assert y.dtype == np.uint32
+    actual = nested.xyf2pix(face, x, y, 1)
+    assert actual.shape == pixels.shape
+    assert actual.dtype == np.uint64
+    np.testing.assert_array_equal(actual, pixels)
+
+
+def test_xyf2pix_broadcasts_inputs():
+    face = np.arange(12, dtype=np.uint8)[:, np.newaxis]
+    x = np.arange(4, dtype=np.uint32)[np.newaxis, :]
+    y = np.array(2, dtype=np.uint32)
+
+    pixels = nested.xyf2pix(face, x, y, 2)
+
+    assert pixels.shape == (12, 4)
+    actual_face, actual_x, actual_y = nested.pix2xyf(pixels, 2)
+    np.testing.assert_array_equal(actual_face, np.broadcast_to(face, (12, 4)))
+    np.testing.assert_array_equal(actual_x, np.broadcast_to(x, (12, 4)))
+    np.testing.assert_array_equal(actual_y, np.full((12, 4), 2, dtype=np.uint32))
+
+
+def test_array_depth_broadcasts_with_pixels():
+    depth = np.array([0, 1, 2, 10, 29], dtype=np.uint8)
+    face = np.array([0, 3, 7, 11, 5], dtype=np.uint8)
+    x = np.array([0, 1, 3, 1023, 2**29 - 1], dtype=np.uint32)
+    y = np.array([0, 0, 2, 17, 123_456_789], dtype=np.uint32)
+
+    pixels = nested.xyf2pix(face, x, y, depth)
+    actual = nested.pix2xyf(pixels, depth)
+
+    for component, expected in zip(actual, (face, x, y), strict=True):
+        np.testing.assert_array_equal(component, expected)
+
+
+@pytest.mark.parametrize(
+    ("face", "x", "y", "depth", "message"),
+    [
+        (-1, 0, 0, 1, "Face"),
+        (12, 0, 0, 1, "Face"),
+        (0, -1, 0, 1, "x"),
+        (0, 2, 0, 1, "x"),
+        (0, 0, -1, 1, "y"),
+        (0, 0, 2, 1, "y"),
+    ],
+)
+def test_xyf2pix_rejects_invalid_coordinates(face, x, y, depth, message):
+    with pytest.raises(ValueError, match=message):
+        nested.xyf2pix(face, x, y, depth)
+
+
+@pytest.mark.parametrize("depth", [-1, 30])
+def test_topology_rejects_invalid_depth(depth):
+    with pytest.raises(ValueError, match="Depth"):
+        nested.pix2xyf([0], depth)
+    with pytest.raises(ValueError, match="Depth"):
+        nested.xyf2pix([0], [0], [0], depth)
+
+
+def test_pix2xyf_rejects_invalid_cell_id():
+    with pytest.raises(ValueError, match="out of"):
+        nested.pix2xyf([48], 1)
+
+
+def test_matches_healpy_reference():
+    healpy = pytest.importorskip("healpy")
+    rng = np.random.default_rng(234243)
+
+    for depth in (0, 1, 2, 7, 14, 29):
+        nside = 2**depth
+        npix = 12 * nside**2
+        pixels = rng.integers(0, npix, size=256, dtype=np.uint64)
+
+        face, x, y = nested.pix2xyf(pixels, depth)
+        expected_x, expected_y, expected_face = healpy.pix2xyf(
+            nside, pixels.astype(np.int64), nest=True
+        )
+
+        np.testing.assert_array_equal(face, expected_face)
+        np.testing.assert_array_equal(x, expected_x)
+        np.testing.assert_array_equal(y, expected_y)
+        np.testing.assert_array_equal(
+            nested.xyf2pix(face, x, y, depth),
+            healpy.xyf2pix(
+                nside,
+                x.astype(np.int64),
+                y.astype(np.int64),
+                face.astype(np.int64),
+                nest=True,
+            ),
+        )

--- a/python/healpix-geo/src/indexing_schemes/nested/coverage.rs
+++ b/python/healpix-geo/src/indexing_schemes/nested/coverage.rs
@@ -5,6 +5,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 use healpix_geo_core::scalar::nested::coverage as scalar;
+use healpix_geo_core::vectorized::nested::coverage as vectorized;
 
 #[allow(clippy::type_complexity)]
 #[pyfunction]
@@ -136,6 +137,91 @@ pub(crate) fn cone_coverage<'py>(
         scalar::cone_coverage(center, radius, layer, &ellipsoid_, delta_depth, flat);
 
     Ok((
+        PyArray1::from_vec(py, ipix),
+        PyArray1::from_vec(py, depths),
+        PyArray1::from_vec(py, fully_covered),
+    ))
+}
+
+#[allow(clippy::type_complexity, clippy::too_many_arguments)]
+#[pyfunction]
+#[pyo3(signature = (depth, centers, radius, *, ellipsoid, delta_depth = 0, flat = true, nthreads = 0))]
+pub(crate) fn cone_coverage_many<'py>(
+    py: Python<'py>,
+    depth: u8,
+    centers: &Bound<'py, PyArray2<f64>>,
+    radius: f64,
+    ellipsoid: EllipsoidLike,
+    delta_depth: u8,
+    flat: bool,
+    nthreads: u16,
+) -> PyResult<(
+    Bound<'py, PyArray1<u64>>,
+    Bound<'py, PyArray1<u64>>,
+    Bound<'py, PyArray1<u8>>,
+    Bound<'py, PyArray1<bool>>,
+)> {
+    if depth > 29 {
+        return Err(PyValueError::new_err(
+            "depth must be between 0 and 29, inclusive.",
+        ));
+    } else if depth + delta_depth > 29 {
+        return Err(PyValueError::new_err(
+            "delta_depth must chosen such that depth + delta_depth <= 29",
+        ));
+    }
+
+    let shape = centers.shape();
+    if shape[1] != 2 {
+        return Err(PyValueError::new_err(format!(
+            "The last dimension of the centers array must have a size of 2, got shape ({}, {})",
+            shape[0], shape[1]
+        )));
+    }
+
+    let centers_: Vec<(f64, f64)> = centers
+        .to_vec()?
+        .chunks_exact(2)
+        .map(|row| (row[0], row[1]))
+        .collect();
+    let ellipsoid_ = ellipsoid.into_ellipsoid()?;
+    let layer = healpix::nested::get(depth);
+
+    let result = py.detach(move || {
+        let rows = vectorized::cone_coverage_many(
+            &centers_,
+            radius,
+            layer,
+            &ellipsoid_,
+            delta_depth,
+            flat,
+            nthreads as usize,
+        );
+
+        let total_len = rows
+            .iter()
+            .try_fold(0usize, |total, row| total.checked_add(row.0.len()))?;
+        let mut offsets = Vec::<u64>::with_capacity(rows.len() + 1);
+        let mut ipix = Vec::<u64>::with_capacity(total_len);
+        let mut depths = Vec::<u8>::with_capacity(total_len);
+        let mut fully_covered = Vec::<bool>::with_capacity(total_len);
+        offsets.push(0);
+
+        for (row_ipix, row_depths, row_fully_covered) in rows {
+            ipix.extend(row_ipix);
+            depths.extend(row_depths);
+            fully_covered.extend(row_fully_covered);
+            offsets.push(u64::try_from(ipix.len()).ok()?);
+        }
+
+        Some((offsets, ipix, depths, fully_covered))
+    });
+
+    let (offsets, ipix, depths, fully_covered) = result
+        .ok_or_else(|| PyValueError::new_err("cone coverage result is too large to represent"))?;
+
+    Ok((
+        PyArray1::from_vec(py, offsets),
         PyArray1::from_vec(py, ipix),
         PyArray1::from_vec(py, depths),
         PyArray1::from_vec(py, fully_covered),

--- a/python/healpix-geo/src/indexing_schemes/nested/hierarchy.rs
+++ b/python/healpix-geo/src/indexing_schemes/nested/hierarchy.rs
@@ -1,8 +1,45 @@
 use cdshealpix as healpix;
 use numpy::{PyArray1, PyArray2, PyArrayDyn, PyArrayMethods, PyUntypedArrayMethods};
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 use healpix_geo_core::vectorized::nested::hierarchy as vectorized;
+
+/// Return immediate neighbours in fixed directional positions.
+#[pyfunction]
+pub(crate) fn neighbours<'py>(
+    py: Python<'py>,
+    depth: u8,
+    ipix: &Bound<'py, PyArrayDyn<u64>>,
+    connectivity: &str,
+    nthreads: u16,
+) -> PyResult<Bound<'py, PyArrayDyn<i64>>> {
+    let input_shape = ipix.shape();
+    let ipix_ = ipix.readonly();
+    let layer = healpix::nested::get(depth);
+
+    let directions = match connectivity {
+        "edge" => &healpix_geo_core::scalar::nested::hierarchy::EDGE_DIRECTIONS[..],
+        "edge_or_vertex" => {
+            &healpix_geo_core::scalar::nested::hierarchy::EDGE_OR_VERTEX_DIRECTIONS[..]
+        }
+        _ => {
+            return Err(PyValueError::new_err(
+                "connectivity must be 'edge' or 'edge_or_vertex'",
+            ));
+        }
+    };
+
+    let result = vectorized::neighbours(ipix_.as_slice()?, layer, directions, nthreads as usize);
+
+    let output_shape: Vec<usize> = input_shape
+        .iter()
+        .copied()
+        .chain([directions.len()])
+        .collect();
+
+    PyArray1::from_vec(py, result).reshape(output_shape.as_slice())
+}
 
 /// Wrapper of `kth_neighbours`
 #[pyfunction]

--- a/python/healpix-geo/src/indexing_schemes/nested/mod.rs
+++ b/python/healpix-geo/src/indexing_schemes/nested/mod.rs
@@ -14,7 +14,9 @@ pub(crate) use self::coordinates::{
 pub(crate) use self::coverage::{
     box_coverage, cone_coverage, elliptical_cone_coverage, polygon_coverage, zone_coverage,
 };
-pub(crate) use self::hierarchy::{kth_neighbourhood, kth_neighbours, siblings, zoom_to};
+pub(crate) use self::hierarchy::{
+    kth_neighbourhood, kth_neighbours, neighbours, siblings, zoom_to,
+};
 pub(crate) use self::mesh::vertex_indices;
 pub(crate) use self::sets::internal_boundary;
 pub(crate) use self::topology::{face_neighbour_transform, pix2xyf, xyf2pix};

--- a/python/healpix-geo/src/indexing_schemes/nested/mod.rs
+++ b/python/healpix-geo/src/indexing_schemes/nested/mod.rs
@@ -12,7 +12,8 @@ pub(crate) use self::coordinates::{
     healpix_to_lonlat, lonlat_to_healpix, vertices,
 };
 pub(crate) use self::coverage::{
-    box_coverage, cone_coverage, elliptical_cone_coverage, polygon_coverage, zone_coverage,
+    box_coverage, cone_coverage, cone_coverage_many, elliptical_cone_coverage, polygon_coverage,
+    zone_coverage,
 };
 pub(crate) use self::hierarchy::{
     kth_neighbourhood, kth_neighbours, neighbours, siblings, zoom_to,

--- a/python/healpix-geo/src/indexing_schemes/nested/mod.rs
+++ b/python/healpix-geo/src/indexing_schemes/nested/mod.rs
@@ -4,6 +4,7 @@ mod coverage;
 mod hierarchy;
 mod mesh;
 mod sets;
+mod topology;
 
 pub(crate) use self::conversion::{to_ring, to_zuniq};
 pub(crate) use self::coordinates::{
@@ -16,3 +17,4 @@ pub(crate) use self::coverage::{
 pub(crate) use self::hierarchy::{kth_neighbourhood, kth_neighbours, siblings, zoom_to};
 pub(crate) use self::mesh::vertex_indices;
 pub(crate) use self::sets::internal_boundary;
+pub(crate) use self::topology::{face_neighbour_transform, pix2xyf, xyf2pix};

--- a/python/healpix-geo/src/indexing_schemes/nested/topology.rs
+++ b/python/healpix-geo/src/indexing_schemes/nested/topology.rs
@@ -1,0 +1,113 @@
+use numpy::{PyArray1, PyArrayDyn, PyArrayMethods, PyUntypedArrayMethods};
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+use cdshealpix::compass_point::MainWind;
+use healpix_geo_core::vectorized::nested::topology as vectorized;
+
+use crate::indexing_schemes::depth::DepthLike;
+
+#[pyfunction]
+pub(crate) fn face_neighbour_transform(
+    face: u8,
+    direction: &str,
+) -> PyResult<Option<(u8, bool, bool, bool)>> {
+    if face >= 12 {
+        return Err(PyValueError::new_err(
+            "face must be in the [0, 11] closed range",
+        ));
+    }
+    let direction = match direction.to_ascii_uppercase().as_str() {
+        "N" => MainWind::N,
+        "NE" => MainWind::NE,
+        "E" => MainWind::E,
+        "SE" => MainWind::SE,
+        "S" => MainWind::S,
+        "SW" => MainWind::SW,
+        "W" => MainWind::W,
+        "NW" => MainWind::NW,
+        _ => {
+            return Err(PyValueError::new_err(
+                "direction must be one of N, NE, E, SE, S, SW, W, or NW",
+            ));
+        }
+    };
+
+    Ok(
+        vectorized::face_neighbour_transform(face, direction).map(|transform| {
+            (
+                transform.target_face,
+                transform.swap_xy,
+                transform.flip_x,
+                transform.flip_y,
+            )
+        }),
+    )
+}
+
+#[allow(clippy::type_complexity)]
+#[pyfunction]
+pub(crate) fn pix2xyf<'py>(
+    py: Python<'py>,
+    nested: &Bound<'py, PyArrayDyn<u64>>,
+    depth: DepthLike,
+    nthreads: u16,
+) -> PyResult<(
+    Bound<'py, PyArrayDyn<u8>>,
+    Bound<'py, PyArrayDyn<u32>>,
+    Bound<'py, PyArrayDyn<u32>>,
+)> {
+    let input_shape = nested.shape();
+    let flattened = nested.reshape([nested.len()])?;
+    let flattened = flattened.readonly();
+    let depth = depth.as_depth()?;
+
+    let (face, x, y) = vectorized::pix2xyf(flattened.as_slice()?, depth, nthreads as usize);
+
+    Ok((
+        PyArray1::from_vec(py, face)
+            .reshape(input_shape)?
+            .to_dyn()
+            .clone(),
+        PyArray1::from_vec(py, x)
+            .reshape(input_shape)?
+            .to_dyn()
+            .clone(),
+        PyArray1::from_vec(py, y)
+            .reshape(input_shape)?
+            .to_dyn()
+            .clone(),
+    ))
+}
+
+#[pyfunction]
+pub(crate) fn xyf2pix<'py>(
+    py: Python<'py>,
+    face: &Bound<'py, PyArrayDyn<u8>>,
+    x: &Bound<'py, PyArrayDyn<u32>>,
+    y: &Bound<'py, PyArrayDyn<u32>>,
+    depth: DepthLike,
+    nthreads: u16,
+) -> PyResult<Bound<'py, PyArrayDyn<u64>>> {
+    let input_shape = face.shape();
+    let face = face.reshape([face.len()])?;
+    let x = x.reshape([x.len()])?;
+    let y = y.reshape([y.len()])?;
+    let face = face.readonly();
+    let x = x.readonly();
+    let y = y.readonly();
+    let depth = depth.as_depth()?;
+
+    let nested = vectorized::xyf2pix(
+        face.as_slice()?,
+        x.as_slice()?,
+        y.as_slice()?,
+        depth,
+        nthreads as usize,
+    );
+
+    Ok(PyArray1::from_vec(py, nested)
+        .reshape(input_shape)?
+        .to_dyn()
+        .clone())
+}

--- a/python/healpix-geo/src/lib.rs
+++ b/python/healpix-geo/src/lib.rs
@@ -16,10 +16,10 @@ mod nested {
     #[pymodule_export]
     use crate::indexing_schemes::nested::{
         angular_distances, bilinear_interpolation, box_coverage, cartesian_to_healpix,
-        cone_coverage, elliptical_cone_coverage, face_neighbour_transform, healpix_to_cartesian,
-        healpix_to_lonlat, internal_boundary, kth_neighbourhood, kth_neighbours, lonlat_to_healpix,
-        neighbours, pix2xyf, polygon_coverage, siblings, to_ring, to_zuniq, vertex_indices,
-        vertices, xyf2pix, zone_coverage, zoom_to,
+        cone_coverage, cone_coverage_many, elliptical_cone_coverage, face_neighbour_transform,
+        healpix_to_cartesian, healpix_to_lonlat, internal_boundary, kth_neighbourhood,
+        kth_neighbours, lonlat_to_healpix, neighbours, pix2xyf, polygon_coverage, siblings,
+        to_ring, to_zuniq, vertex_indices, vertices, xyf2pix, zone_coverage, zoom_to,
     };
 }
 

--- a/python/healpix-geo/src/lib.rs
+++ b/python/healpix-geo/src/lib.rs
@@ -16,9 +16,10 @@ mod nested {
     #[pymodule_export]
     use crate::indexing_schemes::nested::{
         angular_distances, bilinear_interpolation, box_coverage, cartesian_to_healpix,
-        cone_coverage, elliptical_cone_coverage, healpix_to_cartesian, healpix_to_lonlat,
-        internal_boundary, kth_neighbourhood, kth_neighbours, lonlat_to_healpix, polygon_coverage,
-        siblings, to_ring, to_zuniq, vertex_indices, vertices, zone_coverage, zoom_to,
+        cone_coverage, elliptical_cone_coverage, face_neighbour_transform, healpix_to_cartesian,
+        healpix_to_lonlat, internal_boundary, kth_neighbourhood, kth_neighbours, lonlat_to_healpix,
+        pix2xyf, polygon_coverage, siblings, to_ring, to_zuniq, vertex_indices, vertices, xyf2pix,
+        zone_coverage, zoom_to,
     };
 }
 

--- a/python/healpix-geo/src/lib.rs
+++ b/python/healpix-geo/src/lib.rs
@@ -18,8 +18,8 @@ mod nested {
         angular_distances, bilinear_interpolation, box_coverage, cartesian_to_healpix,
         cone_coverage, elliptical_cone_coverage, face_neighbour_transform, healpix_to_cartesian,
         healpix_to_lonlat, internal_boundary, kth_neighbourhood, kth_neighbours, lonlat_to_healpix,
-        pix2xyf, polygon_coverage, siblings, to_ring, to_zuniq, vertex_indices, vertices, xyf2pix,
-        zone_coverage, zoom_to,
+        neighbours, pix2xyf, polygon_coverage, siblings, to_ring, to_zuniq, vertex_indices,
+        vertices, xyf2pix, zone_coverage, zoom_to,
     };
 }
 

--- a/rust/healpix-geo-core/src/scalar/nested/hierarchy.rs
+++ b/rust/healpix-geo-core/src/scalar/nested/hierarchy.rs
@@ -1,4 +1,33 @@
-use cdshealpix::nested::Layer;
+use cdshealpix::{compass_point::MainWind, nested::Layer};
+
+pub const EDGE_DIRECTIONS: [MainWind; 4] = [MainWind::SW, MainWind::NW, MainWind::NE, MainWind::SE];
+
+pub const EDGE_OR_VERTEX_DIRECTIONS: [MainWind; 8] = [
+    MainWind::SW,
+    MainWind::W,
+    MainWind::NW,
+    MainWind::N,
+    MainWind::NE,
+    MainWind::E,
+    MainWind::SE,
+    MainWind::S,
+];
+
+/// Write immediate neighbours into fixed directional positions.
+///
+/// Missing directions are represented by `-1`. Unlike `kth_neighbours`,
+/// this function never compacts the remaining values when a direction is
+/// missing.
+pub fn write_neighbours(hash: &u64, layer: &Layer, directions: &[MainWind], output: &mut [i64]) {
+    debug_assert_eq!(directions.len(), output.len());
+
+    let neighbours = layer.neighbours(*hash, false);
+    for (value, direction) in output.iter_mut().zip(directions) {
+        *value = neighbours
+            .get(*direction)
+            .map_or(-1, |neighbour| *neighbour as i64);
+    }
+}
 
 pub fn kth_neighbours(hash: &u64, layer: &Layer, ring: &u32) -> Vec<i64> {
     let r = *ring;
@@ -27,4 +56,29 @@ pub fn kth_neighbourhood(hash: &u64, layer: &Layer, ring: &u32) -> Vec<i64> {
     }
 
     neighbours
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_write_edge_neighbours() {
+        let layer = cdshealpix::nested::get(2);
+        let mut result = [-1; 4];
+
+        write_neighbours(&42, layer, &EDGE_DIRECTIONS, &mut result);
+
+        assert_eq!(result, [111, 21, 43, 40]);
+    }
+
+    #[test]
+    fn test_write_full_neighbours_preserves_missing_direction() {
+        let layer = cdshealpix::nested::get(2);
+        let mut result = [-1; 8];
+
+        write_neighbours(&42, layer, &EDGE_OR_VERTEX_DIRECTIONS, &mut result);
+
+        assert_eq!(result, [111, -1, 21, 23, 43, 41, 40, 109]);
+    }
 }

--- a/rust/healpix-geo-core/src/vectorized/nested/coverage.rs
+++ b/rust/healpix-geo-core/src/vectorized/nested/coverage.rs
@@ -1,5 +1,88 @@
-// re-export, no need for vectorization here
+#[cfg(not(target_arch = "wasm32"))]
+use rayon::prelude::*;
+
+use cdshealpix::nested::Layer;
+
+use crate::ellipsoid::Ellipsoid;
+use crate::maybe_parallelize;
+use crate::scalar::nested::coverage as scalar;
+
+pub type Coverage = (Vec<u64>, Vec<u8>, Vec<bool>);
+
+// Keep automatic parallelism conservative because every worker builds an
+// independent variable-sized coverage result.
+const MAX_CONE_COVERAGE_THREADS: usize = 8;
+
+fn bounded_thread_count(nthreads: usize) -> usize {
+    if nthreads == 0 {
+        std::thread::available_parallelism()
+            .map(usize::from)
+            .unwrap_or(1)
+            .min(MAX_CONE_COVERAGE_THREADS)
+    } else {
+        nthreads.clamp(1, MAX_CONE_COVERAGE_THREADS)
+    }
+}
+
+/// Evaluate multiple cone coverage queries while preserving the result and
+/// ordering of [`scalar::cone_coverage`] for every input center.
+pub fn cone_coverage_many(
+    centers: &[(f64, f64)],
+    radius: f64,
+    layer: &Layer,
+    ellipsoid: &Ellipsoid,
+    delta_depth: u8,
+    flat: bool,
+    nthreads: usize,
+) -> Vec<Coverage> {
+    if centers.is_empty() {
+        return Vec::new();
+    }
+
+    let nthreads = bounded_thread_count(nthreads).min(centers.len());
+    let mut result = Vec::<Coverage>::with_capacity(centers.len());
+
+    maybe_parallelize!(nthreads, centers, result, |&center| {
+        scalar::cone_coverage(center, radius, layer, ellipsoid, delta_depth, flat)
+    });
+
+    result
+}
+
+// Re-export the scalar functions which do not benefit from vectorization.
 #[allow(unused)]
 use crate::scalar::nested::coverage::{
     box_coverage, cone_coverage, elliptical_cone_coverage, polygon_coverage, zone_coverage,
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ellipsoid::{Ellipsoid, ReferenceSphere};
+    use geodesy::ellps::Ellipsoid as GeodesyEllipsoid;
+
+    #[test]
+    fn cone_coverage_many_matches_scalar() {
+        let centers = vec![(45.0, 45.0), (179.999, 0.0), (12.0, 89.9)];
+        let layer = cdshealpix::nested::get(8);
+        let ellipsoid = Ellipsoid::Sphere(ReferenceSphere::new(GeodesyEllipsoid::new(1.0, 0.0)));
+
+        let expected: Vec<Coverage> = centers
+            .iter()
+            .map(|&center| scalar::cone_coverage(center, 0.5, layer, &ellipsoid, 1, false))
+            .collect();
+
+        assert_eq!(
+            cone_coverage_many(&centers, 0.5, layer, &ellipsoid, 1, false, 4),
+            expected
+        );
+    }
+
+    #[test]
+    fn cone_coverage_many_accepts_empty_input() {
+        let layer = cdshealpix::nested::get(8);
+        let ellipsoid = Ellipsoid::Sphere(ReferenceSphere::new(GeodesyEllipsoid::new(1.0, 0.0)));
+
+        assert!(cone_coverage_many(&[], 0.5, layer, &ellipsoid, 0, true, 0).is_empty());
+    }
+}

--- a/rust/healpix-geo-core/src/vectorized/nested/hierarchy.rs
+++ b/rust/healpix-geo-core/src/vectorized/nested/hierarchy.rs
@@ -2,10 +2,71 @@
 use rayon::prelude::*;
 
 use cdshealpix as healpix;
+use cdshealpix::compass_point::MainWind;
 use cdshealpix::nested::Layer;
 
 use crate::maybe_parallelize;
 use crate::scalar::nested::hierarchy as scalar;
+
+/// Below this size, creating or scheduling parallel work is generally more
+/// expensive than the immediate-neighbour calculation itself.
+const AUTO_PARALLEL_THRESHOLD: usize = 32_768;
+
+/// Return immediate neighbours without losing their directional positions.
+///
+/// The result is a flat row-major buffer with `directions.len()` values per
+/// input cell. Missing positions are represented by `-1`.
+pub fn neighbours(
+    ipix: &[u64],
+    layer: &Layer,
+    directions: &[MainWind],
+    nthreads: usize,
+) -> Vec<i64> {
+    let width = directions.len();
+    debug_assert!(width > 0);
+
+    let mut result = vec![-1; ipix.len() * width];
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let write_parallel = |output: &mut [i64]| {
+            output
+                .par_chunks_mut(width)
+                .zip(ipix.par_iter())
+                .for_each(|(row, hash)| scalar::write_neighbours(hash, layer, directions, row));
+        };
+
+        match nthreads {
+            1 => result
+                .chunks_mut(width)
+                .zip(ipix)
+                .for_each(|(row, hash)| scalar::write_neighbours(hash, layer, directions, row)),
+            0 if ipix.len() < AUTO_PARALLEL_THRESHOLD => result
+                .chunks_mut(width)
+                .zip(ipix)
+                .for_each(|(row, hash)| scalar::write_neighbours(hash, layer, directions, row)),
+            0 => write_parallel(&mut result),
+            _ => {
+                let pool = rayon::ThreadPoolBuilder::new()
+                    .num_threads(nthreads)
+                    .build()
+                    .unwrap();
+                pool.install(|| write_parallel(&mut result));
+            }
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = nthreads;
+        result
+            .chunks_mut(width)
+            .zip(ipix)
+            .for_each(|(row, hash)| scalar::write_neighbours(hash, layer, directions, row));
+    }
+
+    result
+}
 
 pub fn kth_neighbours(ipix: &[u64], layer: &Layer, ring: &u32, nthreads: usize) -> Vec<Vec<i64>> {
     let mut result = Vec::<Vec<i64>>::with_capacity(ipix.len());

--- a/rust/healpix-geo-core/src/vectorized/nested/mod.rs
+++ b/rust/healpix-geo-core/src/vectorized/nested/mod.rs
@@ -4,3 +4,4 @@ pub mod coverage;
 pub mod distances;
 pub mod hierarchy;
 pub mod mesh;
+pub mod topology;

--- a/rust/healpix-geo-core/src/vectorized/nested/topology.rs
+++ b/rust/healpix-geo-core/src/vectorized/nested/topology.rs
@@ -1,0 +1,217 @@
+//! Integer-only topology operations for NESTED cells.
+
+#[cfg(not(target_arch = "wasm32"))]
+use rayon::prelude::*;
+
+use cdshealpix::compass_point::MainWind;
+use cdshealpix::nested::get;
+use cdshealpix::nested::zordercurve::get_zoc;
+
+use crate::maybe_parallelize;
+use crate::vectorized::depth::Depth;
+
+#[inline]
+fn pix2xyf_scalar(hash: u64, depth: u8) -> (u8, u32, u32) {
+    let twice_depth = depth << 1;
+    let zoc = get_zoc(depth);
+    let ij = zoc.h2ij(hash & ((1_u64 << twice_depth) - 1));
+    ((hash >> twice_depth) as u8, zoc.ij2i(ij), zoc.ij2j(ij))
+}
+
+#[inline]
+fn xyf2pix_scalar(face: u8, x: u32, y: u32, depth: u8) -> u64 {
+    ((face as u64) << (depth << 1)) | get_zoc(depth).ij2h(x, y)
+}
+
+/// The target base face and its orientation relative to the source face.
+///
+/// The booleans describe an array transform applied in this order: swap the
+/// axes, then reverse the target x and/or y axis. Translation is intentionally
+/// omitted because it depends on the coordinate extent used by the caller.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FaceTransform {
+    pub target_face: u8,
+    pub swap_xy: bool,
+    pub flip_x: bool,
+    pub flip_y: bool,
+}
+
+/// Return the canonical orientation of a neighbouring HEALPix base face.
+///
+/// `None` means that the base face has no distinct neighbour in that direction.
+/// The result is derived from `cdshealpix`'s coordinate transform instead of a
+/// separately maintained adjacency or orientation table.
+pub fn face_neighbour_transform(face: u8, direction: MainWind) -> Option<FaceTransform> {
+    if face >= 12 || direction == MainWind::C {
+        return None;
+    }
+
+    // Any depth >= 1 is sufficient: the affine transform has the same signed
+    // permutation at every depth. Sampling its basis vectors avoids duplicating
+    // the canonical face-orientation rules implemented by cdshealpix.
+    let layer = get(1);
+    let (target_face, origin_x, origin_y) =
+        layer.to_neighbour_base_cell_coo(face, 0, 0, direction)?;
+    let (target_x, x_axis_x, x_axis_y) = layer.to_neighbour_base_cell_coo(face, 1, 0, direction)?;
+    let (target_y, y_axis_x, y_axis_y) = layer.to_neighbour_base_cell_coo(face, 0, 1, direction)?;
+    debug_assert_eq!(target_face, target_x);
+    debug_assert_eq!(target_face, target_y);
+
+    let dx = (x_axis_x - origin_x, x_axis_y - origin_y);
+    let dy = (y_axis_x - origin_x, y_axis_y - origin_y);
+    debug_assert!(matches!(dx, (1 | -1, 0) | (0, 1 | -1)));
+    debug_assert!(matches!(dy, (1 | -1, 0) | (0, 1 | -1)));
+
+    let swap_xy = dx.1 != 0;
+    let (flip_x, flip_y) = if swap_xy {
+        (dy.0 < 0, dx.1 < 0)
+    } else {
+        (dx.0 < 0, dy.1 < 0)
+    };
+
+    Some(FaceTransform {
+        target_face,
+        swap_xy,
+        flip_x,
+        flip_y,
+    })
+}
+
+/// Split NESTED cell indexes into base-face-local coordinates.
+///
+/// Inputs are assumed to have already been validated. The returned vectors have
+/// the same length and contain `(face, x, y)` components in matching order.
+pub fn pix2xyf(ipix: &[u64], depth: Depth, nthreads: usize) -> (Vec<u8>, Vec<u32>, Vec<u32>) {
+    let mut result = Vec::<(u8, u32, u32)>::with_capacity(ipix.len());
+
+    match depth {
+        Depth::Scalar(depth) => {
+            maybe_parallelize!(nthreads, ipix, result, |hash| pix2xyf_scalar(*hash, *depth));
+        }
+        Depth::Array(depths) => {
+            let zipped: Vec<_> = ipix.iter().zip(depths.iter()).collect();
+            maybe_parallelize!(nthreads, zipped, result, |(hash, depth)| {
+                pix2xyf_scalar(**hash, **depth)
+            });
+        }
+    }
+
+    let mut face = Vec::with_capacity(result.len());
+    let mut x = Vec::with_capacity(result.len());
+    let mut y = Vec::with_capacity(result.len());
+    for (face_value, x_value, y_value) in result {
+        face.push(face_value);
+        x.push(x_value);
+        y.push(y_value);
+    }
+    (face, x, y)
+}
+
+/// Combine base faces and face-local coordinates into NESTED cell indexes.
+///
+/// Inputs are assumed to have equal lengths and to have already been validated.
+pub fn xyf2pix(face: &[u8], x: &[u32], y: &[u32], depth: Depth, nthreads: usize) -> Vec<u64> {
+    let inputs: Vec<_> = face.iter().zip(x.iter()).zip(y.iter()).collect();
+    let mut result = Vec::<u64>::with_capacity(face.len());
+
+    match depth {
+        Depth::Scalar(depth) => {
+            maybe_parallelize!(nthreads, inputs, result, |((face, x), y)| {
+                xyf2pix_scalar(**face, **x, **y, *depth)
+            });
+        }
+        Depth::Array(depths) => {
+            let inputs: Vec<_> = inputs.iter().zip(depths.iter()).collect();
+            maybe_parallelize!(nthreads, inputs, result, |(((face, x), y), depth)| {
+                xyf2pix_scalar(**face, **x, **y, **depth)
+            });
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cdshealpix::compass_point::MainWind::{E, N, NE, NW, S, SE, SW, W};
+
+    #[test]
+    fn exhaustive_small_depth_round_trips() {
+        for depth in 0..=5 {
+            let npix = 12_u64 << (depth << 1);
+            let pixels: Vec<_> = (0..npix).collect();
+            let (face, x, y) = pix2xyf(&pixels, Depth::Scalar(&depth), 1);
+            let actual = xyf2pix(&face, &x, &y, Depth::Scalar(&depth), 1);
+            assert_eq!(actual, pixels);
+        }
+    }
+
+    #[test]
+    fn level_zero_is_the_base_face() {
+        let pixels: Vec<_> = (0..12).collect();
+        let depth = 0;
+        let (face, x, y) = pix2xyf(&pixels, Depth::Scalar(&depth), 1);
+        assert_eq!(face, (0..12).collect::<Vec<_>>());
+        assert_eq!(x, vec![0; 12]);
+        assert_eq!(y, vec![0; 12]);
+        assert_eq!(xyf2pix(&face, &x, &y, Depth::Scalar(&depth), 1), pixels);
+    }
+
+    #[test]
+    fn supports_per_cell_depths() {
+        let depths = [0, 1, 2, 10, 29];
+        let face = [0, 3, 7, 11, 5];
+        let x = [0, 1, 3, 1023, (1 << 29) - 1];
+        let y = [0, 0, 2, 17, 123_456_789];
+        let pixels = xyf2pix(&face, &x, &y, Depth::Array(&depths), 1);
+        let actual = pix2xyf(&pixels, Depth::Array(&depths), 1);
+        assert_eq!(actual, (face.to_vec(), x.to_vec(), y.to_vec()));
+    }
+
+    #[test]
+    fn face_transforms_match_cdshealpix_for_every_face_and_direction() {
+        let directions = [N, NE, E, SE, S, SW, W, NW];
+        let layer = get(2);
+
+        for face in 0..12 {
+            for direction in directions {
+                let actual = face_neighbour_transform(face, direction);
+                let expected_face = cdshealpix::neighbour(face, direction);
+                assert_eq!(actual.map(|transform| transform.target_face), expected_face);
+
+                let Some(transform) = actual else {
+                    continue;
+                };
+
+                let raw: Vec<_> = (0..4)
+                    .flat_map(|x| {
+                        (0..4).map(move |y| {
+                            layer
+                                .to_neighbour_base_cell_coo(face, x, y, direction)
+                                .unwrap()
+                        })
+                    })
+                    .collect();
+                let min_x = raw.iter().map(|(_, x, _)| *x).min().unwrap();
+                let min_y = raw.iter().map(|(_, _, y)| *y).min().unwrap();
+
+                for (index, (target_face, raw_x, raw_y)) in raw.into_iter().enumerate() {
+                    let x = (index / 4) as i32;
+                    let y = (index % 4) as i32;
+                    let (mut expected_x, mut expected_y) =
+                        if transform.swap_xy { (y, x) } else { (x, y) };
+                    if transform.flip_x {
+                        expected_x = 3 - expected_x;
+                    }
+                    if transform.flip_y {
+                        expected_y = 3 - expected_y;
+                    }
+
+                    assert_eq!(target_face, transform.target_face);
+                    assert_eq!((raw_x - min_x, raw_y - min_y), (expected_x, expected_y));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Promote the changes validated together on the shared `integration` branch to `main`.

This integration contains:

- #244: vectorized NESTED face/xy topology primitives
- #247: direction-preserving NESTED neighbours
- #242: batched NESTED cone coverage
- CI configuration so pushes and pull requests targeting `integration` run the same validation workflows as `main`

## Integration validation

- Resolved the shared Python import and Rust export conflicts additively so all three APIs remain available.
- Local Rust lint passed.
- Local Rust tests: 86 passed.
- Local Python tests: 415 passed, 7 skipped.
- GitHub Actions passed for each feature PR after updating it against the evolving `integration` branch.
- Final combined `integration` branch and this promotion PR completed their GitHub checks without failures.
- The Ubuntu GitHub doctest passed. A local macOS doctest run had one pre-existing last-digit floating-point representation mismatch in `ring.healpix_to_cartesian`; the integrated APIs were unaffected.

## Cross-repository validation

Downstream validation used `GRID4EARTH/healpix-geo:integration` at `e170f4a`:

- `GRID4EARTH/healpix-analyse#37`: 405 passed, 21 skipped locally; GitHub documentation build passed.
- `GRID4EARTH/healpix-analyse#42`: 395 passed, 21 skipped locally; GitHub test job passed.

Both downstream pull requests now use the shared upstream `integration` branch rather than a contributor fork or feature-branch commit. They should return to a released dependency after these changes are promoted to `main` and released.