### PR TITLE
support serializing the index to compressed arrays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,7 +550,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "healpix-geo"
-version = "0.2.1"
+version = "0.3.1"
 dependencies = [
  "cdshealpix 0.9.1 (git+https://github.com/cds-astro/cds-healpix-rust.git?rev=d9d017cda85a097b65d200e3c4cccefc54665915)",
  "geodesy",
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "healpix-geo-core"
-version = "0.2.1"
+version = "0.3.1"
 dependencies = [
  "assertables",
  "cdshealpix 0.9.1 (git+https://github.com/cds-astro/cds-healpix-rust.git?rev=d9d017cda85a097b65d200e3c4cccefc54665915)",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "healpix-geo-wasm"
-version = "0.2.1"
+version = "0.3.1"
 dependencies = [
  "cdshealpix 0.9.1 (git+https://github.com/cds-astro/cds-healpix-rust.git?rev=d9d017cda85a097b65d200e3c4cccefc54665915)",
  "console_error_panic_hook",

--- a/js/src/grid.rs
+++ b/js/src/grid.rs
@@ -394,7 +394,8 @@ impl Grid {
 
         let mut out = Vec::with_capacity(lonlats.len() / 2);
 
-        for (index, pair) in lonlats.chunks_exact(2).enumerate() {
+        // clippy claims that as_chunks is to be preferred over chunks_exact
+        for (index, pair) in lonlats.as_chunks::<2>().0.iter().enumerate() {
             // one NaN in a million-element buffer used to abort the call with
             // `RuntimeError: unreachable` — no message and no index
             let hash = self

--- a/python/healpix-geo/docs/api-hidden.rst
+++ b/python/healpix-geo/docs/api-hidden.rst
@@ -5,9 +5,14 @@
 
    healpix_geo.nested.RangeMOCIndex.empty
    healpix_geo.nested.RangeMOCIndex.from_cell_ids
+   healpix_geo.nested.RangeMOCIndex.from_compacted
+   healpix_geo.nested.RangeMOCIndex.from_ranges
    healpix_geo.nested.RangeMOCIndex.full_domain
 
    healpix_geo.nested.RangeMOCIndex.cell_ids
+   healpix_geo.nested.RangeMOCIndex.ranges
+
+   healpix_geo.nested.RangeMOCIndex.refine
    healpix_geo.nested.RangeMOCIndex.isel
    healpix_geo.nested.RangeMOCIndex.sel
    healpix_geo.nested.RangeMOCIndex.query

--- a/python/healpix-geo/python/healpix_geo/tests/test_index.py
+++ b/python/healpix-geo/python/healpix_geo/tests/test_index.py
@@ -33,6 +33,21 @@ class TestRangeMOCIndex:
         assert index.depth == level
 
     @pytest.mark.parametrize(
+        ["level", "new_level"],
+        (
+            (25, 2),
+            (2, 6),
+        ),
+    )
+    def test_refine(self, level: int, new_level: int) -> None:
+        index = healpix_geo.nested.RangeMOCIndex.full_domain(level)
+
+        expected = np.arange(12 * 4**new_level, dtype="uint64")
+        refined = index.refine(new_level)
+
+        np.testing.assert_equal(refined.cell_ids(), expected)
+
+    @pytest.mark.parametrize(
         ["level", "cell_ids1", "cell_ids2", "expected"],
         (
             (

--- a/python/healpix-geo/python/healpix_geo/tests/test_index.py
+++ b/python/healpix-geo/python/healpix_geo/tests/test_index.py
@@ -1,6 +1,7 @@
 import pickle
 
 import numpy as np
+import numpy.typing as npt
 import pytest
 import shapely
 
@@ -157,6 +158,58 @@ class TestRangeMOCIndex:
 
         assert isinstance(actual, healpix_geo.nested.RangeMOCIndex)
         np.testing.assert_equal(actual.cell_ids(), expected)
+
+    @pytest.mark.parametrize(
+        ["level", "cell_ids", "expected"],
+        (
+            pytest.param(
+                2,
+                np.arange(12 * 4**2, dtype="uint64"),
+                np.array([[0, 12 * 4**29]], dtype="uint64"),
+                id="full_domain",
+            ),
+            pytest.param(
+                1,
+                np.concat(
+                    [
+                        np.arange(1 * 4**1, 3 * 4**1, dtype="uint64"),
+                        np.arange(5 * 4**1, 7 * 4**1, dtype="uint64"),
+                    ]
+                ),
+                np.array(
+                    [[1 * 4**29, 3 * 4**29], [5 * 4**29, 7 * 4**29]], dtype="uint64"
+                ),
+                id="ranges_with_gap",
+            ),
+            pytest.param(
+                3,
+                np.array([4, 5, 6, 7, 9, 15, 16, 19], dtype="uint64"),
+                (
+                    np.array(
+                        [
+                            [4, 8],
+                            [9, 10],
+                            [15, 17],
+                            [19, 20],
+                        ],
+                        dtype="uint64",
+                    )
+                    * 4**26
+                ),
+                id="isolated_pixels",
+            ),
+        ),
+    )
+    def test_ranges(
+        self,
+        level: int,
+        cell_ids: npt.NDArray[np.uint64],
+        expected: npt.NDArray[np.uint64],
+    ) -> None:
+        index = healpix_geo.nested.RangeMOCIndex.from_cell_ids(level, cell_ids)
+
+        actual = index.ranges()
+        np.testing.assert_equal(actual, expected)
 
     @pytest.mark.parametrize(
         ["level", "cell_ids"],

--- a/python/healpix-geo/python/healpix_geo/tests/test_index.py
+++ b/python/healpix-geo/python/healpix_geo/tests/test_index.py
@@ -34,6 +34,52 @@ class TestRangeMOCIndex:
         assert index.depth == level
 
     @pytest.mark.parametrize(
+        ["level", "ranges", "expected"],
+        (
+            pytest.param(
+                2,
+                np.array([[0, 12 * 4**29]], dtype="uint64"),
+                np.arange(12 * 4**2, dtype="uint64"),
+                id="full_domain",
+            ),
+            pytest.param(
+                1,
+                np.array(
+                    [[1 * 4**29, 3 * 4**29], [5 * 4**29, 7 * 4**29]], dtype="uint64"
+                ),
+                np.concat(
+                    [
+                        np.arange(1 * 4**1, 3 * 4**1, dtype="uint64"),
+                        np.arange(5 * 4**1, 7 * 4**1, dtype="uint64"),
+                    ]
+                ),
+                id="ranges_with_gap",
+            ),
+            pytest.param(
+                3,
+                (
+                    np.array(
+                        [
+                            [4, 8],
+                            [9, 10],
+                            [15, 17],
+                            [19, 20],
+                        ],
+                        dtype="uint64",
+                    )
+                    * 4**26
+                ),
+                np.array([4, 5, 6, 7, 9, 15, 16, 19], dtype="uint64"),
+                id="isolated_pixels",
+            ),
+        ),
+    )
+    def test_from_ranges(self, level, ranges, expected) -> None:
+        index = healpix_geo.nested.RangeMOCIndex.from_ranges(level, ranges)
+
+        np.testing.assert_equal(index.cell_ids(), expected)
+
+    @pytest.mark.parametrize(
         ["level", "new_level"],
         (
             (25, 2),

--- a/python/healpix-geo/python/healpix_geo/tests/test_index.py
+++ b/python/healpix-geo/python/healpix_geo/tests/test_index.py
@@ -80,6 +80,49 @@ class TestRangeMOCIndex:
         np.testing.assert_equal(index.cell_ids(), expected)
 
     @pytest.mark.parametrize(
+        ["level", "cell_ids", "expected"],
+        (
+            (
+                0,
+                np.array(
+                    [864691128455135232, 1441151880758558720, 3170534137668829184],
+                    dtype="uint64",
+                ),
+                np.array([1, 2, 5], dtype="uint64"),
+            ),
+            (
+                3,
+                np.array(
+                    [
+                        216172782113783808,
+                        306244774661193728,
+                        342273571680157696,
+                        378302368699121664,
+                    ],
+                    dtype="uint64",
+                ),
+                np.concat(
+                    [
+                        np.arange(1 * 4**2, 2 * 4**2, dtype="uint64"),
+                        np.arange(8 * 4**1, 11 * 4**1, dtype="uint64"),
+                    ],
+                    axis=0,
+                ),
+            ),
+            (
+                6,
+                np.array([22517998136852480], dtype="uint64"),
+                np.arange(2 * 4**3, 3 * 4**3, dtype="uint64"),
+            ),
+        ),
+    )
+    def test_from_compacted(self, level, cell_ids, expected):
+        index = healpix_geo.nested.RangeMOCIndex.from_compacted(level, cell_ids)
+
+        assert index.depth == level
+        np.testing.assert_equal(index.cell_ids(), expected)
+
+    @pytest.mark.parametrize(
         ["level", "new_level"],
         (
             (25, 2),

--- a/python/healpix-geo/src/index.rs
+++ b/python/healpix-geo/src/index.rs
@@ -394,6 +394,12 @@ impl RangeMOCIndex {
         ))
     }
 
+    fn refine(&self, depth: u8) -> PyResult<Self> {
+        Ok(Self {
+            region: self.region.refine(depth),
+        })
+    }
+
     /// Retrieve the cell ids from the index.
     ///
     /// Returns

--- a/python/healpix-geo/src/index.rs
+++ b/python/healpix-geo/src/index.rs
@@ -1,6 +1,6 @@
 use numpy::{
-    PyArray1, PyArrayDescr, PyArrayDescrMethods, PyArrayDyn, PyArrayMethods, PyUntypedArray,
-    PyUntypedArrayMethods, dtype,
+    PyArray1, PyArray2, PyArrayDescr, PyArrayDescrMethods, PyArrayDyn, PyArrayMethods,
+    PyUntypedArray, PyUntypedArrayMethods, dtype,
 };
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
@@ -410,6 +410,25 @@ impl RangeMOCIndex {
         let cell_ids: Vec<u64> = self.region.cell_ids();
 
         Ok(PyArray1::from_vec(py, cell_ids))
+    }
+
+    /// Extract the underlying connected ranges
+    ///
+    /// Returns
+    /// -------
+    /// ranges: numpy.ndarray
+    ///     The ranges as a :math:`N` x :math:`2` array of dtype ``uint64``.
+    fn ranges<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<u64>>> {
+        let ranges = self.region.ranges();
+        let shape = (ranges.len(), 2);
+        let ranges: Vec<u64> = py.detach(move || {
+            ranges
+                .into_iter()
+                .flat_map(|range| [range.start, range.end])
+                .collect()
+        });
+
+        PyArray1::from_vec(py, ranges).reshape(shape)
     }
 
     /// Subset the index using positions

--- a/python/healpix-geo/src/index.rs
+++ b/python/healpix-geo/src/index.rs
@@ -249,6 +249,31 @@ impl RangeMOCIndex {
         Ok(index)
     }
 
+    /// Create an index from the given ranges at level 29
+    ///
+    /// Parameters
+    /// ----------
+    /// depth : int
+    ///     The maximum depth of the index.
+    /// ranges : numpy.ndarray
+    ///     The ranges to construct the index from as a :math:`N` x :math:`2` array.
+    #[pyo3(signature = (depth, ranges, ellipsoid=EllipsoidLike::Named("sphere".to_string())))]
+    #[classmethod]
+    fn from_ranges<'py>(
+        _cls: &Bound<'py, PyType>,
+        _py: Python<'py>,
+        depth: u8,
+        ranges: &Bound<'py, PyArray2<u64>>,
+        ellipsoid: EllipsoidLike,
+    ) -> PyResult<Self> {
+        let ranges_ = ranges.to_vec()?;
+        let index = Self {
+            region: CellRegion::from_ranges(depth, ranges_, ellipsoid.into_ellipsoid()?),
+        };
+
+        Ok(index)
+    }
+
     /// Compute the set union of two indexes
     ///
     /// Parameters

--- a/python/healpix-geo/src/index.rs
+++ b/python/healpix-geo/src/index.rs
@@ -274,6 +274,34 @@ impl RangeMOCIndex {
         Ok(index)
     }
 
+    /// Create an index from the given compacted cells
+    ///
+    /// Parameters
+    /// ----------
+    /// depth : int
+    ///     The maximum depth of the index
+    /// cell_ids : numpy.ndarray
+    ///     The cell ids in ``zuniq`` indexing scheme as a :math:`N` ``uint64`` array
+    #[pyo3(signature = (depth, cell_ids, ellipsoid=EllipsoidLike::Named("sphere".to_string())))]
+    #[classmethod]
+    fn from_compacted<'py>(
+        _cls: &Bound<'py, PyType>,
+        _py: Python<'py>,
+        depth: u8,
+        cell_ids: &Bound<'py, PyArray1<u64>>,
+        ellipsoid: EllipsoidLike,
+    ) -> PyResult<Self> {
+        let index = Self {
+            region: CellRegion::from_compacted(
+                depth,
+                cell_ids.to_vec()?,
+                ellipsoid.into_ellipsoid()?,
+            ),
+        };
+
+        Ok(index)
+    }
+
     /// Compute the set union of two indexes
     ///
     /// Parameters

--- a/python/healpix-geo/src/index.rs
+++ b/python/healpix-geo/src/index.rs
@@ -394,6 +394,19 @@ impl RangeMOCIndex {
         ))
     }
 
+    /// Change the internal depth of the index
+    ///
+    /// This may change the region covered by the index if the new depth is smaller than the current depth.
+    ///
+    /// Parameters
+    /// ----------
+    /// depth : int
+    ///     The new depth
+    ///
+    /// Returns
+    /// -------
+    /// refined : RangeMOCIndex
+    ///     The refined index with a different level
     fn refine(&self, depth: u8) -> PyResult<Self> {
         Ok(Self {
             region: self.region.refine(depth),

--- a/rust/healpix-geo-core/src/index/region.rs
+++ b/rust/healpix-geo-core/src/index/region.rs
@@ -59,6 +59,26 @@ impl CellRegion {
         self.moc.flatten_to_fixed_depth_cells().collect()
     }
 
+    pub fn refine(&self, depth: u8) -> Self {
+        let moc_depth = self.moc.depth_max();
+
+        let moc = if depth == moc_depth {
+            self.moc.clone()
+        } else if depth < moc_depth {
+            self.moc.degraded(depth)
+        } else {
+            let mut moc = self.moc.clone();
+            moc.refine(depth);
+
+            moc
+        };
+
+        Self {
+            moc,
+            ellipsoid: self.ellipsoid.clone(),
+        }
+    }
+
     pub fn cells_at_depth(&self) -> u64 {
         12 * 4u64.pow(self.depth() as u32)
     }

--- a/rust/healpix-geo-core/src/index/region.rs
+++ b/rust/healpix-geo-core/src/index/region.rs
@@ -44,19 +44,41 @@ impl CellRegion {
         }
     }
 
-    pub fn from_ranges(depth: u8, ranges: Vec<u64>, ellipsoid: Ellipsoid) -> Self {
+    fn from_ranges_impl(depth: u8, ranges: Vec<Range<u64>>, ellipsoid: Ellipsoid) -> Self {
         let size = ranges.len();
         Self {
-            moc: RangeMOC::from_maxdepth_ranges(
-                depth,
-                ranges.chunks(2).map(|chunk| Range {
-                    start: chunk[0],
-                    end: chunk[1],
-                }),
-                Some(size),
-            ),
+            moc: RangeMOC::from_maxdepth_ranges(depth, ranges, Some(size)),
             ellipsoid,
         }
+    }
+
+    pub fn from_compacted(depth: u8, cell_ids: Vec<u64>, ellipsoid: Ellipsoid) -> Self {
+        let ranges: Vec<Range<u64>> = cell_ids
+            .into_iter()
+            .map(|hash| {
+                let (hash_nested, compacted_depth) = nested::from_zuniq_unchecked(hash);
+
+                let shift = Hpx::<u64>::shift_from_depth_max(compacted_depth) as u32;
+
+                let from = hash_nested;
+                let to = from + u64::one();
+
+                from.unsigned_shl(shift)..to.unsigned_shl(shift)
+            })
+            .collect();
+
+        Self::from_ranges_impl(depth, ranges, ellipsoid)
+    }
+
+    pub fn from_ranges(depth: u8, ranges: Vec<u64>, ellipsoid: Ellipsoid) -> Self {
+        Self::from_ranges_impl(
+            depth,
+            ranges.chunks(2).map(|chunk| Range {
+                start: chunk[0],
+                end: chunk[1],
+            }),
+            ellipsoid,
+        )
     }
 
     pub fn nbytes(&self) -> usize {

--- a/rust/healpix-geo-core/src/index/region.rs
+++ b/rust/healpix-geo-core/src/index/region.rs
@@ -14,6 +14,7 @@ use moc::moc::{
     CellMOCIntoIterator, CellMOCIterator, HasMaxDepth, RangeMOCIntoIterator, RangeMOCIterator,
 };
 use moc::qty::Hpx;
+use std::ops::Range;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct CellRegion {
@@ -85,6 +86,10 @@ impl CellRegion {
 
     pub fn ellipsoid(&self) -> &Ellipsoid {
         &self.ellipsoid
+    }
+
+    pub fn ranges(&self) -> Vec<Range<u64>> {
+        self.moc.moc_ranges().iter().cloned().collect()
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {

--- a/rust/healpix-geo-core/src/index/region.rs
+++ b/rust/healpix-geo-core/src/index/region.rs
@@ -13,7 +13,8 @@ use moc::moc::range::{CellSelection, RangeMOC};
 use moc::moc::{
     CellMOCIntoIterator, CellMOCIterator, HasMaxDepth, RangeMOCIntoIterator, RangeMOCIterator,
 };
-use moc::qty::Hpx;
+use moc::qty::{Hpx, MocQty};
+use num_traits::PrimInt;
 use std::ops::Range;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -47,7 +48,7 @@ impl CellRegion {
     fn from_ranges_impl(depth: u8, ranges: Vec<Range<u64>>, ellipsoid: Ellipsoid) -> Self {
         let size = ranges.len();
         Self {
-            moc: RangeMOC::from_maxdepth_ranges(depth, ranges, Some(size)),
+            moc: RangeMOC::from_maxdepth_ranges(depth, ranges.into_iter(), Some(size)),
             ellipsoid,
         }
     }
@@ -56,12 +57,12 @@ impl CellRegion {
         let ranges: Vec<Range<u64>> = cell_ids
             .into_iter()
             .map(|hash| {
-                let (hash_nested, compacted_depth) = nested::from_zuniq_unchecked(hash);
+                let (compacted_depth, hash_nested) = nested::from_zuniq(hash);
 
                 let shift = Hpx::<u64>::shift_from_depth_max(compacted_depth) as u32;
 
                 let from = hash_nested;
-                let to = from + u64::one();
+                let to = from + 1;
 
                 from.unsigned_shl(shift)..to.unsigned_shl(shift)
             })
@@ -73,10 +74,13 @@ impl CellRegion {
     pub fn from_ranges(depth: u8, ranges: Vec<u64>, ellipsoid: Ellipsoid) -> Self {
         Self::from_ranges_impl(
             depth,
-            ranges.chunks(2).map(|chunk| Range {
-                start: chunk[0],
-                end: chunk[1],
-            }),
+            ranges
+                .chunks(2)
+                .map(|chunk| Range {
+                    start: chunk[0],
+                    end: chunk[1],
+                })
+                .collect::<Vec<Range<u64>>>(),
             ellipsoid,
         )
     }

--- a/rust/healpix-geo-core/src/index/region.rs
+++ b/rust/healpix-geo-core/src/index/region.rs
@@ -44,6 +44,21 @@ impl CellRegion {
         }
     }
 
+    pub fn from_ranges(depth: u8, ranges: Vec<u64>, ellipsoid: Ellipsoid) -> Self {
+        let size = ranges.len();
+        Self {
+            moc: RangeMOC::from_maxdepth_ranges(
+                depth,
+                ranges.chunks(2).map(|chunk| Range {
+                    start: chunk[0],
+                    end: chunk[1],
+                }),
+                Some(size),
+            ),
+            ellipsoid,
+        }
+    }
+
     pub fn nbytes(&self) -> usize {
         self.moc.len() * 2 * u64::BITS as usize / 8
     }


### PR DESCRIPTION
The main purpose of this is the compression formats in the [zarr dggs convention](https://github.com/zarr-conventions/dggs), which for larger datasets can make the difference between loading data on the order of hundreds of gigabytes and data on the order of kB to ~1MB.