### PR TITLE
resolve inconveniences and inconsistencies in v0.3.0

### DIFF
--- a/python/healpix-geo/docs/api.rst
+++ b/python/healpix-geo/docs/api.rst
@@ -26,8 +26,8 @@ Overview
 .. tip::
    **For most of the applications**, use module ``healpix_geo.auto`` with the ``nested`` indexing scheme. It offers the best support for hierarchical operations.
 
-Helpers
-~~~~~~~
+Geometry helpers
+~~~~~~~~~~~~~~~~
 .. currentmodule:: healpix_geo
 
 .. autosummary::
@@ -37,6 +37,7 @@ Helpers
 
    cartesian_to_lonlat
    lonlat_to_cartesian
+   vertex_to_lonlat
 
 Common Parameters
 ==================

--- a/python/healpix-geo/docs/api/auto.rst
+++ b/python/healpix-geo/docs/api/auto.rst
@@ -21,6 +21,13 @@ Coordinate Conversions
    lonlat_to_healpix
    healpix_to_cartesian
    cartesian_to_healpix
+
+
+Cell geometry
+~~~~~~~~~~~~~
+.. autosummary::
+   :toctree: ../generated/
+
    vertices
 
 Indexing Scheme Conversions

--- a/python/healpix-geo/docs/api/nested.rst
+++ b/python/healpix-geo/docs/api/nested.rst
@@ -17,10 +17,18 @@ Conversions between geographic coordinates and HEALPix indices.
    lonlat_to_healpix
    healpix_to_cartesian
    cartesian_to_healpix
-   vertices
 
 .. seealso::
    Tutorial complete : :doc:`../tutorials/coordinate_conversion`
+
+Cell geometry
+~~~~~~~~~~~~~
+.. autosummary::
+   :toctree: ../generated/
+
+   vertices
+   vertex_indices
+
 
 Indexing Scheme Conversions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/python/healpix-geo/docs/api/ring.rst
+++ b/python/healpix-geo/docs/api/ring.rst
@@ -18,7 +18,14 @@ Coordinate Conversions
    lonlat_to_healpix
    healpix_to_cartesian
    cartesian_to_healpix
+
+Cell geometry
+~~~~~~~~~~~~~
+.. autosummary::
+   :toctree: ../generated/
+
    vertices
+   vertex_indices
 
 Indexing Scheme Conversions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/python/healpix-geo/docs/api/zuniq.rst
+++ b/python/healpix-geo/docs/api/zuniq.rst
@@ -20,6 +20,14 @@ Coordinate Conversions
 .. seealso::
    Complete tutorial : :doc:`../tutorials/coordinate_conversion`
 
+Cell geometry
+~~~~~~~~~~~~~
+.. autosummary::
+   :toctree: ../generated/
+
+   vertices
+   vertex_indices
+
 Indexing Scheme Conversions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/python/healpix-geo/python/healpix_geo/__init__.py
+++ b/python/healpix-geo/python/healpix_geo/__init__.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from healpix_geo import geometry, healpix_geo, nested, ring, zuniq
 from healpix_geo.geometry import Bbox
-from healpix_geo.mesh import vertex_to_geographic
+from healpix_geo.mesh import vertex_to_lonlat
 
 
 def cartesian_to_lonlat(x, y, z, ellipsoid="sphere", num_threads=0):
@@ -99,7 +99,7 @@ __all__ = [
     "slices",
     "geometry",
     "Bbox",
-    "vertex_to_geographic",
+    "vertex_to_lonlat",
     "lonlat_to_cartesian",
     "cartesian_to_lonlat",
 ]

--- a/python/healpix-geo/python/healpix_geo/__init__.py
+++ b/python/healpix-geo/python/healpix_geo/__init__.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+import healpix_geo.ellipsoid  # noqa: F401
 from healpix_geo import geometry, healpix_geo, nested, ring, zuniq
 from healpix_geo.geometry import Bbox
 from healpix_geo.mesh import vertex_to_lonlat

--- a/python/healpix-geo/python/healpix_geo/mesh.py
+++ b/python/healpix-geo/python/healpix_geo/mesh.py
@@ -13,14 +13,14 @@ if TYPE_CHECKING:
     from healpix_geo.typing import EllipsoidLike
 
 
-def vertex_to_geographic(
+def vertex_to_lonlat(
     vertex_ids: npt.NDArray[np.uint64],
     depth: int,
     *,
     ellipsoid: EllipsoidLike = "sphere",
     num_threads: int = 0,
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
-    """geographic coordinates for the given vertex ids
+    """Longitude and latitude coordinates for the given vertex ids
 
     Parameters
     ----------
@@ -42,11 +42,11 @@ def vertex_to_geographic(
 
     Examples
     --------
-    >>> from healpix_geo import vertex_to_geographic
+    >>> from healpix_geo import vertex_to_lonlat
     >>> import numpy as np
     >>> depth = 0
     >>> vertex_ids = np.arange(12 * 4**depth + 2, dtype="uint64")
-    >>> lon, lat = vertex_to_geographic(vertex_ids, depth, ellipsoid="sphere")
+    >>> lon, lat = vertex_to_lonlat(vertex_ids, depth, ellipsoid="sphere")
     >>> np.stack([lon, lat], axis=-1)
     array([[  0.       ,  90.       ],
            [  0.       ,  41.8103149],
@@ -73,4 +73,4 @@ def vertex_to_geographic(
 
     num_threads = np.uint16(num_threads)
 
-    return healpix_geo.vertex_to_geographic(depth, vertex_ids, ellipsoid, num_threads)
+    return healpix_geo.vertex_to_lonlat(depth, vertex_ids, ellipsoid, num_threads)

--- a/python/healpix-geo/python/healpix_geo/nested.py
+++ b/python/healpix-geo/python/healpix_geo/nested.py
@@ -436,7 +436,7 @@ def vertex_indices(
 
     See Also
     --------
-    healpix_geo.vertex_to_geographic
+    healpix_geo.vertex_to_lonlat
 
     Examples
     --------

--- a/python/healpix-geo/python/healpix_geo/ring.py
+++ b/python/healpix-geo/python/healpix_geo/ring.py
@@ -431,7 +431,7 @@ def vertex_indices(
 
     See Also
     --------
-    healpix_geo.vertex_to_geographic
+    healpix_geo.vertex_to_lonlat
 
     Examples
     --------

--- a/python/healpix-geo/python/healpix_geo/zuniq.py
+++ b/python/healpix-geo/python/healpix_geo/zuniq.py
@@ -413,7 +413,7 @@ def vertex_indices(
 
     See Also
     --------
-    healpix_geo.vertex_to_geographic
+    healpix_geo.vertex_to_lonlat
 
     Examples
     --------

--- a/python/healpix-geo/src/lib.rs
+++ b/python/healpix-geo/src/lib.rs
@@ -68,7 +68,7 @@ mod healpix_geo {
     #[pymodule_export]
     use crate::geometry::{cartesian_to_lonlat, lonlat_to_cartesian};
     #[pymodule_export]
-    use crate::mesh::vertex_to_geographic;
+    use crate::mesh::vertex_to_lonlat;
 
     #[pymodule_export]
     use crate::ellipsoid::resolve_ellipsoid;

--- a/python/healpix-geo/src/mesh.rs
+++ b/python/healpix-geo/src/mesh.rs
@@ -6,7 +6,7 @@ use healpix_geo_core::vectorized::mesh as vectorized;
 
 #[allow(clippy::type_complexity)]
 #[pyfunction]
-pub(crate) fn vertex_to_geographic<'py>(
+pub(crate) fn vertex_to_lonlat<'py>(
     py: Python<'py>,
     depth: u8,
     ipix: &Bound<'py, PyArrayDyn<u64>>,
@@ -19,7 +19,7 @@ pub(crate) fn vertex_to_geographic<'py>(
     let ipix_ = ipix.readonly();
 
     let (lon, lat): (Vec<f64>, Vec<f64>) =
-        vectorized::vertex_to_geographic(depth, ipix_.as_slice()?, &ellipsoid, nthreads as usize)
+        vectorized::vertex_to_lonlat(depth, ipix_.as_slice()?, &ellipsoid, nthreads as usize)
             .into_iter()
             .unzip();
 

--- a/rust/healpix-geo-core/src/scalar/mesh.rs
+++ b/rust/healpix-geo-core/src/scalar/mesh.rs
@@ -178,11 +178,8 @@ fn decode_vertex(depth: u8, vertex_id: u64, scheme: VertexIdScheme) -> (f64, f64
     }
 }
 
-// /// Deduplicate and sort the given vertex ids
-// pub fn vertex_indices(ipix: &[CellVertices]) -> (Vec<u64>, Vec<CellIndices>) {}
-
 /// Convert a vertex id to coordinates
-pub fn vertex_to_geographic(depth: u8, hash: &u64, ellipsoid: &Ellipsoid) -> (f64, f64) {
+pub fn vertex_to_lonlat(depth: u8, hash: &u64, ellipsoid: &Ellipsoid) -> (f64, f64) {
     // convert vertex hash to (face, x, y)
     // - convert the vertex id into (face, x, y, depth, corner-kind)
     // - from there, convert to (x, y) healpix plane coordinates (offset from the healpix
@@ -608,7 +605,7 @@ mod tests {
     #[case::l3_ellipsoid_north_polar_cap(
         3, 21, TestEllipsoid::Ellipsoid,
         (239.99999999999997, 72.46140571909436))]
-    fn test_vertex_to_geographic(
+    fn test_vertex_to_lonlat(
         #[case] level: u8,
         #[case] vertex_id: u64,
         #[case] ellipsoid_kind: TestEllipsoid,
@@ -623,7 +620,7 @@ mod tests {
             )),
         };
 
-        let actual = vertex_to_geographic(level, &vertex_id, &ellipsoid);
+        let actual = vertex_to_lonlat(level, &vertex_id, &ellipsoid);
         assert_approx_eq!(actual.0, expected.0);
         assert_approx_eq!(actual.1, expected.1);
     }

--- a/rust/healpix-geo-core/src/vectorized/mesh.rs
+++ b/rust/healpix-geo-core/src/vectorized/mesh.rs
@@ -5,7 +5,7 @@ use rayon::prelude::*;
 use crate::ellipsoid::Ellipsoid;
 use crate::scalar::mesh as scalar;
 
-pub fn vertex_to_geographic(
+pub fn vertex_to_lonlat(
     depth: u8,
     hashes: &[u64],
     ellipsoid: &Ellipsoid,
@@ -14,7 +14,7 @@ pub fn vertex_to_geographic(
     let mut result = Vec::<(f64, f64)>::with_capacity(hashes.len());
 
     maybe_parallelize!(nthreads, hashes, result, |hash| {
-        scalar::vertex_to_geographic(depth, hash, ellipsoid)
+        scalar::vertex_to_lonlat(depth, hash, ellipsoid)
     });
 
     result


### PR DESCRIPTION
- `vertex_to_geographic` is inconsistent with the current naming scheme. For consistency it should be `vertex_to_lonlat`. This also side-steps the apparent inconsistency in the use the term "geographic latitude", which sometimes can be used as synonymous to "geodetic latitude" (which I was doing) or "astronomic latitude". The latter being a physical and not geometrical latitude makes this a weird problem, but oh well. Other languages are much more consistent than English in that regard.
- `healpix_geo.ellipsoid.resolve` is nice, but currently needs to be imported manually, which is really inconvenient.