### PR TITLE
docs: deploy documentation to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,65 @@
+name: Build and deploy documentation
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@f00437f565399d418b0acc85936d12c1fb668347 # v0.10.1
+
+      - name: Build Emscripten package
+        run: pixi run -e jupyterlite build-emscripten
+
+      - name: Create local Emscripten channel
+        run: pixi run -e jupyterlite create-channel
+
+      - name: Create JupyterLite environment
+        run: pixi run -e templates create-environment
+
+      - name: Build HTML documentation
+        run: pixi run -e docs build-docs
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: python/healpix-geo/docs/_build/html
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Rust CI](https://github.com/GRID4EARTH/healpix-geo/actions/workflows/rust-ci.yml/badge.svg)](https://github.com/GRID4EARTH/healpix-geo/actions/workflows/rust-ci.yml)
 [![Python CI](https://github.com/GRID4EARTH/healpix-geo/actions/workflows/python-ci.yml/badge.svg)](https://github.com/GRID4EARTH/healpix-geo/actions/workflows/python-ci.yml)
-[![Docs](https://readthedocs.org/projects/healpix-geo/badge/?version=latest)](https://healpix-geo.readthedocs.io/)
+[![Docs](https://img.shields.io/badge/docs-grid4earth.eu-blue.svg)](https://grid4earth.eu/healpix-geo/)
 [![Formatted with black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 [![Available on pypi](https://img.shields.io/pypi/v/healpix-geo.svg)](https://pypi.python.org/pypi/healpix-geo/)
 [![PyPI Downloads](https://pepy.tech/badge/healpix-geo)](https://pepy.tech/projects/healpix-geo)
@@ -27,4 +27,4 @@ pip install healpix-geo  # with pip
 uv add healpix-geo  # with uv
 ```
 
-For more information, see the [documentation](https://healpix-geo.readthedocs.io/en/latest).
+For more information, see the [documentation](https://grid4earth.eu/healpix-geo/).

--- a/python/healpix-geo/docs/conf.py
+++ b/python/healpix-geo/docs/conf.py
@@ -122,6 +122,7 @@ nb_execution_timeout = 120
 
 # -- Options for HTML output -------------------------------------------------
 
+html_baseurl = "https://grid4earth.eu/healpix-geo/"
 html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
 html_css_files = ["css/custom.css"]


### PR DESCRIPTION
## Summary

Migrate the `healpix-geo` documentation deployment from Read the Docs to GitHub Pages under the GRID4EARTH domain.

The documentation will be published at:

https://grid4earth.eu/healpix-geo/

## Changes

- Add a GitHub Actions workflow that:
  - builds the Emscripten package
  - creates the local Emscripten channel
  - prepares the JupyterLite environment
  - builds the Sphinx documentation
  - uploads the generated HTML as a GitHub Pages artifact
  - deploys the documentation after a successful push to `main`
- Update the README documentation badge and link to the GRID4EARTH URL
- Set the Sphinx `html_baseurl` to `https://grid4earth.eu/healpix-geo/`

## Validation

- `git diff --check` passes
- The workflow YAML parses successfully
- Confirmed that no HEALPix-Geo Read the Docs URLs remain
- Ran `pixi run -e docs build-docs`
  - Sphinx generated the HTML documentation and JupyterLite output
  - The command exited with an error because the existing documentation contains five unresolved Python class references and warnings are treated as errors with `-W`

The remaining generic `readthedocs` references are unrelated to the public HEALPix-Geo documentation URL: the existing `build-docs-rtd` task and the Shapely intersphinx mapping.